### PR TITLE
Use helper functions from ignition common and math

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,8 @@ if (BUILD_SDF)
 
   ########################################
   # Find ignition common
-  ign_find_package(ignition-common5 COMPONENTS graphics REQUIRED)
+  ign_find_package(ignition-common5 COMPONENTS graphics REQUIRED_BY usd)
+  ign_find_package(ignition-common5 REQUIRED)
   set(IGN_COMMON_VER ${ignition-common5_VERSION_MAJOR})
 
   ########################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ if (BUILD_SDF)
 
   ########################################
   # Find ignition common
-  ign_find_package(ignition-common5 COMPONENTS graphics REQUIRED_BY usd)
+  ign_find_package(ignition-common5 COMPONENTS graphics REQUIRED)
   set(IGN_COMMON_VER ${ignition-common5_VERSION_MAJOR})
 
   ########################################

--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,16 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## libsdformat 12.x to 13.0
+
+### Deprecations
+
+1. **sdf/Types.hh**: The `split`, `trim`, `lowercase`, and `equal` functions
+   are deprecated. These functions are replaced by equivalent functions in
+   `ignition::common' and `ignition::math. The replacements are
+   `ignition::common::split`,  `ignition::common::trimmed`,
+   `ignition::common::lowercase`, and `ignition::math::equal`.
+
 ## libsdformat 11.x to 12.0
 
 An error is now emitted instead of a warning for a file containing more than

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -33,6 +33,7 @@
 #include <variant>
 #include <vector>
 
+#include <ignition/common/Util.hh>
 #include <ignition/math.hh>
 
 #include "sdf/Console.hh"
@@ -535,7 +536,7 @@ namespace sdf
         // this section for handling bool types is to keep backward behavior
         // TODO(anyone) remove for Fortress. For more details:
         // https://github.com/ignitionrobotics/sdformat/pull/638
-        valueStr = lowercase(valueStr);
+        valueStr = ignition::common::lowercase(valueStr);
 
         std::stringstream tmp;
         if (valueStr == "true" || valueStr == "1")

--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -75,28 +75,32 @@ namespace sdf
   /// \param[in] str       The string to split.
   /// \param[in] splitter  The delimiter to use.
   /// \return A vector of strings containing the split tokens.
+  /// \deprecated Use the trim function found in Ignition Common.
   SDFORMAT_VISIBLE
