### PR TITLE
Add visibility mask to Lidar / Ray sensor

### DIFF
--- a/include/sdf/Lidar.hh
+++ b/include/sdf/Lidar.hh
@@ -221,6 +221,14 @@ namespace sdf
     /// \param[in] _noise Noise values for the lidar sensor.
     public: void SetLidarNoise(const Noise &_noise);
 
+    /// \brief Get the visibility mask of a lidar
+    /// \return visibility mask
+    public: uint32_t VisibilityMask() const;
+
+    /// \brief Set the visibility mask of a lidar
+    /// \param[in] _mask visibility mask
+    public: void SetVisibilityMask(uint32_t _mask);
+
     /// \brief Return true if both Lidar objects contain the same values.
     /// \param[_in] _lidar Lidar value to compare.
     /// \return True if 'this' == _lidar.

--- a/sdf/1.9/lidar.sdf
+++ b/sdf/1.9/lidar.sdf
@@ -70,4 +70,9 @@
       <description>For type "gaussian," the standard deviation of the Gaussian distribution from which noise values are drawn.</description>
     </element>
   </element> <!-- End Noise -->
+
+  <element name="visibility_mask" type="unsigned int" default="4294967295" required="0">
+    <description><![CDATA[Visibility mask of a lidar. When (lidar's visibility_mask & object's visibility_flags) evaluates to non-zero, the object will be visible to the lidar.]]></description>
+  </element>
+
 </element> <!-- End Lidar -->

--- a/sdf/1.9/ray.sdf
+++ b/sdf/1.9/ray.sdf
@@ -70,4 +70,9 @@
       <description>For type "gaussian," the standard deviation of the Gaussian distribution from which noise values are drawn.</description>
     </element>
   </element> <!-- End Noise -->
+
+  <element name="visibility_mask" type="unsigned int" default="4294967295" required="0">
+    <description><![CDATA[Visibility mask of a ray sensor. When (rays' visibility_mask & object's visibility_flags) evaluates to non-zero, the object will be visible to the ray sensor.]]></description>
+  </element>
+
 </element> <!-- End Ray -->

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -188,7 +188,7 @@ class sdf::Camera::Implementation
   public: bool hasIntrinsics = false;
 
   /// \brief Visibility mask of a camera. Defaults to 0xFFFFFFFF
-  public: uint32_t visibilityMask{4294967295u};
+  public: uint32_t visibilityMask{UINT32_MAX};
 };
 
 /////////////////////////////////////////////////

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -188,7 +188,7 @@ TEST(DOMCamera, Construction)
 
   EXPECT_TRUE(cam.HasLensIntrinsics());
 
-  EXPECT_EQ(4294967295u, cam.VisibilityMask());
+  EXPECT_EQ(UINT32_MAX, cam.VisibilityMask());
   cam.SetVisibilityMask(123u);
   EXPECT_EQ(123u, cam.VisibilityMask());
 

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -63,7 +63,7 @@ class sdf::Lidar::Implementation
   public: sdf::ElementPtr sdf{nullptr};
 
   /// \brief Visibility mask of a lidar. Defaults to 0xFFFFFFFF
-  public: uint32_t visibilityMask{4294967295u};
+  public: uint32_t visibilityMask{UINT32_MAX};
 };
 
 //////////////////////////////////////////////////

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -61,6 +61,9 @@ class sdf::Lidar::Implementation
 
   /// \brief The SDF element pointer used during load.
   public: sdf::ElementPtr sdf{nullptr};
+
+  /// \brief Visibility mask of a lidar. Defaults to 0xFFFFFFFF
+  public: uint32_t visibilityMask{4294967295u};
 };
 
 //////////////////////////////////////////////////
@@ -172,6 +175,12 @@ Errors Lidar::Load(ElementPtr _sdf)
 
   if (_sdf->HasElement("noise"))
     this->dataPtr->lidarNoise.Load(_sdf->GetElement("noise"));
+
+  if (_sdf->HasElement("visibility_mask"))
+  {
+    this->dataPtr->visibilityMask = _sdf->Get<uint32_t>("visibility_mask",
+        this->dataPtr->visibilityMask).first;
+  }
 
   return errors;
 }
@@ -326,6 +335,18 @@ void Lidar::SetLidarNoise(const Noise &_noise)
   this->dataPtr->lidarNoise = _noise;
 }
 
