### PR TITLE
Added Exceptions to the python Frame interface

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -44,6 +44,7 @@ pybind11_add_module(sdformat SHARED
   src/sdf/pyCylinder.cc
   src/sdf/pyEllipsoid.cc
   src/sdf/pyError.cc
+  src/sdf/pyExceptions.cc
   src/sdf/pyFrame.cc
   src/sdf/pyGeometry.cc
   src/sdf/pyJoint.cc

--- a/python/src/sdf/pyExceptions.cc
+++ b/python/src/sdf/pyExceptions.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "pyExceptions.hh"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "sdf/Error.hh"
+
+namespace sdf
+{
+// Inline bracket to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE {
+namespace python
+{
+/////////////////////////////////////////////////
+void defineExceptions(pybind11::object module)
+{
+
+}
+}  // namespace python
+}  // namespace SDF_VERSION_NAMESPACE
+}  // namespace sdf

--- a/python/src/sdf/pyExceptions.hh
+++ b/python/src/sdf/pyExceptions.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDFORMAT_PYTHON_EXCEPTIONS_HH_
+#define SDFORMAT_PYTHON_EXCEPTIONS_HH_
+
+#include "sdf/Error.hh"
+#include "sdf/config.hh"
+
+namespace sdf
+{
+// Inline bracket to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE {
+namespace python
+{
+
+std::string ErrorString(const sdf::Errors &_errors)
+{
+  std::string errorStr = "\n";
+  for (const auto & error : _errors)
+  {
+    errorStr += std::string("Error code: ") +
+                std::to_string(static_cast<int>(error.Code()));
+    auto lineNumber = error.LineNumber();
+    if (lineNumber)
+    {
+      errorStr += std::string("Line: ") +
+                  std::to_string(error.LineNumber().value());
+    }
+    errorStr += std::string(" Message: ") + error.Message() + "\n";
+  }
+  return errorStr;
+}
+
+class SDFErrorsException : public std::runtime_error
+{
+public:
+  explicit SDFErrorsException(const sdf::Errors &_errors)
+   : std::runtime_error(ErrorString(_errors))
+  {}
+
+  ~SDFErrorsException() = default;
+};
+
+}  // namespace python
+}  // namespace SDF_VERSION_NAMESPACE
+}  // namespace sdf
+
+#endif  // SDFORMAT_PYTHON_EXCEPTIONS_HH_

--- a/python/src/sdf/pyExceptions.hh
+++ b/python/src/sdf/pyExceptions.hh
@@ -17,44 +17,100 @@
 #ifndef SDFORMAT_PYTHON_EXCEPTIONS_HH_
 #define SDFORMAT_PYTHON_EXCEPTIONS_HH_
 
-#include "sdf/Error.hh"
-#include "sdf/config.hh"
+#include <exception>
+#include <stdexcept>
 
