### PR TITLE
Port to new codecov configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         id: ci
         uses: ignition-tooling/action-ignition-ci@bionic
         with:
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          codecov-enabled: true
   focal-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Focal CI

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ allows conversion from previous versions.
 
 Test coverage:
 
-[![codecov](https://codecov.io/bb/osrf/sdformat/branch/default/graph/badge.svg)](https://codecov.io/bb/osrf/sdformat)
+[![codecov](https://codecov.io/bb/ignitionrobotics/sdformat/branch/default/graph/badge.svg)](https://codecov.io/bb/ignitionrobotics/sdformat)
 
 # Installation
 


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
Use the codecov config proposed in ignition-tooling/action-ignition-ci#32. 
This also uses a new codecov url in the README now that sdformat is in the ignitionrobotics org.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
