### PR TITLE
Backport test utilities from sdf10

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ if (BUILD_SDF_TEST)
     )
   endif()
 
+  include_directories(${PROJECT_SOURCE_DIR}/test)
   sdf_build_tests(${gtest_sources})
 
   if (NOT WIN32)

--- a/src/Converter_TEST.cc
+++ b/src/Converter_TEST.cc
@@ -1887,13 +1887,11 @@ TEST(Converter, MuchNewerVersion)
 
 static std::string ConvertDoc_15_16()
 {
-  return sdf::filesystem::append(PROJECT_SOURCE_PATH, "sdf", "1.6",
-                                 "1_5.convert");
+  return sdf::testing::SourceFile("sdf", "1.6", "1_5.convert");
 }
 static std::string ConvertDoc_16_17()
 {
-  return sdf::filesystem::append(PROJECT_SOURCE_PATH, "sdf", "1.7",
-                                 "1_6.convert");
+  return sdf::testing::SourceFile("sdf", "1.7", "1_6.convert");
 }
 
 /////////////////////////////////////////////////

--- a/src/FrameSemantics_TEST.cc
+++ b/src/FrameSemantics_TEST.cc
@@ -38,8 +38,7 @@
 TEST(FrameSemantics, buildFrameAttachedToGraph_Model)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_frame_attached_to.sdf");