+#include <pybind11/pybind11.h>
+
+#include "sdf/Error.hh"
+#include "sdf/Types.hh"
+#include "sdf/config.hh"
 namespace sdf
 {
 // Inline bracket to help doxygen filtering.
 inline namespace SDF_VERSION_NAMESPACE {
 namespace python
 {
-
-std::string ErrorString(const sdf::Errors &_errors)
-{
-  std::string errorStr = "\n";
-  for (const auto & error : _errors)
-  {
-    errorStr += std::string("Error code: ") +
-                std::to_string(static_cast<int>(error.Code()));
-    auto lineNumber = error.LineNumber();
-    if (lineNumber)
-    {
-      errorStr += std::string("Line: ") +
-                  std::to_string(error.LineNumber().value());
-    }
-    errorStr += std::string(" Message: ") + error.Message() + "\n";
-  }
-  return errorStr;
-}
-
-class SDFErrorsException : public std::runtime_error
+class SDFErrorsException : public std::exception
 {
 public:
   explicit SDFErrorsException(const sdf::Errors &_errors)
-   : std::runtime_error(ErrorString(_errors))
-  {}
+  : errors(_errors)
+  {
+  }
+
+  std::string getErrorString()
+  {
+    std::string errorStr = "\n";
+    for (const auto & error : this->errors)
+    {
+      errorStr += std::string("Error code: ") +
+                  std::to_string(static_cast<int>(error.Code()));
+      auto lineNumber = error.LineNumber();
+      if (lineNumber)
+      {
+        errorStr += std::string("Line: ") +
+                    std::to_string(error.LineNumber().value());
+      }
+      errorStr += std::string(" Message: ") + error.Message() + "\n";
+    }
+    return errorStr;
+  }
+
+  sdf::Errors GetErrors()
+  {
+    return this->errors;
+  }
 
   ~SDFErrorsException() = default;
+
+private:
+  sdf::Errors errors;
 };
 
+static PyObject *SDFErrorsException_tp_str(PyObject *selfPtr)
+{
+	pybind11::str ret;
+	try {
+		pybind11::handle self(selfPtr);
+		pybind11::tuple args = self.attr("args");
+		ret = pybind11::str(args[0]);
+	} catch (pybind11::error_already_set &e) {
+		ret = "";
+	}
+
+	/* ret will go out of scope when returning, therefore increase its reference
+	count, and transfer it to the caller (like PyObject_Str). */
+	ret.inc_ref();
+	return ret.ptr();
+}
+
+static PyObject *SDFErrorsException_geterrors(PyObject *selfPtr, void */*closure*/)
+{
+	try {
+		pybind11::handle self(selfPtr);
+		pybind11::tuple args = self.attr("args");
+		pybind11::object code = args[1];
+		code.inc_ref();
+		return  code.ptr();
+	} catch (pybind11::error_already_set &e) {
+		/* We could simply backpropagate the exception with e.restore, but
+		exceptions like OSError return None when an attribute is not set. */
+		pybind11::none ret;
+		ret.inc_ref();
+		return ret.ptr();
+	}
+}
+
+static PyGetSetDef SDFErrorsException_getsetters[] = {
+	{"errors", SDFErrorsException_geterrors, NULL, NULL, NULL},
+	{NULL}
+};
+/// Define a pybind11 wrapper for Exceptions
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+void defineExceptions(pybind11::object module);
 }  // namespace python
 }  // namespace SDF_VERSION_NAMESPACE
 }  // namespace sdf

--- a/python/src/sdf/pyFrame.cc
+++ b/python/src/sdf/pyFrame.cc
@@ -20,6 +20,7 @@
 #include <pybind11/stl.h>
 
 #include "sdf/Frame.hh"
+#include "pyExceptions.hh"
 
 using namespace pybind11::literals;
 
@@ -64,6 +65,10 @@ void defineFrame(pybind11::object module)
          {
            std::string body;
            auto errors = self.ResolveAttachedToBody(body);
+           if (!errors.empty())
+           {
+             throw SDFErrorsException(errors);
+           }
            return std::make_tuple(errors, body);
          },
          "Resolve the attached-to body of this frame from the "

--- a/python/test/pyFrame_TEST.py
+++ b/python/test/pyFrame_TEST.py
@@ -18,7 +18,7 @@ from sdformat import Frame, Error
 import unittest
 import math
 
-class FrameColor(unittest.TestCase):
+class FrameTest(unittest.TestCase):
 
     def test_default_construction(self):
         frame = Frame()
@@ -62,9 +62,8 @@ class FrameColor(unittest.TestCase):
         # expect errors when trying to resolve pose
         self.assertEqual(1, len(semanticPose.resolve(pose)))
 
-        errors, resolveAttachedToBody = frame.resolve_attached_to_body();
-        self.assertEqual(1, len(errors))
-        self.assertFalse(resolveAttachedToBody)
+        with self.assertRaises(RuntimeError):
+            frame.resolve_attached_to_body()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🎉 New feature

## Summary

I made this prototype to use exceptions instead of returning errors

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

