### PR TITLE
Add Link::ResolveInertial API

### DIFF
--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -192,11 +192,11 @@ namespace sdf
     /// \sa const ignition::math::Inertiald &Inertial() const
     public: bool SetInertial(const ignition::math::Inertiald &_inertial);
 
-    /// \brief Resolve the Inertial pose to a specified frame.
-    /// If there are any errors resolving the pose, the output will not be
-    /// modified.
-    /// \param[out] _pose The resolved pose.
-    /// \param[in] _resolveTo The pose will be resolved with respect to this
+    /// \brief Resolve the Inertial to a specified frame.
+    /// If there are any errors resolving the Inertial, the output will not
+    /// be modified.
+    /// \param[out] _inertial The resolved Inertial.
+    /// \param[in] _resolveTo The Inertial will be resolved with respect to this
     /// frame. If unset or empty, the default resolve-to frame will be used.
     /// \return Errors in resolving pose.
     public: Errors ResolveInertial(ignition::math::Inertiald &_inertial,

--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -192,6 +192,16 @@ namespace sdf
     /// \sa const ignition::math::Inertiald &Inertial() const
     public: bool SetInertial(const ignition::math::Inertiald &_inertial);
 
+    /// \brief Resolve the Inertial pose to a specified frame.
+    /// If there are any errors resolving the pose, the output will not be
+    /// modified.
+    /// \param[out] _pose The resolved pose.
+    /// \param[in] _resolveTo The pose will be resolved with respect to this
+    /// frame. If unset or empty, the default resolve-to frame will be used.
+    /// \return Errors in resolving pose.
+    public: Errors ResolveInertial(ignition::math::Inertiald &_inertial,
+                                   const std::string &_resolveTo = "") const;
+
     /// \brief Get the pose of the link. This is the pose of the link
     /// as specified in SDF (<link> <pose> ... </pose></link>).
     /// \return The pose of the link.

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -350,6 +350,21 @@ bool Link::SetInertial(const ignition::math::Inertiald &_inertial)
 }
 
 /////////////////////////////////////////////////
+Errors Link::ResolveInertial(
+  ignition::math::Inertiald &_inertial,
+  const std::string &_resolveTo) const
+{
+  ignition::math::Pose3d linkPose;
+  auto errors = this->SemanticPose().Resolve(linkPose, _resolveTo);
+  if (errors.empty())
+  {
+    _inertial = this->dataPtr->inertial;
+    _inertial.SetPose(linkPose * _inertial.Pose());
+  }
+  return errors;
+}
+
+/////////////////////////////////////////////////
 const ignition::math::Pose3d &Link::Pose() const
 {
   return this->RawPose();

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -204,13 +204,9 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
 
   for (uint64_t i = 0; i < model->LinkCount(); i++)
   {
-    ignition::math::Pose3d linkPoseRelativeToModel;
-    errors = model->LinkByIndex(i)->SemanticPose().
-      Resolve(linkPoseRelativeToModel, "__model__");
+    ignition::math::Inertiald currentLinkInertial;
+    model->LinkByIndex(i)->ResolveInertial(currentLinkInertial, "__model__");
 
-    auto currentLinkInertial = model->LinkByIndex(i)->Inertial();
-    currentLinkInertial.SetPose(linkPoseRelativeToModel *
-      currentLinkInertial.Pose());
     totalInertial += currentLinkInertial;
   }
 


### PR DESCRIPTION
# 🎉 New feature

Closes #935

## Summary

The `Link::Inertial()` method returns an Inertial object with a Pose
specified relative to the link frame. This adds a new method for
resolving the Inertial's Pose to a specified frame. The method
is demonstrated in the `ign sdf --inertial-states` command code.

## Test it

Run the `UNIT_ign_TEST` and confirm that `ign sdf --inertial-stats` test still passes.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
