### PR TITLE
Camera: fix default trigger topic

### DIFF
--- a/sdf/1.9/camera.sdf
+++ b/sdf/1.9/camera.sdf
@@ -9,7 +9,7 @@
     <description>If the camera will be triggered by a topic</description>
   </element> <!-- End Triggered -->
 
-  <element name="trigger_topic" type="string" default="__default__/trigger" required="0">
+  <element name="trigger_topic" type="string" default="" required="0">
     <description>Name of the topic that will trigger the camera if enabled</description>
   </element> <!-- End Trigger_Topic -->
 

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -228,8 +228,11 @@ Errors Camera::Load(ElementPtr _sdf)
   this->dataPtr->triggered = _sdf->Get<bool>("triggered",
       this->dataPtr->triggered).first;
 
-  this->dataPtr->triggerTopic = _sdf->Get<std::string>("trigger_topic",
-      this->dataPtr->triggerTopic).first;
+  if (_sdf->HasElement("trigger_topic"))
+  {
+    this->dataPtr->triggerTopic = _sdf->Get<std::string>("trigger_topic",
+        this->dataPtr->triggerTopic).first;
+  }
 
   this->dataPtr->hfov = _sdf->Get<ignition::math::Angle>("horizontal_fov",
       this->dataPtr->hfov).first;

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -228,11 +228,8 @@ Errors Camera::Load(ElementPtr _sdf)
   this->dataPtr->triggered = _sdf->Get<bool>("triggered",
       this->dataPtr->triggered).first;
 
-  if (_sdf->HasElement("trigger_topic"))
-  {
-    this->dataPtr->triggerTopic = _sdf->Get<std::string>("trigger_topic",
-        this->dataPtr->triggerTopic).first;
-  }
+  this->dataPtr->triggerTopic = _sdf->Get<std::string>("trigger_topic",
+      this->dataPtr->triggerTopic).first;
 
   this->dataPtr->hfov = _sdf->Get<ignition::math::Angle>("horizontal_fov",
       this->dataPtr->hfov).first;

--- a/test/integration/link_dom.cc
+++ b/test/integration/link_dom.cc
@@ -274,6 +274,9 @@ TEST(DOMLink, Sensors)
   EXPECT_EQ(ignition::math::Pose3d(0.1, 0.2, 0.3, 0, 0, 0),
             camSensor->RawPose());
   EXPECT_DOUBLE_EQ(0.75, camSensor->HorizontalFov().Radian());
+  EXPECT_EQ("", cameraSensor->Topic());
+  EXPECT_EQ("my_camera/trigger", camSensor->TriggerTopic());
+  EXPECT_TRUE(camSensor->Triggered());
   EXPECT_EQ(640u, camSensor->ImageWidth());
   EXPECT_EQ(480u, camSensor->ImageHeight());
   EXPECT_EQ(sdf::PixelFormatType::RGB_INT8, camSensor->PixelFormat());
@@ -352,6 +355,9 @@ TEST(DOMLink, Sensors)
   const sdf::Camera *rgbdCamSensor = rgbdSensor->CameraSensor();
   ASSERT_NE(nullptr, rgbdCamSensor);
   EXPECT_EQ("my_rgbd_camera", rgbdCamSensor->Name());
+  EXPECT_EQ("", rgbdSensor->Topic());
+  EXPECT_EQ("", rgbdCamSensor->TriggerTopic());
+  EXPECT_TRUE(rgbdCamSensor->Triggered());
 
   // Get the thermal sensor
   const sdf::Sensor *thermalSensor = link->SensorByName("thermal_sensor");
@@ -664,6 +670,9 @@ TEST(DOMLink, Sensors)
   EXPECT_EQ(ignition::math::Pose3d(0.2, 0.3, 0.4, 0, 0, 0),
             wideAngleCam->RawPose());
   EXPECT_DOUBLE_EQ(3.14, wideAngleCam->HorizontalFov().Radian());
+  EXPECT_EQ("wideanglecamera", wideAngleCameraSensor->Topic());
+  EXPECT_EQ("", wideAngleCam->TriggerTopic());
+  EXPECT_FALSE(wideAngleCam->Triggered());
   EXPECT_EQ(320u, wideAngleCam->ImageWidth());
   EXPECT_EQ(240u, wideAngleCam->ImageHeight());
   EXPECT_EQ(sdf::PixelFormatType::RGB_INT8, wideAngleCam->PixelFormat());

--- a/test/sdf/sensors.sdf
+++ b/test/sdf/sensors.sdf
@@ -26,6 +26,8 @@
         <camera name="my_camera">
           <pose>0.1 0.2 0.3 0 0 0</pose>
           <horizontal_fov>.75</horizontal_fov>
+          <triggered>true</triggered>
+          <trigger_topic>my_camera/trigger</trigger_topic>
           <image>
             <width>640</width>
             <height>480</height>
@@ -384,6 +386,7 @@
         <camera name="my_rgbd_camera">
           <pose>0.1 0.2 0.3 0 0 0</pose>
           <horizontal_fov>.75</horizontal_fov>
+          <triggered>true</triggered>
           <image>
             <width>640</width>
             <height>480</height>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes default trigger topic when unset

## Summary

In https://github.com/ignitionrobotics/ign-sensors/pull/215#discussion_r855757419 I noticed that if the trigger topic name is not explicitly set in SDFormat that ign-sensors uses `__default__/trigger` as the default trigger topic name. I believe this is due to the way the DOM object is loaded, so I have adjusted it in https://github.com/ignitionrobotics/sdformat/commit/361fa6aa8d7083cb1c0c50b291bd3b5e522cb3ae to only read the value of the `trigger_topic` element if that element exists. Thus it will return an empty string `""` if no trigger topic is specified, leaving the default behavior up to the downstream library (ign-sensors in the case I noticed).

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
