### PR TITLE
Add Friction, ODE python interfaces

### DIFF
--- a/python/src/sdf/_ignition_sdformat_pybind11.cc
+++ b/python/src/sdf/_ignition_sdformat_pybind11.cc
@@ -69,6 +69,7 @@ PYBIND11_MODULE(sdformat, m) {
   sdf::python::defineError(m);
   sdf::python::defineForceTorque(m);
   sdf::python::defineFrame(m);
+  sdf::python::defineFriction(m);
   sdf::python::defineGeometry(m);
   sdf::python::defineIMU(m);
   sdf::python::defineJoint(m);
@@ -82,6 +83,7 @@ PYBIND11_MODULE(sdformat, m) {
   sdf::python::defineModel(m);
   sdf::python::defineNavSat(m);
   sdf::python::defineNoise(m);
+  sdf::python::defineODE(m);
   sdf::python::defineParserConfig(m);
   sdf::python::definePbr(m);
   sdf::python::definePbrWorkflow(m);

--- a/python/src/sdf/pySurface.cc
+++ b/python/src/sdf/pySurface.cc
@@ -51,7 +51,7 @@ void defineFriction(pybind11::object module)
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Friction>())
     .def("ode", &sdf::Friction::ODE,
-         pybind11::return_value_policy::reference,
+         pybind11::return_value_policy::reference_internal,
          "Get the ODE object.")
     .def("set_ode", &sdf::Friction::SetODE,
          "Set the ODE object.")
@@ -102,12 +102,12 @@ void defineSurface(pybind11::object module)
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Surface>())
     .def("contact", &sdf::Surface::Contact,
-         pybind11::return_value_policy::reference,
+         pybind11::return_value_policy::reference_internal,
          "Get the associated contact object")
     .def("set_contact", &sdf::Surface::SetContact,
          "Set the associated contact object.")
     .def("friction", &sdf::Surface::Friction,
-         pybind11::return_value_policy::reference,
+         pybind11::return_value_policy::reference_internal,
          "Get the associated friction object")
     .def("set_friction", &sdf::Surface::SetFriction,
          "Set the associated friction object.")

--- a/python/src/sdf/pySurface.cc
+++ b/python/src/sdf/pySurface.cc
@@ -45,6 +45,57 @@ void defineContact(pybind11::object module)
     }, "memo"_a);
 }
 /////////////////////////////////////////////////
+void defineFriction(pybind11::object module)
+{
+  pybind11::class_<sdf::Friction>(module, "Friction")
+    .def(pybind11::init<>())
+    .def(pybind11::init<sdf::Friction>())
+    .def("ode", &sdf::Friction::ODE,
+         pybind11::return_value_policy::reference,
+         "Get the ODE object.")
+    .def("set_ode", &sdf::Friction::SetODE,
+         "Set the ODE object.")
+    .def("__copy__", [](const sdf::Friction &self) {
+      return sdf::Friction(self);
+    })
+    .def("__deepcopy__", [](const sdf::Friction &self, pybind11::dict) {
+      return sdf::Friction(self);
+    }, "memo"_a);
+}
+/////////////////////////////////////////////////
+void defineODE(pybind11::object module)
+{
+  pybind11::class_<sdf::ODE>(module, "ODE")
+    .def(pybind11::init<>())
+    .def(pybind11::init<sdf::ODE>())
+    .def("fdir1", &sdf::ODE::Fdir1,
+         "Get the fdir1 parameter.")
+    .def("set_fdir1", &sdf::ODE::SetFdir1,
+         "Set the fdir1 parameter.")
+    .def("mu", &sdf::ODE::Mu,
+         "Get the mu parameter.")
+    .def("set_mu", &sdf::ODE::SetMu,
+         "Set the mu parameter.")
+    .def("mu2", &sdf::ODE::Mu2,
+         "Get the mu2 parameter.")
+    .def("set_mu2", &sdf::ODE::SetMu2,
+         "Set the mu2 parameter.")
+    .def("slip1", &sdf::ODE::Slip1,
+         "Get the slip1 parameter.")
+    .def("set_slip1", &sdf::ODE::SetSlip1,
+         "Set the slip1 parameter.")
+    .def("slip2", &sdf::ODE::Slip2,
+         "Get the slip2 parameter.")
+    .def("set_slip2", &sdf::ODE::SetSlip2,
+         "Set the slip2 parameter.")
+    .def("__copy__", [](const sdf::ODE &self) {
+      return sdf::ODE(self);
+    })
+    .def("__deepcopy__", [](const sdf::ODE &self, pybind11::dict) {
+      return sdf::ODE(self);
+    }, "memo"_a);
+}
+/////////////////////////////////////////////////
 void defineSurface(pybind11::object module)
 {
   pybind11::class_<sdf::Surface>(module, "Surface")
@@ -55,6 +106,11 @@ void defineSurface(pybind11::object module)
          "Get the associated contact object")
     .def("set_contact", &sdf::Surface::SetContact,
          "Set the associated contact object.")
