### PR TITLE
Deprecate inertia

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,10 @@ if (BUILD_SDF)
 
   ########################################
   # Find ignition common
-  ign_find_package(ignition-common5 COMPONENTS graphics REQUIRED)
+  ign_find_package(ignition-common5 COMPONENTS graphics REQUIRED_BY usd)
+  set(IGN_COMMON_VER ${ignition-common5_VERSION_MAJOR})
+
+  ign_find_package(ignition-common5 REQUIRED)
   set(IGN_COMMON_VER ${ignition-common5_VERSION_MAJOR})
 
   ########################################

--- a/Migration.md
+++ b/Migration.md
@@ -29,6 +29,8 @@ but with improved human-readability..
    `ignition::common' and `ignition::math. The replacements are
    `ignition::common::split`,  `ignition::common::trimmed`,
    `ignition::common::lowercase`, and `ignition::math::equal`.
+1. **sdf/Types.hh**: The `Inertia` class has been deprecated. Please use the 
+   `Inertial` class in the `ign-math` library.
 
 ## libsdformat 11.x to 12.0
 

--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -174,7 +174,7 @@ namespace sdf
   };
 
   /// \brief A class for inertial information about a link.
-  class SDFORMAT_VISIBLE Inertia
+  class SDFORMAT_VISIBLE SDF_DEPRECATED(13) Inertia
   {
     public: double mass;
   };


### PR DESCRIPTION
# 🎉 New feature
## Summary

Deprecates `Inertia`, which is not used by libsdformat.

## Test it
The tests were not changed, they should all pass.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.