+    sdf::testing::TestFile("sdf", "model_frame_attached_to.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -103,8 +102,7 @@ TEST(FrameSemantics, buildFrameAttachedToGraph_Model)
 TEST(FrameSemantics, buildFrameAttachedToGraph_World)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_frame_attached_to.sdf");
+    sdf::testing::TestFile("sdf", "world_frame_attached_to.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -198,8 +196,7 @@ TEST(FrameSemantics, buildFrameAttachedToGraph_World)
 TEST(FrameSemantics, buildPoseRelativeToGraph)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_frame_relative_to_joint.sdf");
+    sdf::testing::TestFile("sdf", "model_frame_relative_to_joint.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -721,7 +721,7 @@ int main(int argc, char **argv)
 {
   // Set IGN_CONFIG_PATH to the directory where the .yaml configuration file
   // is located.
-  setenv("IGN_CONFIG_PATH", IGN_CONFIG_PATH, 1);
+  sdf::testing::setenv("IGN_CONFIG_PATH", IGN_CONFIG_PATH);
 
   // Make sure that we load the library recently built and not the one installed
   // in your system. This is done by placing the the current build directory
@@ -732,13 +732,13 @@ int main(int argc, char **argv)
 #ifndef _WIN32
   std::string testLibraryPath = IGN_TEST_LIBRARY_PATH;
 
-  char *currentLibraryPath = std::getenv("LD_LIBRARY_PATH");
-  if (currentLibraryPath)
+  std::string currentLibraryPath;
+  if (sdf::testing::env("LD_LIBRARY_PATH", currentLibraryPath))
   {
     testLibraryPath = testLibraryPath + ":" + currentLibraryPath;
   }
 
-  setenv("LD_LIBRARY_PATH", testLibraryPath.c_str(), 1);
+  sdf::testing::setenv("LD_LIBRARY_PATH", testLibraryPath);
 #endif
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -62,10 +62,9 @@ sdf::SDFPtr InitSDF()
 /////////////////////////////////////////////////
 TEST(Parser, ReusedSDFVersion)
 {
-  std::string pathBase = PROJECT_SOURCE_PATH;
-  pathBase += "/test/sdf";
-  const std::string path17 = pathBase +"/model_link_relative_to.sdf";
-  const std::string path16 = pathBase +"/joint_complete.sdf";
+  const auto path17 = sdf::testing::TestFile(
+      "sdf", "model_link_relative_to.sdf");
+  const auto path16 = sdf::testing::TestFile("sdf", "joint_complete.sdf");
 
   // Call readFile API that always converts
   sdf::SDFPtr sdf = InitSDF();
@@ -85,9 +84,7 @@ TEST(Parser, ReusedSDFVersion)
 /////////////////////////////////////////////////
 TEST(Parser, readFileConversions)
 {
-  std::string pathBase = PROJECT_SOURCE_PATH;
-  pathBase += "/test/sdf";
-  const std::string path = pathBase +"/joint_complete.sdf";
+  const auto path = sdf::testing::TestFile("sdf", "joint_complete.sdf");
 
   // Call readFile API that always converts
   {
@@ -346,16 +343,13 @@ TEST(Parser, addNestedModel)
 /////////////////////////////////////////////////
 TEST(Parser, NameUniqueness)
 {
-  std::string pathBase = PROJECT_SOURCE_PATH;
-  pathBase += "/test/sdf";
-
   // These tests are copies of the ones in ign_TEST.cc but use direct calls to
   // name uniqueness validator functions instead of going through ign.
 
   // Check an SDF file with sibling elements of the same type (world)
   // that have duplicate names.
   {
-    std::string path = pathBase +"/world_duplicate.sdf";
+    const auto path = sdf::testing::TestFile("sdf", "world_duplicate.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_FALSE(sdf::recursiveSameTypeUniqueNames(sdf->Root()));
@@ -368,7 +362,8 @@ TEST(Parser, NameUniqueness)
   // Check an SDF file with sibling elements of different types (model, light)
   // that have duplicate names.
   {
-    std::string path = pathBase +"/world_sibling_same_names.sdf";
+    const auto path = sdf::testing::TestFile("sdf",
+        "world_sibling_same_names.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_FALSE(sdf::recursiveSiblingUniqueNames(sdf->Root()));
@@ -381,7 +376,8 @@ TEST(Parser, NameUniqueness)
   // Check an SDF file with sibling elements of the same type (link)
   // that have duplicate names.
   {
-    std::string path = pathBase +"/model_duplicate_links.sdf";
+    const auto path = sdf::testing::TestFile("sdf",
+        "model_duplicate_links.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_FALSE(sdf::recursiveSameTypeUniqueNames(sdf->Root()));
@@ -394,7 +390,8 @@ TEST(Parser, NameUniqueness)
   // Check an SDF file with sibling elements of the same type (joint)
   // that have duplicate names.
   {
-    std::string path = pathBase +"/model_duplicate_joints.sdf";
+    const auto path = sdf::testing::TestFile("sdf",
+        "model_duplicate_joints.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_FALSE(sdf::recursiveSameTypeUniqueNames(sdf->Root()));
@@ -407,7 +404,8 @@ TEST(Parser, NameUniqueness)
   // Check an SDF file with sibling elements of different types (link, joint)
   // that have duplicate names.
   {
-    std::string path = pathBase +"/model_link_joint_same_name.sdf";
+    const auto path = sdf::testing::TestFile("sdf",
+        "model_link_joint_same_name.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_FALSE(sdf::recursiveSiblingUniqueNames(sdf->Root()));
@@ -420,7 +418,8 @@ TEST(Parser, NameUniqueness)
   // Check an SDF file with sibling elements of the same type (collision)
   // that have duplicate names.
   {
-    std::string path = pathBase +"/link_duplicate_sibling_collisions.sdf";
+    const auto path = sdf::testing::TestFile("sdf",
+        "link_duplicate_sibling_collisions.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_FALSE(sdf::recursiveSameTypeUniqueNames(sdf->Root()));
@@ -433,7 +432,8 @@ TEST(Parser, NameUniqueness)
   // Check an SDF file with sibling elements of the same type (visual)
   // that have duplicate names.
   {
-    std::string path = pathBase +"/link_duplicate_sibling_visuals.sdf";
+    const auto path = sdf::testing::TestFile("sdf",
+        "link_duplicate_sibling_visuals.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_FALSE(sdf::recursiveSiblingUniqueNames(sdf->Root()));
@@ -446,7 +446,8 @@ TEST(Parser, NameUniqueness)
   // Check an SDF file with cousin elements of the same type (collision)
   // that have duplicate names. This is a valid file.
   {
-    std::string path = pathBase +"/link_duplicate_cousin_collisions.sdf";
+    const auto path = sdf::testing::TestFile("sdf",
+        "link_duplicate_cousin_collisions.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_TRUE(sdf::recursiveSameTypeUniqueNames(sdf->Root()));
@@ -460,7 +461,8 @@ TEST(Parser, NameUniqueness)
   // Check an SDF file with cousin elements of the same type (visual)
   // that have duplicate names. This is a valid file.
   {
-    std::string path = pathBase +"/link_duplicate_cousin_visuals.sdf";
+    const auto path = sdf::testing::TestFile("sdf",
+        "link_duplicate_cousin_visuals.sdf");
     sdf::SDFPtr sdf = InitSDF();
     EXPECT_TRUE(sdf::readFile(path, sdf));
     EXPECT_TRUE(sdf::recursiveSameTypeUniqueNames(sdf->Root()));

--- a/test/env.hh
+++ b/test/env.hh
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Note: this is a direct copy from ignition::common,
+// and can be removed when sdformat has common as a dependency
+
+#ifndef SDF_TEST_ENV_HH
+#define SDF_TEST_ENV_HH
+
+#include <cstdlib>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace sdf
+{
+  namespace testing
+  {
+
+    /// \brief Find the environment variable '_name' and return its value.
+    ///
+    /// Note: the intention is to put this in ign-util, and remove it
+    /// from sdformat once the depcnency is in place
+    ///
+    /// \param[in] _name Name of the environment variable.
+    /// \param[out] _value Value if the variable was found.
+    /// \param[in] _allowEmpty Allow set-but-empty variables.
+    ///           (Unsupported on Windows)
+    /// \return True if the variable was found or false otherwise.
+    bool env(const std::string &_name,
+             std::string &_value,
+             bool _allowEmpty)
+    {
+      std::string v;
+      bool valid = false;
+#ifdef _WIN32
+      // Unused on Windows, suppress warning
+      (void) _allowEmpty;
+      const DWORD buffSize = 32767;
+      static char buffer[buffSize];
+      if (GetEnvironmentVariable(_name.c_str(), buffer, buffSize))
+      {
+        v = buffer;
+      }
+
+      if (!v.empty())
+      {
+        valid = true;
+      }
+
+#else
+      const char *cvar = std::getenv(_name.c_str());
+      if (cvar != nullptr)
+      {
+        v = cvar;
+        valid = true;
+
+        if (v[0] == '\0' && !_allowEmpty)
+        {
+          valid = false;
+        }
+      }
+#endif
+      if (valid)
+      {
+        _value = v;
+        return true;
+      }
+      return false;
+    }
+
+    bool env(const std::string &_name, std::string &_value)
+    {
+      return env(_name, _value, false);
+    }
+
+    /// \brief Set the environment variable '_name'.
+    ///
+    /// Note that on Windows setting an empty string (_value=="")
+    /// is the equivalent of unsetting the variable.
+    ///
+    /// \param[in] _name Name of the environment variable.
+    /// \param[in] _value Value of the variable to be set.
+    /// \return True if the variable was set or false otherwise.
+    bool setenv(const std::string &_name,
+                const std::string &_value)
+    {
+#ifdef _WIN32
+      if (0 != _putenv_s(_name.c_str(), _value.c_str()))
+      {
+        return false;
+      }
+#else
+      if (0 != ::setenv(_name.c_str(), _value.c_str(), true))
+      {
+        return false;
+      }
+#endif
+      return true;
+    }
+
+    /// \brief Unset the environment variable '_name'.
+    /// \param[in] _name Name of the environment variable.
+    /// \return True if the variable was unset or false otherwise.
+    bool unsetenv(const std::string &_name)
+    {
+#ifdef _WIN32
+      if (0 != _putenv_s(_name.c_str(), ""))
+      {
+        return false;
+      }
+#else
+      if (0 != ::unsetenv(_name.c_str()))
+      {
+        return false;
+      }
+#endif
+      return true;
+    }
+  }  // namespace testing
+}  // namespace sdf
+
+#endif

--- a/test/integration/actor_dom.cc
+++ b/test/integration/actor_dom.cc
@@ -31,8 +31,7 @@
 TEST(DOMActor, LoadActors)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_complete.sdf");
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
@@ -145,8 +144,7 @@ TEST(DOMActor, CopySdfLoadedProperties)
   // Verify that copying an actor also copies the underlying ElementPtr
   // Joints and Links
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_complete.sdf");
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);

--- a/test/integration/audio.cc
+++ b/test/integration/audio.cc
@@ -23,12 +23,13 @@
 
 #include "test_config.h"
 
-
+//////////////////////////////////////////////////
 TEST(SDFParser, AudioSDF_FullParameters_noThrow)
 {
-  const std::string sdfTestFile = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "audio.sdf");
+  const auto sdfTestFile =
+    sdf::testing::TestFile("integration", "audio.sdf");
+
   sdf::SDFPtr p(new sdf::SDF());
   sdf::init(p);
-  ASSERT_TRUE(sdf::readFile(sdfTestFile , p));
+  ASSERT_TRUE(sdf::readFile(sdfTestFile, p));
 }

--- a/test/integration/cfm_damping_implicit_spring_damper.cc
+++ b/test/integration/cfm_damping_implicit_spring_damper.cc
@@ -27,9 +27,8 @@
 /////////////////////////////////////////////////
 TEST(SDFParser, CFMDampingSDFTest)
 {
-  const std::string sdfTestFile =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                              "cfm_damping_implicit_spring_damper.sdf");
+  const std::string sdfTestFile = sdf::testing::TestFile(
+      "integration", "cfm_damping_implicit_spring_damper.sdf");
   sdf::SDFPtr robot(new sdf::SDF());
   sdf::init(robot);
   ASSERT_TRUE(sdf::readFile(sdfTestFile, robot));
@@ -107,9 +106,8 @@ TEST(SDFParser, CFMDampingSDFTest)
 /////////////////////////////////////////////////
 TEST(SDFParser, CFMDampingURDFTest)
 {
-  const std::string urdfTestFile =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                              "cfm_damping_implicit_spring_damper.urdf");
+  const std::string urdfTestFile = sdf::testing::TestFile(
+      "integration", "cfm_damping_implicit_spring_damper.urdf");
 
   sdf::SDFPtr robot(new sdf::SDF());
   sdf::init(robot);

--- a/test/integration/collision_dom.cc
+++ b/test/integration/collision_dom.cc
@@ -64,8 +64,7 @@ TEST(DOMCollision, NoName)
 TEST(DOMCollision, DoublePendulum)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "double_pendulum.sdf");
+    sdf::testing::TestFile("sdf", "double_pendulum.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -95,8 +94,7 @@ TEST(DOMCollision, DoublePendulum)
 TEST(DOMCollision, LoadModelFramesRelativeToJoint)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_frame_relative_to_joint.sdf");
+    sdf::testing::TestFile("sdf", "model_frame_relative_to_joint.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/converter.cc
+++ b/test/integration/converter.cc
@@ -31,8 +31,7 @@ void ParserStringConverter(const std::string &_version);
 /// Test conversion using the parser sdf file converter interface.
 TEST(ConverterIntegration, ParserFileConverter)
 {
-  std::string filename = sdf::filesystem::append(PROJECT_SOURCE_PATH, "test",
-                                                 "integration", "audio.sdf");
+  const auto filename = sdf::testing::TestFile("integration", "audio.sdf");
 
   sdf::SDFPtr sdf(new sdf::SDF());
   sdf::init(sdf);
@@ -73,8 +72,8 @@ TEST(ConverterIntegration, ParserFileConverter)
 /// Convert to a previous SDF version
 TEST(ConverterIntegration, convertFileToNotLatestVersion)
 {
-  std::string filename = sdf::filesystem::append(PROJECT_SOURCE_PATH, "test",
-                                                 "integration", "audio.sdf");
+  const auto filename = sdf::testing::TestFile(
+      "integration", "audio.sdf");
 
   sdf::SDFPtr sdf(new sdf::SDF());
   sdf::init(sdf);

--- a/test/integration/disable_fixed_joint_reduction.cc
+++ b/test/integration/disable_fixed_joint_reduction.cc
@@ -45,12 +45,11 @@ bool findJointInModel(const std::string &desired_joint_name, sdf::SDFPtr robot)
 /////////////////////////////////////////////////
 TEST(SDFParser, DisableFixedJointReductionTest)
 {
-  const std::string sdfFixedJntFile = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "fixed_joint_reduction.urdf");
+  const std::string sdfFixedJntFile =
+      sdf::testing::TestFile("integration", "fixed_joint_reduction.urdf");
 
-  const std::string sdfFixedJntNoLumpingFile =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                              "fixed_joint_reduction_disabled.urdf");
+  const std::string sdfFixedJntNoLumpingFile = sdf::testing::TestFile(
+      "integration", "fixed_joint_reduction_disabled.urdf");
 
   sdf::SDFPtr robot(new sdf::SDF());
   sdf::init(robot);

--- a/test/integration/element_memory_leak.cc
+++ b/test/integration/element_memory_leak.cc
@@ -72,7 +72,7 @@ const std::string sdfString(
 int getMemoryUsage()
 {
   static const std::string getMemInfoPath =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "tools", "get_mem_info.py");
+      sdf::testing::SourceFile("tools", "get_mem_info.py");
   static const std::string pythonMeminfo("python3 " + getMemInfoPath);
 
   return std::stoi(custom_exec(pythonMeminfo));

--- a/test/integration/fixed_joint_reduction.cc
+++ b/test/integration/fixed_joint_reduction.cc
@@ -24,14 +24,10 @@
 
 #include "test_config.h"
 
-const char SDF_TEST_FILE[] =
-    "fixed_joint_reduction.urdf";
-const char SDF_TEST_FILE_COLLISION[] =
-    "fixed_joint_reduction_collision.urdf";
-const char SDF_TEST_FILE_SIMPLE[] =
-    "fixed_joint_reduction_simple.urdf";
-const char SDF_TEST_FILE_VISUAL[] =
-    "fixed_joint_reduction_visual.urdf";
+const char SDF_TEST_FILE[] = "fixed_joint_reduction.urdf";
+const char SDF_TEST_FILE_COLLISION[] = "fixed_joint_reduction_collision.urdf";
+const char SDF_TEST_FILE_SIMPLE[] = "fixed_joint_reduction_simple.urdf";
+const char SDF_TEST_FILE_VISUAL[] = "fixed_joint_reduction_visual.urdf";
 const char SDF_TEST_FILE_COLLISION_VISUAL_EXTENSION[] =
     "fixed_joint_reduction_collision_visual_extension.urdf";
 const char SDF_TEST_FILE_COLLISION_VISUAL_EXTENSION_SDF[] =
@@ -43,8 +39,7 @@ const char SDF_TEST_FILE_COLLISION_VISUAL_EXTENSION_EMPTY_ROOT_SDF[] =
 
 static std::string GetFullTestFilePath(const char *_input)
 {
-  return sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                                 _input);
+  return sdf::testing::TestFile("integration", _input);
 }
 
 const double gc_tolerance = 1e-6;

--- a/test/integration/force_torque_sensor.cc
+++ b/test/integration/force_torque_sensor.cc
@@ -26,8 +26,8 @@
 /////////////////////////////////////////////////
 TEST(SDFParser, ForceTorqueSensorTest)
 {
-  const std::string sdfTestFile = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "force_torque_sensor.urdf");
+  const std::string sdfTestFile =
+      sdf::testing::TestFile("integration", "force_torque_sensor.urdf");
 
   sdf::SDFPtr robot(new sdf::SDF());
   sdf::init(robot);

--- a/test/integration/frame.cc
+++ b/test/integration/frame.cc
@@ -301,8 +301,7 @@ TEST(Frame, StateFrame)
 TEST(Frame, IncludeRelativeTo)
 {
   const std::string MODEL_PATH =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                            "model", "box");
+    sdf::testing::TestFile("integration", "model", "box");
 
   std::ostringstream stream;
   std::string version = SDF_VERSION;
@@ -348,8 +347,7 @@ TEST(Frame, IncludeRelativeTo)
 TEST(Frame, IncludeRelativeToEmptyPose)
 {
   const std::string MODEL_PATH =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                            "model", "box");
+    sdf::testing::TestFile("integration", "model", "box");
 
   std::ostringstream stream;
   std::string version = SDF_VERSION;
@@ -415,8 +413,7 @@ TEST(Frame, IncludeRelativeToEmptyPose)
 TEST(DOMFrame, LoadModelFramesAttachedTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_frame_attached_to.sdf");
+    sdf::testing::TestFile("sdf", "model_frame_attached_to.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -475,7 +472,7 @@ TEST(DOMFrame, LoadModelFramesAttachedTo)
 TEST(DOMFrame, LoadModelFramesInvalidAttachedTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_frame_invalid_attached_to.sdf");
 
   // Load the SDF file
@@ -577,7 +574,7 @@ TEST(DOMFrame, LoadModelFramesInvalidAttachedTo)
 TEST(DOMFrame, LoadModelFramesAttachedToJoint)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_frame_attached_to_joint.sdf");
 
   // Load the SDF file
@@ -642,7 +639,7 @@ TEST(DOMFrame, LoadModelFramesAttachedToJoint)
 TEST(DOMFrame, LoadModelFramesAttachedToNestedModel)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_frame_attached_to_nested_model.sdf");
 
   // Load the SDF file
@@ -691,7 +688,7 @@ TEST(DOMFrame, LoadModelFramesAttachedToNestedModel)
 TEST(DOMFrame, LoadWorldFramesAttachedTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "world_frame_attached_to.sdf");
 
   // Load the SDF file
@@ -758,7 +755,7 @@ TEST(DOMFrame, LoadWorldFramesAttachedTo)
 TEST(DOMFrame, LoadWorldFramesInvalidAttachedTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "world_frame_invalid_attached_to.sdf");
 
   // Load the SDF file
@@ -862,7 +859,7 @@ TEST(DOMFrame, LoadWorldFramesInvalidAttachedTo)
 TEST(DOMFrame, LoadModelFramesRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_frame_relative_to.sdf");
 
   // Load the SDF file
@@ -995,7 +992,7 @@ TEST(DOMFrame, LoadModelFramesRelativeTo)
 TEST(DOMFrame, LoadModelFramesInvalidRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_invalid_frame_relative_to.sdf");
 
   // Load the SDF file
@@ -1023,7 +1020,7 @@ TEST(DOMFrame, LoadModelFramesInvalidRelativeTo)
 TEST(DOMFrame, LoadModelFramesRelativeToJoint)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_frame_relative_to_joint.sdf");
 
   // Load the SDF file
@@ -1157,7 +1154,7 @@ TEST(DOMFrame, LoadModelFramesRelativeToJoint)
 TEST(DOMFrame, LoadWorldFramesRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "world_frame_relative_to.sdf");
 
   // Load the SDF file
@@ -1223,7 +1220,7 @@ TEST(DOMFrame, LoadWorldFramesRelativeTo)
 TEST(DOMFrame, LoadWorldFramesInvalidRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "world_frame_invalid_relative_to.sdf");
 
   // Load the SDF file
@@ -1249,8 +1246,7 @@ TEST(DOMFrame, LoadWorldFramesInvalidRelativeTo)
 TEST(DOMFrame, WorldIncludeModel)
 {
   const std::string MODEL_PATH =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                            "model", "box");
+    sdf::testing::TestFile("integration", "model", "box");
 
   std::ostringstream stream;
   std::string version = SDF_VERSION;

--- a/test/integration/geometry_dom.cc
+++ b/test/integration/geometry_dom.cc
@@ -34,14 +34,13 @@
 #include "sdf/Types.hh"
 #include "sdf/Visual.hh"
 #include "sdf/World.hh"
+
 #include "test_config.h"
 
 //////////////////////////////////////////////////
 TEST(DOMGeometry, Shapes)
 {
-  const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "shapes.sdf");
+  const auto testFile = sdf::testing::TestFile("sdf", "shapes.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/include.cc
+++ b/test/integration/include.cc
@@ -29,8 +29,7 @@
 TEST(Include, IncludeDescription)
 {
   const std::string SDF_DESCRIPTION_PATH =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                            "include_description.sdf");
+    sdf::testing::TestFile("integration", "include_description.sdf");
 
   std::ostringstream stream;
   std::string version = SDF_VERSION;

--- a/test/integration/includes.cc
+++ b/test/integration/includes.cc
@@ -34,14 +34,10 @@
 #include "sdf/World.hh"
 #include "test_config.h"
 
-const auto g_testPath = sdf::filesystem::append(PROJECT_SOURCE_PATH, "test");
-const auto g_modelsPath =
-    sdf::filesystem::append(g_testPath, "integration", "model");
-
 /////////////////////////////////////////////////
 std::string findFileCb(const std::string &_input)
 {
-  return sdf::filesystem::append(g_testPath, "integration", "model", _input);
+  return sdf::testing::TestFile("integration", "model", _input);
 }
 
 //////////////////////////////////////////////////
@@ -49,8 +45,7 @@ TEST(IncludesTest, Includes)
 {
   sdf::setFindCallback(findFileCb);
 
-  const auto worldFile =
-    sdf::filesystem::append(g_testPath, "sdf", "includes.sdf");
+  const auto worldFile = sdf::testing::TestFile("sdf", "includes.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(worldFile);
@@ -77,8 +72,8 @@ TEST(IncludesTest, Includes)
   const auto *actor = world->ActorByIndex(0);
   EXPECT_EQ("1.6", actor->Element()->OriginalVersion());
 
-  const auto actorFile = sdf::filesystem::append(g_modelsPath, "test_actor",
-      "model.sdf");
+  const auto actorFile = sdf::testing::TestFile(
+      "integration", "model", "test_actor", "model.sdf");
   EXPECT_EQ(actorFile, actor->FilePath());
 
   EXPECT_EQ("actor", actor->Name());
@@ -166,8 +161,8 @@ TEST(IncludesTest, Includes)
   EXPECT_FALSE(model->LinkNameExists("coconut"));
   EXPECT_EQ("1.6", model->Element()->OriginalVersion());
 
-  const auto modelFile = sdf::filesystem::append(g_modelsPath, "test_model",
-      "model.sdf");
+  const auto modelFile = sdf::testing::TestFile(
+      "integration", "model", "test_model", "model.sdf");
 
   const auto *link = model->LinkByName("link");
   ASSERT_NE(nullptr, link);
@@ -216,8 +211,7 @@ TEST(IncludesTest, Includes_15)
 {
   sdf::setFindCallback(findFileCb);
 
-  const auto worldFile =
-    sdf::filesystem::append(g_testPath, "sdf", "includes_1.5.sdf");
+  const auto worldFile = sdf::testing::TestFile("sdf", "includes_1.5.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(worldFile);
@@ -273,8 +267,7 @@ TEST(IncludesTest, Includes_15_convert)
 {
   sdf::setFindCallback(findFileCb);
 
-  const auto worldFile =
-    sdf::filesystem::append(g_testPath, "sdf", "includes_1.5.sdf");
+  const auto worldFile = sdf::testing::TestFile("sdf", "includes_1.5.sdf");
 
   sdf::SDFPtr sdf(new sdf::SDF());
   sdf::init(sdf);

--- a/test/integration/joint_axis_dom.cc
+++ b/test/integration/joint_axis_dom.cc
@@ -33,8 +33,7 @@
 TEST(DOMJointAxis, Complete)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "joint_complete.sdf");
+    sdf::testing::TestFile("sdf", "joint_complete.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -114,8 +113,7 @@ TEST(DOMJointAxis, Complete)
 TEST(DOMJointAxis, XyzExpressedIn)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_joint_axis_expressed_in.sdf");
+    sdf::testing::TestFile("sdf", "model_joint_axis_expressed_in.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -63,8 +63,7 @@ TEST(DOMJoint, NoName)
 TEST(DOMJoint, DoublePendulum)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "double_pendulum.sdf");
+    sdf::testing::TestFile("sdf", "double_pendulum.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -117,8 +116,7 @@ TEST(DOMJoint, DoublePendulum)
 TEST(DOMJoint, Complete)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "joint_complete.sdf");
+    sdf::testing::TestFile("sdf", "joint_complete.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -160,8 +158,7 @@ TEST(DOMJoint, Complete)
 TEST(DOMJoint, LoadJointParentWorld)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "joint_parent_world.sdf");
+    sdf::testing::TestFile("sdf", "joint_parent_world.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -204,8 +201,7 @@ TEST(DOMJoint, LoadJointParentWorld)
 TEST(DOMJoint, LoadInvalidJointChildWorld)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "joint_child_world.sdf");
+    sdf::testing::TestFile("sdf", "joint_child_world.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -229,8 +225,7 @@ TEST(DOMJoint, LoadInvalidJointChildWorld)
 TEST(DOMJoint, LoadJointPoseRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_joint_relative_to.sdf");
+    sdf::testing::TestFile("sdf", "model_joint_relative_to.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -324,7 +319,7 @@ TEST(DOMJoint, LoadJointPoseRelativeTo)
 TEST(DOMJoint, LoadInvalidJointPoseRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_invalid_joint_relative_to.sdf");
 
   // Load the SDF file
@@ -353,8 +348,7 @@ TEST(DOMJoint, LoadInvalidJointPoseRelativeTo)
 TEST(DOMJoint, LoadInvalidChild)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "joint_invalid_child.sdf");
+    sdf::testing::TestFile("sdf", "joint_invalid_child.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -383,7 +377,7 @@ TEST(DOMJoint, LoadInvalidChild)
 TEST(DOMJoint, LoadLinkJointSameName17Invalid)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_link_joint_same_name.sdf");
 
   // Read with sdf::readFile, which converts from 1.6 to latest
@@ -414,8 +408,7 @@ TEST(DOMJoint, LoadLinkJointSameName17Invalid)
 TEST(DOMJoint, LoadLinkJointSameName16Valid)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_link_joint_same_name.sdf");
+    sdf::testing::TestFile("sdf", "model_link_joint_same_name.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -493,8 +486,7 @@ TEST(DOMJoint, LoadLinkJointSameName16Valid)
 TEST(DOMJoint, LoadURDFJointPoseRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-        "provide_feedback.urdf");
+    sdf::testing::TestFile("integration", "provide_feedback.urdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/light_dom.cc
+++ b/test/integration/light_dom.cc
@@ -33,8 +33,7 @@
 TEST(DOMWorld, LoadLights)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_complete.sdf");
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);

--- a/test/integration/link_dom.cc
+++ b/test/integration/link_dom.cc
@@ -73,8 +73,7 @@ TEST(DOMLink, NoName)
 TEST(DOMLink, LoadVisualCollision)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "empty.sdf");
+    sdf::testing::TestFile("sdf", "empty.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -116,8 +115,7 @@ TEST(DOMLink, LoadVisualCollision)
 TEST(DOMLink, InertialDoublePendulum)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "double_pendulum.sdf");
+    sdf::testing::TestFile("sdf", "double_pendulum.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -171,8 +169,7 @@ TEST(DOMLink, InertialDoublePendulum)
 TEST(DOMLink, InertialComplete)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "inertial_complete.sdf");
+    sdf::testing::TestFile("sdf", "inertial_complete.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -203,8 +200,7 @@ TEST(DOMLink, InertialComplete)
 TEST(DOMLink, InertialInvalid)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "inertial_invalid.sdf");
+    sdf::testing::TestFile("sdf", "inertial_invalid.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -228,9 +224,7 @@ TEST(DOMLink, InertialInvalid)
 //////////////////////////////////////////////////
 TEST(DOMLink, Sensors)
 {
-  const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "sensors.sdf");
+  const std::string testFile = sdf::testing::TestFile("sdf", "sensors.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -615,8 +609,7 @@ TEST(DOMLink, Sensors)
 /////////////////////////////////////////////////
 TEST(DOMLink, LoadLinkPoseRelativeTo)
 {
-  const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+  const std::string testFile = sdf::testing::TestFile("sdf",
         "model_link_relative_to.sdf");
 
   // Load the SDF file
@@ -692,8 +685,7 @@ TEST(DOMLink, LoadLinkPoseRelativeTo)
 /////////////////////////////////////////////////
 TEST(DOMLink, LoadInvalidLinkPoseRelativeTo)
 {
-  const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+  const std::string testFile = sdf::testing::TestFile("sdf",
         "model_invalid_link_relative_to.sdf");
 
   // Load the SDF file

--- a/test/integration/material_pbr.cc
+++ b/test/integration/material_pbr.cc
@@ -26,8 +26,7 @@
 TEST(Material, PbrDOM)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "material_pbr.sdf");
+    sdf::testing::TestFile("sdf", "material_pbr.sdf");
 
   // Load the SDF file into DOM
   sdf::Root root;
@@ -261,8 +260,7 @@ TEST(Material, PbrDOM)
 TEST(Material, MaterialPBR)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "material_pbr.sdf");
+    sdf::testing::TestFile("sdf", "material_pbr.sdf");
 
   // load material pbr sdf file
   sdf::Errors errors;

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -63,8 +63,7 @@ TEST(DOMModel, NoName)
 TEST(DOMModel, NoLinks)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_without_links.sdf");
+    sdf::testing::TestFile("sdf", "model_without_links.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -85,8 +84,7 @@ TEST(DOMModel, NoLinks)
 TEST(DOMRoot, LoadLinkCheck)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "empty.sdf");
+    sdf::testing::TestFile("sdf", "empty.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -114,8 +112,7 @@ TEST(DOMRoot, LoadLinkCheck)
 TEST(DOMRoot, LoadDoublePendulum)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "double_pendulum.sdf");
+    sdf::testing::TestFile("sdf", "double_pendulum.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -153,8 +150,7 @@ TEST(DOMRoot, LoadDoublePendulum)
 TEST(DOMRoot, NestedModel)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "nested_model.sdf");
+    sdf::testing::TestFile("sdf", "nested_model.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -206,7 +202,7 @@ TEST(DOMRoot, NestedModel)
 TEST(DOMLink, NestedModelPoseRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf",
         "model_nested_model_relative_to.sdf");
 
   // Load the SDF file
@@ -289,8 +285,7 @@ TEST(DOMLink, NestedModelPoseRelativeTo)
 TEST(DOMRoot, LoadCanonicalLink)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_canonical_link.sdf");
+    sdf::testing::TestFile("sdf", "model_canonical_link.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -331,8 +326,7 @@ TEST(DOMRoot, LoadCanonicalLink)
 TEST(DOMRoot, LoadNestedCanonicalLink)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "nested_canonical_link.sdf");
+    sdf::testing::TestFile("sdf", "nested_canonical_link.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/model_versions.cc
+++ b/test/integration/model_versions.cc
@@ -32,8 +32,8 @@ TEST(ModelVersionsTest, Empty_ModelFilePath)
 
 TEST(ModelVersionsTest, NonExistent_ModelFilePath)
 {
-  const std::string MODEL_PATH = sdf::filesystem::append(PROJECT_SOURCE_PATH,
-    "test", "integration", "model", "non-existent");
+  const std::string MODEL_PATH =
+    sdf::testing::TestFile("integration", "model", "non-existent");
 
   std::string modelPath = sdf::getModelFilePath(MODEL_PATH);
 
@@ -42,8 +42,8 @@ TEST(ModelVersionsTest, NonExistent_ModelFilePath)
 
 TEST(ModelVersionsTest, MalFormed_ModelFilePath)
 {
-  const std::string MODEL_PATH = sdf::filesystem::append(PROJECT_SOURCE_PATH,
-    "test", "integration", "model", "cococan_malformed");
+  const std::string MODEL_PATH =
+    sdf::testing::TestFile("integration", "model", "cococan_malformed");
 
   std::string modelPath = sdf::getModelFilePath(MODEL_PATH);
 
@@ -52,8 +52,8 @@ TEST(ModelVersionsTest, MalFormed_ModelFilePath)
 
 TEST(ModelVersionsTest, NoVersionTag_ModelFilePath)
 {
-  const std::string MODEL_PATH = sdf::filesystem::append(PROJECT_SOURCE_PATH,
-    "test", "integration", "model", "cococan_noversiontag");
+  const std::string MODEL_PATH =
+    sdf::testing::TestFile("integration", "model", "cococan_noversiontag");
 
   std::string modelPath = sdf::getModelFilePath(MODEL_PATH);
 
@@ -62,8 +62,8 @@ TEST(ModelVersionsTest, NoVersionTag_ModelFilePath)
 
 TEST(ModelVersionsTest, Correct_ModelFilePath)
 {
-  const std::string MODEL_PATH = sdf::filesystem::append(PROJECT_SOURCE_PATH,
-    "test", "integration", "model", "cococan");
+  const std::string MODEL_PATH =
+    sdf::testing::TestFile("integration", "model", "cococan");
 
   std::string modelPath = sdf::getModelFilePath(MODEL_PATH);
 

--- a/test/integration/plugin_include.cc
+++ b/test/integration/plugin_include.cc
@@ -25,8 +25,8 @@
 // Test that plugin child elements are available even when nested in an include
 TEST(PluginInclude, PluginChildElements)
 {
-  const std::string MODEL_PATH = std::string(PROJECT_SOURCE_PATH)
-      + "/test/integration/model/box";
+  const auto MODEL_PATH =
+    sdf::testing::TestFile("integration", "model", "box");
 
   std::ostringstream stream;
   stream
@@ -80,8 +80,8 @@ TEST(PluginInclude, PluginChildElements)
 // Test that missing required plugin attributes are detected
 TEST(PluginInclude, PluginMissingFilename)
 {
-  const std::string MODEL_PATH = std::string(PROJECT_SOURCE_PATH)
-      + "/test/integration/model/box";
+  const auto MODEL_PATH =
+    sdf::testing::TestFile("integration", "model", "box");
 
   std::ostringstream stream;
   stream

--- a/test/integration/provide_feedback.cc
+++ b/test/integration/provide_feedback.cc
@@ -26,8 +26,8 @@
 /////////////////////////////////////////////////
 TEST(SDFParser, ProvideFeedbackTest)
 {
-  const std::string sdfTestFile = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "provide_feedback.urdf");
+  const std::string sdfTestFile =
+      sdf::testing::TestFile("integration", "provide_feedback.urdf");
 
   sdf::SDFPtr robot(new sdf::SDF());
   sdf::init(robot);

--- a/test/integration/root_dom.cc
+++ b/test/integration/root_dom.cc
@@ -30,8 +30,7 @@
 TEST(DOMRoot, InvalidSDF)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "empty_invalid.sdf");
+    sdf::testing::TestFile("sdf", "empty_invalid.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
@@ -43,8 +42,7 @@ TEST(DOMRoot, InvalidSDF)
 TEST(DOMRoot, NoVersion)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "empty_noversion.sdf");
+    sdf::testing::TestFile("sdf", "empty_noversion.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
@@ -56,8 +54,7 @@ TEST(DOMRoot, NoVersion)
 TEST(DOMRoot, Load)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "empty.sdf");
+    sdf::testing::TestFile("sdf", "empty.sdf");
 
   sdf::Root root;
   EXPECT_EQ(0u, root.WorldCount());
@@ -79,8 +76,7 @@ TEST(DOMRoot, Load)
 TEST(DOMRoot, LoadMultipleModels)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "root_multiple_models.sdf");
+    sdf::testing::TestFile("sdf", "root_multiple_models.sdf");
 
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
@@ -100,8 +96,7 @@ TEST(DOMRoot, LoadMultipleModels)
 TEST(DOMRoot, LoadDuplicateModels)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "root_duplicate_models.sdf");
+    sdf::testing::TestFile("sdf", "root_duplicate_models.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);

--- a/test/integration/scene_dom.cc
+++ b/test/integration/scene_dom.cc
@@ -35,8 +35,7 @@
 TEST(DOMScene, LoadScene)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "scene_with_sky.sdf");
+    sdf::testing::TestFile("sdf", "scene_with_sky.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);

--- a/test/integration/sdf_custom.cc
+++ b/test/integration/sdf_custom.cc
@@ -26,8 +26,8 @@
 /////////////////////////////////////////////////
 TEST(SDFParser, CustomElements)
 {
-  const std::string sdfTestFile = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "custom_elems_attrs.sdf");
+  const std::string sdfTestFile =
+      sdf::testing::TestFile("integration", "custom_elems_attrs.sdf");
 
   sdf::Root root;
   EXPECT_TRUE(root.Load(sdfTestFile).empty());

--- a/test/integration/surface_dom.cc
+++ b/test/integration/surface_dom.cc
@@ -27,14 +27,14 @@
 #include "sdf/Surface.hh"
 #include "sdf/Types.hh"
 #include "sdf/World.hh"
+
 #include "test_config.h"
 
 //////////////////////////////////////////////////
 TEST(DOMSurface, Shapes)
 {
   const auto testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "shapes.sdf");
+    sdf::testing::TestFile("sdf", "shapes.sdf");
 
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());

--- a/test/integration/urdf_gazebo_extensions.cc
+++ b/test/integration/urdf_gazebo_extensions.cc
@@ -27,8 +27,7 @@
 TEST(SDFParser, UrdfGazeboExtensionURDFTest)
 {
   const std::string urdfTestFile =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                              "urdf_gazebo_extensions.urdf");
+      sdf::testing::TestFile("integration", "urdf_gazebo_extensions.urdf");
 
   sdf::SDFPtr robot(new sdf::SDF());
   sdf::init(robot);

--- a/test/integration/urdf_joint_parameters.cc
+++ b/test/integration/urdf_joint_parameters.cc
@@ -26,8 +26,8 @@
 /////////////////////////////////////////////////
 TEST(SDFParser, JointAxisParameters)
 {
-  const std::string sdfTestFile = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "urdf_joint_parameters.urdf");
+  const std::string sdfTestFile =
+      sdf::testing::TestFile("integration", "urdf_joint_parameters.urdf");
 
   sdf::SDFPtr robot(new sdf::SDF());
   sdf::init(robot);

--- a/test/integration/visual_dom.cc
+++ b/test/integration/visual_dom.cc
@@ -64,8 +64,7 @@ TEST(DOMVisual, NoName)
 TEST(DOMVisual, DoublePendulum)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "double_pendulum.sdf");
+    sdf::testing::TestFile("sdf", "double_pendulum.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -97,8 +96,7 @@ TEST(DOMVisual, DoublePendulum)
 TEST(DOMVisual, Material)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "material.sdf");
+    sdf::testing::TestFile("sdf", "material.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -146,8 +144,7 @@ TEST(DOMVisual, Material)
 TEST(DOMVisual, MaterialScriptNoUri)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "material_script_no_uri.sdf");
+    sdf::testing::TestFile("sdf", "material_script_no_uri.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -167,8 +164,7 @@ TEST(DOMVisual, MaterialScriptNoUri)
 TEST(DOMVisual, MaterialScriptNormalMapMissing)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "material_normal_map_missing.sdf");
+    sdf::testing::TestFile("sdf", "material_normal_map_missing.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -184,8 +180,7 @@ TEST(DOMVisual, MaterialScriptNormalMapMissing)
 TEST(DOMVisual, Transparency)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "shapes.sdf");
+    sdf::testing::TestFile("sdf", "shapes.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -231,8 +226,7 @@ TEST(DOMVisual, LaserRetro)
 TEST(DOMVisual, LoadModelFramesRelativeToJoint)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_frame_relative_to_joint.sdf");
+    sdf::testing::TestFile("sdf", "model_frame_relative_to_joint.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -425,8 +419,7 @@ TEST(DOMVisual, LoadModelFramesRelativeToJoint)
 TEST(DOMVisual, VisibilityFlags)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "shapes.sdf");
+    sdf::testing::TestFile("sdf", "shapes.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/world_dom.cc
+++ b/test/integration/world_dom.cc
@@ -25,15 +25,13 @@
 #include "sdf/Model.hh"
 #include "sdf/Root.hh"
 #include "sdf/World.hh"
-#include "sdf/Filesystem.hh"
 #include "test_config.h"
 
 //////////////////////////////////////////////////
 TEST(DOMWorld, NoName)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_noname.sdf");
+    sdf::testing::TestFile("sdf", "world_noname.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
@@ -46,8 +44,7 @@ TEST(DOMWorld, NoName)
 TEST(DOMWorld, Duplicate)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_duplicate.sdf");
+    sdf::testing::TestFile("sdf", "world_duplicate.sdf");
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
@@ -59,8 +56,7 @@ TEST(DOMWorld, Duplicate)
 TEST(DOMWorld, LoadIncorrectElement)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_complete.sdf");
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
 
   sdf::Errors errors;
   // Read an SDF file, and store the result in sdfParsed.
@@ -82,8 +78,7 @@ TEST(DOMWorld, LoadIncorrectElement)
 TEST(DOMWorld, Load)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_complete.sdf");
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
 
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
@@ -152,8 +147,7 @@ TEST(DOMWorld, Load)
 TEST(DOMWorld, LoadModelFrameSameName)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_model_frame_same_name.sdf");
+    sdf::testing::TestFile("sdf", "world_model_frame_same_name.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/performance/parser_urdf.cc
+++ b/test/performance/parser_urdf.cc
@@ -26,10 +26,9 @@
 
 TEST(URDFParser, AtlasURDF_5runs_performance)
 {
-  const std::string
-    URDF_TEST_FILE = sdf::filesystem::append(PROJECT_SOURCE_PATH, "test",
-                                             "performance",
-                                             "parser_urdf_atlas.urdf");
+  const std::string URDF_TEST_FILE =
+      sdf::testing::TestFile("performance", "parser_urdf_atlas.urdf");
+
   for (int i = 0; i < 5; i++)
   {
     sdf::SDFPtr root = sdf::readFile(URDF_TEST_FILE);

--- a/test/test_config.h.in
+++ b/test/test_config.h.in
@@ -25,27 +25,104 @@
 #define PROJECT_SOURCE_PATH "${PROJECT_SOURCE_DIR}"
 #define PROJECT_BINARY_DIR  "${CMAKE_BINARY_DIR}"
 #define SDF_PROTOCOL_VERSION "${SDF_PROTOCOL_VERSION}"
+#define SDF_TMP_DIR "tmp-sdf/"
 
-/*
- * setenv/unstenv are not present in Windows. Define them to make the code
- * portable
- */
-#if (_MSC_VER >= 1400) // Visual Studio 2005
-#include <sstream>
+#include "env.hh"
 
-int setenv(const char * name, const char * value, int /*rewrite*/)
+#include <sdf/Filesystem.hh>
+namespace sdf
 {
-  std::stringstream sstr;
-  sstr << *name << '=' << value;
-  return _putenv(sstr.str().c_str());
-}
+  namespace testing
+  {
+    /// \brief Method to retrieve root directory of project source
+    ///
+    /// This is used to get various test files
+    /// \param[inout] _sourceDir Full path to the source directory
+    /// \return True if directory is set correctly, false otherwise
+    bool ProjectSourcePath(std::string &_sourceDir)
+    {
+      // Bazel builds set TEST_SRCDIR
+      if(env("TEST_SRCDIR", _sourceDir))
+      {
+        _sourceDir = sdf::filesystem::append(
+            _sourceDir, "__main__", "sdformat");
+        return true;
+      }
+      else
+      {
+        // CMake builds set PROJECT_SOURCE_PATH
+        _sourceDir = PROJECT_SOURCE_PATH;
+        return true;
+      }
 
-void unsetenv(const char * name)
-{
-  std::stringstream sstr;
-  sstr << *name << '=';
-  _putenv(sstr.str().c_str());
-  return;
-}
+      return false;
+    }
+
+    /// \brief Method to retrieve temporary directory for test outputs
+    ///
+    /// \param[inout] _tmpDir Full path to the temp directory
+    /// \return True if directory is set correctly, false otherwise
+    bool TestTmpPath(std::string &_tmpDir)
+    {
+      // Bazel builds set TEST_UNDECLARED_OUTPUTS_DIR
+      if (env("TEST_UNDECLARED_OUTPUTS_DIR", _tmpDir))
+      {
+        return true;
+      }
+      else
+      {
+        _tmpDir = sdf::filesystem::append(PROJECT_BINARY_DIR, SDF_TMP_DIR);
+        return true;
+      }
+    }
+
+    /// \brief Method to retrieve temporary home directory for tests
+    ///
+    /// This will update the contents of the home directory path variable
+    /// (HOME on Linux/MacOS, HOMEPATH on Windows) to this newly-set
+    /// directory
+    /// This additionally sets the HOME and HOMEPATH environment variables
+    ///
+    /// \param[inout] _homeDir Full path to the home directory
+    /// \return True if directory is set correctly, false otherwise
+    bool TestSetHomePath(std::string &_homeDir)
+    {
+      if (env("TEST_UNDECLARED_OUTPUTS_DIR", _homeDir)) 
+      {
+        return true;
+      } 
+      else
+      {
+        _homeDir = PROJECT_BINARY_DIR;
+        // Set both for linux and windows
+        return setenv("HOME", _homeDir) && setenv("HOMEPATH", _homeDir);
+      }
+    }
+
+    /// \brief Retrieve a file from the project source directory
+    /// \param[in] variable length of arguments relative to the
+    ///   repository source directory
+    /// \return Full path to requested file
+    template <typename... Args>
+    std::string SourceFile(Args const &... args)
+    {
+      std::string dataDir;
+      ProjectSourcePath(dataDir);
+      return sdf::filesystem::append(dataDir, args...);
+    }
+
+    /// \brief Retrieve a file from the test directory
+    /// \param[in] variable length of arguments relative to the
+    ///   repository test directory
+    /// \return Full path to requested test file
+    template <typename... Args>
+    std::string TestFile(Args const &... args)
+    {
+      return SourceFile("test", args...);
+    }
+
+  }  // namespace testing
+}  // namespace sdf
+
 #endif
-#endif
+


### PR DESCRIPTION
# Backport

## Summary
Adds `sdf::testing::SourceFile`, `sdf::testing::TestFile`, `sdf::testing::env`, and `sdf::testing::setenv` and updates tests to use them. This makes it easier to backport other changes from newer branches.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