-  std::vector<std::string> split(const std::string &_str,
+  std::vector<std::string> SDF_DEPRECATED(13) split(const std::string &_str,
                                  const std::string &_splitter);
 
   /// \brief Trim leading and trailing whitespace from a string.
   /// \param[in] _in The string to trim.
   /// \return A string containing the trimmed value.
+  /// \deprecated Use the trim function found in Ignition Common.
   SDFORMAT_VISIBLE
-  std::string trim(const char *_in);
+  std::string SDF_DEPRECATED(13) trim(const char *_in);
 
   /// \brief Trim leading and trailing whitespace from a string.
   /// \param[in] _in The string to trim.
   /// \return A string containing the trimmed value.
+  /// \deprecated Use the trim function found in Ignition Common.
   SDFORMAT_VISIBLE
-  std::string trim(const std::string &_in);
+  std::string SDF_DEPRECATED(13) trim(const std::string &_in);
 
   /// \brief check if two values are equal, within a tolerance
   /// \param[in] _a the first value
   /// \param[in] _b the second value
   /// \param[in] _epsilon the tolerance
+  /// \deprecated Use ignition::math::equal
   template<typename T>
-  inline bool equal(const T &_a, const T &_b,
+  inline bool SDF_DEPRECATED(13) equal(const T &_a, const T &_b,
                     const T &_epsilon = 1e-6f)
   {
     return std::fabs(_a - _b) <= _epsilon;
@@ -178,7 +182,9 @@ namespace sdf
   /// \brief Transforms a string to its lowercase equivalent
   /// \param[in] _in String to convert to lowercase
   /// \return Lowercase equilvalent of _in.
-  std::string SDFORMAT_VISIBLE lowercase(const std::string &_in);
+  /// \deprecated Use ignition::common::lowercase
+  std::string SDFORMAT_VISIBLE SDF_DEPRECATED(13) lowercase(
+      const std::string &_in);
 
   /// \brief Split a name into a two strings based on the '::' delimeter
   /// \param[in] _absoluteName The fully qualified absolute name

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,7 @@ ign_create_core_library(SOURCES ${sources}
 target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PUBLIC
     ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER}
+    ignition-common${IGN_COMMON_VER}::ignition-common${IGN_COMMON_VER}
     ignition-utils${IGN_UTILS_VER}::ignition-utils${IGN_UTILS_VER}
   PRIVATE
     TINYXML2::TINYXML2

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -768,11 +768,24 @@ void Converter::Map(tinyxml2::XMLElement *_elem, tinyxml2::XMLElement *_mapElem)
   std::string fromStr = fromNameStr;
   std::string toStr = toNameStr;
 
-  std::vector<std::string> fromTokens = split(fromStr, "/");
-  std::vector<std::string> toTokens = split(toStr, "/");
+  std::vector<std::string> fromTokens = ignition::common::split(fromStr, "/");
+  std::vector<std::string> toTokens = ignition::common::split(toStr, "/");
 
-  // split() always returns at least one element, even with the
-  // empty string.  Thus we don't check if the fromTokens or toTokens are empty.
+  // Return if empty.
+  if (fromTokens.empty() || toTokens.empty())
+    return;
+
+  // The logic in the rest of this function assumes that an empty string is
+  // present in the toTokens and fromTokens if the corresponding strings
+  // started or ended with a forward slash.
+  if (fromStr.front() == '/')
+    fromTokens.insert(fromTokens.begin(), "");
+  if (fromStr.back() == '/')
+    fromTokens.push_back("");
+  if (toStr.front() == '/')
+    toTokens.insert(toTokens.begin(), "");
+  if (toStr.back() == '/')
+    toTokens.push_back("");
 
   // get value of the 'from' element/attribute
   tinyxml2::XMLElement *fromElem = _elem;
@@ -791,7 +804,7 @@ void Converter::Map(tinyxml2::XMLElement *_elem, tinyxml2::XMLElement *_mapElem)
   if (fromLeaf[0] == '\0' ||
       (fromLeaf[0] == '@' && fromLeaf[1] == '\0'))
   {
-    sdferr << "Map: <from> has invalid name attribute\n";
+    sdferr << "Map: <from>[" << fromLeaf << "] has invalid name attribute\n";
     return;
   }
   const char *fromValue = nullptr;
@@ -812,7 +825,7 @@ void Converter::Map(tinyxml2::XMLElement *_elem, tinyxml2::XMLElement *_mapElem)
     return;
   }
   const char *toValue = valueMap[std::string(fromValue)].c_str();
-  // sdfdbg << "Map from [" << fromValue << "] to [" << toValue << "]\n";
+  sdfdbg << "Map from [" << fromValue << "] to [" << toValue << "]\n";
 
   // check if destination elements before leaf exist and create if necessary
   unsigned int newDirIndex = 0;
@@ -834,7 +847,7 @@ void Converter::Map(tinyxml2::XMLElement *_elem, tinyxml2::XMLElement *_mapElem)
   if (toLeaf[0] == '\0' ||
       (toLeaf[0] == '@' && toLeaf[1] == '\0'))
   {
-    sdferr << "Map: <to> has invalid name attribute\n";
+    sdferr << "Map: <to> [" << toLeaf << "] has invalid name attribute\n";
     return;
   }
   bool toAttribute = toLeaf[0] == '@';
@@ -909,11 +922,25 @@ void Converter::Move(tinyxml2::XMLElement *_elem,
     toStr = toAttrStr;
   }
 
-  std::vector<std::string> fromTokens = split(fromStr, "::");
-  std::vector<std::string> toTokens = split(toStr, "::");
+  std::vector<std::string> fromTokens = ignition::common::split(fromStr, "::");
+  std::vector<std::string> toTokens = ignition::common::split(toStr, "::");
 
   // split() always returns at least one element, even with the
   // empty string.  Thus we don't check if the fromTokens or toTokens are empty.
+  if (fromTokens.empty() || toTokens.empty())
+    return;
+
+  // The logic in the rest of this function assumes that an empty string is
+  // present in the toTokens and fromTokens if the corresponding strings
+  // started or ended with a forward slash.
+  if (fromStr.find("::") == 0)
+    fromTokens.insert(fromTokens.begin(), "");
+  if (fromStr.find("::") == fromStr.size()-2)
+    fromTokens.push_back("");
+  if (toStr.find("::") == '/')
+    toTokens.insert(toTokens.begin(), "");
+  if (toStr.find("::") == toStr.size()-2)
+    toTokens.push_back("");
 
   // get value of the 'from' element/attribute
   tinyxml2::XMLElement *fromElem = _elem;
@@ -1069,7 +1096,7 @@ void Converter::CheckDeprecation(tinyxml2::XMLElement *_elem,
        deprecatedElem = deprecatedElem->NextSiblingElement("deprecated"))
   {
     std::string value = deprecatedElem->GetText();
-    std::vector<std::string> valueSplit = split(value, "/");
+    std::vector<std::string> valueSplit = ignition::common::split(value, "/");
 
     bool found = false;
     tinyxml2::XMLElement *e = _elem;

--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include <ignition/common/Util.hh>
+
 #include "sdf/Element.hh"
 #include "sdf/Error.hh"
 #include "sdf/Frame.hh"
@@ -639,7 +641,7 @@ void addVerticesToGraph(ScopedGraph<GraphT> &_out,
     {
       _errors.emplace_back(ErrorCode::DUPLICATE_NAME, item.elementType +
           " with non-unique name [" + item.name + "] detected in " +
-          lowercase(_parent.elementType) + " with name [" +
+          ignition::common::lowercase(_parent.elementType) + " with name [" +
           _parent.name + "].");
       continue;
     }
@@ -703,8 +705,8 @@ void addEdgesToGraph(ScopedGraph<PoseRelativeToGraph> &_out,
       {
         std::stringstream errMsg;
         errMsg << typeForErrorMsg << " name[" << relativeTo << "] specified by "
-               << lowercase(item.elementType) << " with name[" << item.name
-               << "] does not match a";
+               << ignition::common::lowercase(item.elementType)
+               << " with name[" << item.name << "] does not match a";
         if (_parent.frameType == FrameType::WORLD)
         {
           errMsg << " model or frame name ";
@@ -713,8 +715,8 @@ void addEdgesToGraph(ScopedGraph<PoseRelativeToGraph> &_out,
         {
           errMsg << " nested model, link, joint, or frame name ";
         }
-        errMsg << "in " + lowercase(_parent.elementType) + " with name[" +
-                      _parent.name + "].";
+        errMsg << "in " + ignition::common::lowercase(_parent.elementType) +
+          " with name[" + _parent.name + "].";
 
         _errors.push_back({errorCode, errMsg.str()});
         continue;
@@ -725,9 +727,10 @@ void addEdgesToGraph(ScopedGraph<PoseRelativeToGraph> &_out,
       {
         _errors.push_back({ErrorCode::POSE_RELATIVE_TO_CYCLE,
             "relative_to name[" + relativeTo +
-            "] is identical to " + lowercase(item.elementType) + " name[" +
+            "] is identical to " +
+            ignition::common::lowercase(item.elementType) + " name[" +
             item.name + "], causing a graph cycle in " +
-            lowercase(_parent.elementType) + " with name[" +
+            ignition::common::lowercase(_parent.elementType) + " with name[" +
             _parent.name + "]."});
       }
     }
@@ -770,7 +773,8 @@ void addEdgesToGraph(ScopedGraph<FrameAttachedToGraph> &_out,
       _errors.push_back(
           {ErrorCode::JOINT_CHILD_LINK_INVALID,
            "Child frame with name[" + joint.childName + "] specified by " +
-               lowercase(joint.elementType) + " with name[" + joint.name +
+               ignition::common::lowercase(joint.elementType) +
+               " with name[" + joint.name +
                "] not found in model with name[" + _model.name + "]."});
       continue;
     }
@@ -805,7 +809,8 @@ void addEdgesToGraph(ScopedGraph<FrameAttachedToGraph> &_out,
     {
       std::stringstream errMsg;
       errMsg << "attached_to name[" << attachedTo << "] specified by "
-             << lowercase(frame.elementType) << " with name[" << frame.name
+             << ignition::common::lowercase(frame.elementType)
+             << " with name[" << frame.name
              << "] does not match a";
       if (_parent.frameType == FrameType::WORLD)
       {
@@ -815,8 +820,8 @@ void addEdgesToGraph(ScopedGraph<FrameAttachedToGraph> &_out,
       {
         errMsg << " nested model, link, joint, or frame name ";
       }
-      errMsg << "in " + lowercase(_parent.elementType) + " with name[" +
-                    _parent.name + "].";
+      errMsg << "in " + ignition::common::lowercase(_parent.elementType) +
+        " with name[" + _parent.name + "].";
 
       _errors.push_back({ErrorCode::FRAME_ATTACHED_TO_INVALID, errMsg.str()});
       continue;
@@ -831,7 +836,8 @@ void addEdgesToGraph(ScopedGraph<FrameAttachedToGraph> &_out,
       _errors.push_back({ErrorCode::FRAME_ATTACHED_TO_CYCLE,
           "attached_to name[" + attachedTo +
           "] is identical to frame name[" + frame.attachedTo +
-          "], causing a graph cycle in " + lowercase(_parent.elementType) +
+          "], causing a graph cycle in " +
+          ignition::common::lowercase(_parent.elementType) +
           " with name[" + _parent.name + "]."});
     }
     _out.AddEdge({frameId, attachedToId}, edgeData);

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include "sdf/Error.hh"
 #include "sdf/Joint.hh"
@@ -185,7 +186,7 @@ Errors Joint::Load(ElementPtr _sdf)
   std::pair<std::string, bool> typePair = _sdf->Get<std::string>("type", "");
   if (typePair.second)
   {
-    typePair.first = lowercase(typePair.first);
+    typePair.first = ignition::common::lowercase(typePair.first);
     if (typePair.first == "ball")
       this->dataPtr->type = JointType::BALL;
     else if (typePair.first == "continuous")

--- a/src/JointAxis.cc
+++ b/src/JointAxis.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <iterator>
 
+#include <ignition/math/Helpers.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
 
@@ -170,7 +171,7 @@ ignition::math::Vector3d JointAxis::Xyz() const
 /////////////////////////////////////////////////
 sdf::Errors JointAxis::SetXyz(const ignition::math::Vector3d &_xyz)
 {
-  if (sdf::equal(_xyz.Length(), 0.0))
+  if (ignition::math::equal(_xyz.Length(), 0.0))
   {
     return {Error(ErrorCode::ELEMENT_INVALID,
                   "The norm of the xyz vector cannot be zero")};
@@ -185,6 +186,7 @@ double JointAxis::Damping() const
 {
   return this->dataPtr->damping;
 }
+
 /////////////////////////////////////////////////
 void JointAxis::SetDamping(const double _damping)
 {

--- a/src/Noise.cc
+++ b/src/Noise.cc
@@ -16,6 +16,7 @@
  */
 
 #include <algorithm>
+#include <ignition/common/Util.hh>
 #include "sdf/Noise.hh"
 #include "sdf/parser.hh"
 #include "sdf/Types.hh"
@@ -85,7 +86,7 @@ Errors Noise::Load(ElementPtr _sdf)
         "Noise is missing the type attribute. Defaulting to 'none'."});
   }
 
-  std::string typeLower = lowercase(type.first);
+  std::string typeLower = ignition::common::lowercase(type.first);
 
   if (typeLower == "none")
     this->dataPtr->type = NoiseType::NONE;

--- a/src/Param.cc
+++ b/src/Param.cc
@@ -27,6 +27,8 @@
 #include <locale.h>
 #include <math.h>
 
+#include <ignition/common/Util.hh>
+
 #include "sdf/Assert.hh"
 #include "sdf/Param.hh"
 #include "sdf/Types.hh"
@@ -636,9 +638,9 @@ bool ParamPrivate::ValueFromStringImpl(const std::string &_typeName,
   // comma for decimal position instead of a dot, making the conversion
   // to fail. See bug #60 for more information. Force to use always C
   setlocale(LC_NUMERIC, "C");
-  std::string trimmed = sdf::trim(_valueStr);
+  std::string trimmed = ignition::common::trimmed(_valueStr);
   std::string tmp(trimmed);
-  std::string lowerTmp = lowercase(trimmed);
+  std::string lowerTmp = ignition::common::lowercase(trimmed);
 
   // "true" and "false" doesn't work properly (except for string)
   if (_typeName != "string" && _typeName != "std::string")
@@ -1028,7 +1030,7 @@ bool Param::SetFromString(const std::string &_value,
                           bool _ignoreParentAttributes)
 {
   this->dataPtr->ignoreParentAttributes = _ignoreParentAttributes;
-  std::string str = sdf::trim(_value.c_str());
+  std::string str = ignition::common::trimmed(_value.c_str());
 
   if (str.empty() && this->dataPtr->required)
   {

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -97,7 +97,7 @@ void ParserConfig::AddURIPath(const std::string &_uri, const std::string &_path)
   constexpr char multiplePathSeparator[] = ":";
 #endif
 
-  for (const auto &part : sdf::split(_path, multiplePathSeparator))
+  for (const auto &part : ignition::common::split(_path, multiplePathSeparator))
   {
     // Only add valid paths
     if (!part.empty() && sdf::filesystem::is_directory(part))

--- a/src/SDF.cc
+++ b/src/SDF.cc
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+#include <ignition/common/Util.hh>
+
 #include "sdf/parser.hh"
 #include "sdf/Assert.hh"
 #include "sdf/Console.hh"
@@ -123,7 +125,7 @@ std::string findFile(const std::string &_filename, bool _searchLocalPath,
   std::string sdfPathEnv;
   if(ignition::utils::env("SDF_PATH", sdfPathEnv))
   {
-    std::vector<std::string> paths = sdf::split(sdfPathEnv, ":");
+    std::vector<std::string> paths = ignition::common::split(sdfPathEnv, ":");
     for (std::vector<std::string>::iterator iter = paths.begin();
          iter != paths.end(); ++iter)
     {

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include <ignition/common/Util.hh>
+
 #include "sdf/Types.hh"
 
 namespace sdf
@@ -53,7 +55,7 @@ std::vector<std::string> split(const std::string &_str,
 //////////////////////////////////////////////////
 std::string trim(const char *_in)
 {
-  return sdf::trim(std::string(_in));
+  return ignition::common::trimmed(std::string(_in));
 }
 
 //////////////////////////////////////////////////

--- a/src/Types_TEST.cc
+++ b/src/Types_TEST.cc
@@ -24,6 +24,7 @@
 #include "sdf/Error.hh"
 #include "sdf/Types.hh"
 
+SDF_SUPPRESS_DEPRECATED_BEGIN
 /////////////////////////////////////////////////
 TEST(Types, split_nothing)
 {
@@ -100,6 +101,7 @@ TEST(Types, trim_nothing)
   out = sdf::trim("\n    xyz    \n");
   EXPECT_EQ(out, "xyz");
 }
+SDF_SUPPRESS_DEPRECATED_END
 
 /////////////////////////////////////////////////
 TEST(Types, ErrorsOutputStream)

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string>
 
+#include <ignition/common/Util.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "sdf/parser.hh"
@@ -1621,7 +1622,8 @@ TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldPoseRelativeTo))
     << "  8 -> 15 [label=1];\n"
     << "  10 -> 16 [label=1];\n"
     << "}";
-  EXPECT_EQ(sdf::trim(expected.str()), sdf::trim(output));
+  EXPECT_EQ(ignition::common::trimmed(expected.str()),
+            ignition::common::trimmed(output));
 }
 
 /////////////////////////////////////////////////
@@ -1697,7 +1699,8 @@ TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelPoseRelativeTo))
     << "  0 -> 1 [label=1];\n"
     << "}";
 
-  EXPECT_EQ(sdf::trim(expected.str()), sdf::trim(output));
+  EXPECT_EQ(ignition::common::trimmed(expected.str()),
+            ignition::common::trimmed(output));
 }
 
 /////////////////////////////////////////////////
@@ -1743,7 +1746,8 @@ TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldFrameAttachedTo))
            << "  15 -> 5 [label=1];\n"
            << "  16 -> 4 [label=1];\n"
            << "}";
-  EXPECT_EQ(sdf::trim(expected.str()), sdf::trim(output));
+  EXPECT_EQ(ignition::common::trimmed(expected.str()),
+            ignition::common::trimmed(output));
 }
 
 /////////////////////////////////////////////////
@@ -1792,7 +1796,8 @@ TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelFrameAttachedTo))
       << "  2 -> 3 [label=1];\n"
       << "}";
 
-  EXPECT_EQ(sdf::trim(expected.str()), sdf::trim(output));
+  EXPECT_EQ(ignition::common::trimmed(expected.str()),
+            ignition::common::trimmed(output));
 }
 
 /////////////////////////////////////////////////

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -573,7 +573,7 @@ bool initXml(tinyxml2::XMLElement *_xml,
       sdferr << "Attribute is missing a required string\n";
       return false;
     }
-    std::string requiredStr = sdf::trim(requiredString);
+    std::string requiredStr = ignition::common::trimmed(requiredString);
     bool required = requiredStr == "1" ? true : false;
     std::string description;
 

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -272,7 +272,7 @@ bool URDF2SDF::IsURDF(const std::string &_filename)
 /////////////////////////////////////////////////
 urdf::Vector3 ParseVector3(const std::string &_str, double _scale)
 {
-  std::vector<std::string> pieces = sdf::split(_str, " ");
+  std::vector<std::string> pieces = ignition::common::split(_str, " ");
   std::vector<double> vals;
 
   for (unsigned int i = 0; i < pieces.size(); ++i)
@@ -1189,7 +1189,7 @@ std::string GetKeyValueAsString(tinyxml2::XMLElement* _elem)
       sdfwarn << "Attribute value string not set\n";
     }
   }
-  return trim(valueStr);
+  return ignition::common::trimmed(valueStr);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/toml_parser.hh
+++ b/test/integration/toml_parser.hh
@@ -22,6 +22,8 @@
 #include <string>
 #include <variant>
 
+#include <ignition/common/Util.hh>
+
 #include "sdf/Param.hh"
 // This is a very basic toml parser for use in the interface_api integration
 // test and is not capable of parsing the full toml syntax. Specifically, this
@@ -78,7 +80,7 @@ struct Value
 
   public: Value &operator[](const std::string &_key)
   {
-    auto keys = sdf::split(_key, ".");
+    auto keys = ignition::common::split(_key, ".");
     Value *curValue = &(this->Map()[keys[0]]);
 
     for (std::size_t i = 1; i < keys.size(); ++i)
@@ -148,7 +150,7 @@ Document parseToml(const std::string &_filePath, sdf::Errors &_errors)
 
   auto readValue = [](const std::string &_inp)
   {
-    const std::string trimmed = sdf::trim(_inp);
+    const std::string trimmed = ignition::common::trimmed(_inp);
     // Find the quotes
     auto begInd = trimmed.find('"');
     auto endInd = trimmed.rfind('"');
@@ -156,7 +158,7 @@ Document parseToml(const std::string &_filePath, sdf::Errors &_errors)
   };
   auto readTableName = [](const std::string &_inp)
   {
-    const std::string trimmed = sdf::trim(_inp);
+    const std::string trimmed = ignition::common::trimmed(_inp);
     // Find the quotes
     auto begInd = trimmed.find('[');
     auto endInd = trimmed.rfind(']');
@@ -167,7 +169,7 @@ Document parseToml(const std::string &_filePath, sdf::Errors &_errors)
   std::string line;
   while (std::getline(fs, line))
   {
-    sdf::trim(line);
+    ignition::common::trimmed(line);
     if (line.empty() || line[0] == '#' )
     {
       continue;
@@ -177,7 +179,8 @@ Document parseToml(const std::string &_filePath, sdf::Errors &_errors)
       std::size_t eqInd = line.find('=');
       if (eqInd != std::string::npos)
       {
-        const std::string key = sdf::trim(line.substr(0, eqInd));
+        const std::string key =
+          ignition::common::trimmed(line.substr(0, eqInd));
         const std::string value = readValue(line.substr(eqInd + 1));
 
         sdf::Param param(key, keyType(key), "", true);


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

This deprecates duplicate functions found in libsdformat in favor of the functions found in ignition common.

## Test it

The tests should all pass.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.