+/////////////////////////////////////////////////
+uint32_t Lidar::VisibilityMask() const
+{
+  return this->dataPtr->visibilityMask;
+}
+
+/////////////////////////////////////////////////
+void Lidar::SetVisibilityMask(uint32_t _mask)
+{
+  this->dataPtr->visibilityMask = _mask;
+}
+
 //////////////////////////////////////////////////
 bool Lidar::operator==(const Lidar &_lidar) const
 {
@@ -357,6 +378,8 @@ bool Lidar::operator==(const Lidar &_lidar) const
     return false;
   }
   if (this->dataPtr->lidarNoise != _lidar.LidarNoise())
+    return false;
+  if (this->dataPtr->visibilityMask != _lidar.VisibilityMask())
     return false;
 
   return true;
@@ -421,6 +444,9 @@ sdf::ElementPtr Lidar::ToElement() const
   noiseElem->GetElement("mean")->Set<double>(this->dataPtr->lidarNoise.Mean());
   noiseElem->GetElement("stddev")->Set<double>(
       this->dataPtr->lidarNoise.StdDev());
+
+  elem->GetElement("visibility_mask")->Set<uint32_t>(
+      this->VisibilityMask());
 
   return elem;
 }

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -66,7 +66,7 @@ TEST(DOMLidar, Set)
   lidar.SetHorizontalScanSamples(111);
   lidar.SetHorizontalScanResolution(2.2);
 
-  EXPECT_EQ(4294967295u, lidar.VisibilityMask());
+  EXPECT_EQ(UINT32_MAX, lidar.VisibilityMask());
   lidar.SetVisibilityMask(123u);
   EXPECT_EQ(123u, lidar.VisibilityMask());
 

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -66,6 +66,10 @@ TEST(DOMLidar, Set)
   lidar.SetHorizontalScanSamples(111);
   lidar.SetHorizontalScanResolution(2.2);
 
+  EXPECT_EQ(4294967295u, lidar.VisibilityMask());
+  lidar.SetVisibilityMask(123u);
+  EXPECT_EQ(123u, lidar.VisibilityMask());
+
   // Inequality operator
   sdf::Lidar lidar2;
   EXPECT_NE(lidar2, lidar);
@@ -135,6 +139,7 @@ TEST(DOMLidar, ToElement)
   lidar.SetRangeMin(1.2);
   lidar.SetRangeMax(3.4);
   lidar.SetRangeResolution(5.6);
+  lidar.SetVisibilityMask(123u);
 
   sdf::Noise noise;
   noise.SetMean(6.5);
@@ -160,6 +165,7 @@ TEST(DOMLidar, ToElement)
   EXPECT_DOUBLE_EQ(1.2, lidar2.RangeMin());
   EXPECT_DOUBLE_EQ(3.4, lidar2.RangeMax());
   EXPECT_DOUBLE_EQ(5.6, lidar2.RangeResolution());
+  EXPECT_EQ(123u, lidar2.VisibilityMask());
   EXPECT_EQ(noise, lidar2.LidarNoise());
 
   // make changes to DOM and verify ToElement produces updated values

--- a/src/Visual.cc
+++ b/src/Visual.cc
@@ -61,7 +61,7 @@ class sdf::Visual::Implementation
   public: sdf::ScopedGraph<sdf::PoseRelativeToGraph> poseRelativeToGraph;
 
   /// \brief Visibility flags of a visual. Defaults to 0xFFFFFFFF
-  public: uint32_t visibilityFlags = 4294967295u;
+  public: uint32_t visibilityFlags = UINT32_MAX;
 
   /// \brief True indicates the lidar reflective intensity was set.
   public: bool hasLaserRetro{false};

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -76,7 +76,7 @@ TEST(DOMVisual, Construction)
   EXPECT_EQ(nullptr, visual.Material());
 
   // visibility flags
-  EXPECT_EQ(4294967295u, visual.VisibilityFlags());
+  EXPECT_EQ(UINT32_MAX, visual.VisibilityFlags());
   visual.SetVisibilityFlags(1u);
   EXPECT_EQ(1u, visual.VisibilityFlags());
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary

Similar to the camera `<visibiliity_mask>` SDF element, this PR Adds a new `<visibility_mask>` SDF element to the lidar.sdf. I believe `ray.sdf` is being deprecated in favor of `lidar.sdf` but I also update its spec to be consistent with lidar.

## Test it

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

