### PR TITLE
Fixed usd2sdf when import from model://

### DIFF
--- a/usd/src/sdf_parser/Geometry.cc
+++ b/usd/src/sdf_parser/Geometry.cc
@@ -204,6 +204,36 @@ namespace usd
       fullName =
         ignition::common::findFile(uri.Str());
     }
+    else if (uri.Scheme() == "model")
+    {
+      fullName =
+        ignition::common::findFile(_geometry.MeshShape()->Uri());
+
+      std::function<void(const std::string)> addSubFolders =
+        [&](const std::string &_dir)
+      {
+        for (ignition::common::DirIter file(_dir);
+          file != ignition::common::DirIter(); ++file)
+        {
+          std::string current(*file);
+          if (ignition::common::isDirectory(current))
+          {
+            auto systemPaths = ignition::common::systemPaths();
+            systemPaths->AddFilePaths(current);
+            addSubFolders(current);
+          }
+        }
+      };
+      auto fileExtensionIndex = fullName.rfind(
+        ignition::common::basename(fullName));
+      if (fileExtensionIndex != std::string::npos)
+      {
+        std::string dirName = fullName;
+        dirName.erase(fileExtensionIndex,
+          ignition::common::basename(fullName).length() + 1);
+        addSubFolders(ignition::common::parentPath(dirName));
+      }
+    }
     else
     {
       fullName =


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🦟 Bug fix

## Summary

Added the `model://` path to the set of folder where sdf should look for models and textures

FYI @rbonghi

```
SDF_PATH="models" IGN_FILE_PATH="models" sdf2usd worlds/office.sdf office.usda
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