+    .def("friction", &sdf::Surface::Friction,
+         pybind11::return_value_policy::reference,
+         "Get the associated friction object")
+    .def("set_friction", &sdf::Surface::SetFriction,
+         "Set the associated friction object.")
     .def("__copy__", [](const sdf::Surface &self) {
       return sdf::Surface(self);
     })

--- a/python/src/sdf/pySurface.hh
+++ b/python/src/sdf/pySurface.hh
@@ -35,6 +35,18 @@ namespace python
  */
 void defineContact(pybind11::object module);
 
+/// Define a pybind11 wrapper for an sdf::Friction
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+void defineFriction(pybind11::object module);
+
+/// Define a pybind11 wrapper for an sdf::ODE
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+void defineODE(pybind11::object module);
+
 /// Define a pybind11 wrapper for an sdf::Surface
 /**
  * \param[in] module a pybind11 module to add the definition to

--- a/python/test/pySurface_TEST.py
+++ b/python/test/pySurface_TEST.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import copy
-from sdformat import Surface, Contact
+from ignition.math import Vector3d
+from sdformat import Surface, Contact, Friction, ODE
 import unittest
 
 
@@ -27,46 +28,151 @@ class SurfaceTEST(unittest.TestCase):
   def test_assigment_construction(self):
     surface1 = Surface()
     contact = Contact()
+    ode = ODE()
+    ode.set_mu(0.1)
+    ode.set_mu2(0.2)
+    ode.set_slip1(3)
+    ode.set_slip2(4)
+    ode.set_fdir1(Vector3d(1, 2, 3))
+    friction = Friction()
+    friction.set_ode(ode)
     contact.set_collide_bitmask(0x12)
     surface1.set_contact(contact)
+    surface1.set_friction(friction)
 
     surface2 = surface1
     self.assertEqual(surface2.contact().collide_bitmask(), 0x12)
+    self.assertEqual(surface2.friction().ode().mu(), 0.1)
+    self.assertEqual(surface2.friction().ode().mu2(), 0.2)
+    self.assertEqual(surface2.friction().ode().slip1(), 3)
+    self.assertEqual(surface2.friction().ode().slip2(), 4)
+    self.assertEqual(surface2.friction().ode().fdir1(),
+                     Vector3d(1, 2, 3))
 
     contact.set_collide_bitmask(0x21)
     surface1.set_contact(contact)
     self.assertEqual(surface1.contact().collide_bitmask(), 0x21)
     self.assertEqual(surface2.contact().collide_bitmask(), 0x21)
 
+    ode.set_mu(1.1)
+    ode.set_mu2(1.2)
+    ode.set_slip1(3.1)
+    ode.set_slip2(4.1)
+    ode.set_fdir1(Vector3d(1.1, 2.1, 3.1))
+    friction.set_ode(ode)
+    surface1.set_friction(friction)
+    self.assertEqual(surface1.friction().ode().mu(), 1.1)
+    self.assertEqual(surface1.friction().ode().mu2(), 1.2)
+    self.assertEqual(surface1.friction().ode().slip1(), 3.1)
+    self.assertEqual(surface1.friction().ode().slip2(), 4.1)
+    self.assertEqual(surface1.friction().ode().fdir1(),
+                     Vector3d(1.1, 2.1, 3.1))
+    self.assertEqual(surface2.friction().ode().mu(), 1.1)
+    self.assertEqual(surface2.friction().ode().mu2(), 1.2)
+    self.assertEqual(surface2.friction().ode().slip1(), 3.1)
+    self.assertEqual(surface2.friction().ode().slip2(), 4.1)
+    self.assertEqual(surface2.friction().ode().fdir1(),
+                     Vector3d(1.1, 2.1, 3.1))
+
 
   def test_copy_construction(self):
     surface1 = Surface()
     contact = Contact()
+    ode = ODE()
+    ode.set_mu(0.1)
+    ode.set_mu2(0.2)
+    ode.set_slip1(3)
+    ode.set_slip2(4)
+    ode.set_fdir1(Vector3d(1, 2, 3))
+    friction = Friction()
+    friction.set_ode(ode)
     contact.set_collide_bitmask(0x12)
     surface1.set_contact(contact)
+    surface1.set_friction(friction)
 
     surface2 = Surface(surface1)
     self.assertEqual(surface2.contact().collide_bitmask(), 0x12)
+    self.assertEqual(surface2.friction().ode().mu(), 0.1)
+    self.assertEqual(surface2.friction().ode().mu2(), 0.2)
+    self.assertEqual(surface2.friction().ode().slip1(), 3)
+    self.assertEqual(surface2.friction().ode().slip2(), 4)
+    self.assertEqual(surface2.friction().ode().fdir1(),
+                     Vector3d(1, 2, 3))
 
     contact.set_collide_bitmask(0x21)
     surface1.set_contact(contact)
     self.assertEqual(surface1.contact().collide_bitmask(), 0x21)
     self.assertEqual(surface2.contact().collide_bitmask(), 0x12)
+
+    ode.set_mu(1.1)
+    ode.set_mu2(1.2)
+    ode.set_slip1(3.1)
+    ode.set_slip2(4.1)
+    ode.set_fdir1(Vector3d(1.1, 2.1, 3.1))
+    friction.set_ode(ode)
+    surface1.set_friction(friction)
+    self.assertEqual(surface1.friction().ode().mu(), 1.1)
+    self.assertEqual(surface1.friction().ode().mu2(), 1.2)
+    self.assertEqual(surface1.friction().ode().slip1(), 3.1)
+    self.assertEqual(surface1.friction().ode().slip2(), 4.1)
+    self.assertEqual(surface1.friction().ode().fdir1(),
+                     Vector3d(1.1, 2.1, 3.1))
+    self.assertEqual(surface2.friction().ode().mu(), 0.1)
+    self.assertEqual(surface2.friction().ode().mu2(), 0.2)
+    self.assertEqual(surface2.friction().ode().slip1(), 3)
+    self.assertEqual(surface2.friction().ode().slip2(), 4)
+    self.assertEqual(surface2.friction().ode().fdir1(),
+                     Vector3d(1, 2, 3))
 
 
   def test_deepcopy(self):
     surface1 = Surface()
     contact = Contact()
+    ode = ODE()
+    ode.set_mu(0.1)
+    ode.set_mu2(0.2)
+    ode.set_slip1(3)
+    ode.set_slip2(4)
+    ode.set_fdir1(Vector3d(1, 2, 3))
+    friction = Friction()
+    friction.set_ode(ode)
     contact.set_collide_bitmask(0x12)
     surface1.set_contact(contact)
+    surface1.set_friction(friction)
 
     surface2 = copy.deepcopy(surface1)
     self.assertEqual(surface2.contact().collide_bitmask(), 0x12)
+    self.assertEqual(surface2.friction().ode().mu(), 0.1)
+    self.assertEqual(surface2.friction().ode().mu2(), 0.2)
+    self.assertEqual(surface2.friction().ode().slip1(), 3)
+    self.assertEqual(surface2.friction().ode().slip2(), 4)
+    self.assertEqual(surface2.friction().ode().fdir1(),
+                     Vector3d(1, 2, 3))
 
     contact.set_collide_bitmask(0x21)
     surface1.set_contact(contact)
     self.assertEqual(surface1.contact().collide_bitmask(), 0x21)
     self.assertEqual(surface2.contact().collide_bitmask(), 0x12)
+
+    ode.set_mu(1.1)
+    ode.set_mu2(1.2)
+    ode.set_slip1(3.1)
+    ode.set_slip2(4.1)
+    ode.set_fdir1(Vector3d(1.1, 2.1, 3.1))
+    friction.set_ode(ode)
+    surface1.set_friction(friction)
+    self.assertEqual(surface1.friction().ode().mu(), 1.1)
+    self.assertEqual(surface1.friction().ode().mu2(), 1.2)
+    self.assertEqual(surface1.friction().ode().slip1(), 3.1)
+    self.assertEqual(surface1.friction().ode().slip2(), 4.1)
+    self.assertEqual(surface1.friction().ode().fdir1(),
+                     Vector3d(1.1, 2.1, 3.1))
+    self.assertEqual(surface2.friction().ode().mu(), 0.1)
+    self.assertEqual(surface2.friction().ode().mu2(), 0.2)
+    self.assertEqual(surface2.friction().ode().slip1(), 3)
+    self.assertEqual(surface2.friction().ode().slip2(), 4)
+    self.assertEqual(surface2.friction().ode().fdir1(),
+                     Vector3d(1, 2, 3))
 
 
   def test_default_contact_construction(self):
@@ -80,6 +186,15 @@ class SurfaceTEST(unittest.TestCase):
 
     contact2 = Contact(contact1)
     self.assertEqual(contact2.collide_bitmask(), 0x12)
+
+  def test_default_ode_construction(self):
+    ode = ODE()
+    self.assertEqual(ode.mu(), 1.0)
+    self.assertEqual(ode.mu2(), 1.0)
+    self.assertEqual(ode.slip1(), 0)
+    self.assertEqual(ode.slip2(), 0)
+    self.assertEqual(ode.fdir1(),
+                     Vector3d(0, 0, 0))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/sdformat/issues/931

## Summary

Add python interface for `sdf::Friction` and `sdf::ODE` classes from `sdf/Surface.hh`.

## Test it

~~~
from sdformat import Friction, ODE

friction = Friction()
friction.set_ode(ODE())
~~~

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
