### PR TITLE
Add skybox URI

### DIFF
--- a/include/sdf/Sky.hh
+++ b/include/sdf/Sky.hh
@@ -99,6 +99,14 @@ namespace sdf
     /// \param[in] _ambient cloud ambient color
     public: void SetCloudAmbient(const ignition::math::Color &_ambient);
 
+    /// \brief Get the skybox texture URI.
+    /// \return The URI of the skybox texture.
+    public: std::string Uri() const;
+
+    /// \brief Set the skybox texture URI.
+    /// \param[in] _uri The URI of the skybox texture.
+    public: void SetUri(const std::string &_uri);
+
     /// \brief Load the sky based on a element pointer. This is *not* the
     /// usual entry point. Typical usage of the SDF DOM is through the Root
     /// object.

--- a/src/Sky.cc
+++ b/src/Sky.cc
@@ -186,13 +186,6 @@ Errors Sky::Load(ElementPtr _sdf)
     return errors;
   }
 
-  // Optional uri element. If not provided, assume there is some default in
-  // downstream implementation.
-  if (_sdf->HasElement("uri"))
-  {
-    this->dataPtr->uri = _sdf->Get<std::string>("uri", "").first;
-  }
-
   this->dataPtr->time = _sdf->Get<double>("time", this->dataPtr->time).first;
   this->dataPtr->sunrise =
       _sdf->Get<double>("sunrise", this->dataPtr->sunrise).first;
@@ -216,6 +209,13 @@ Errors Sky::Load(ElementPtr _sdf)
         this->dataPtr->cloudAmbient).first;
   }
 
+  // Optional uri element. If not provided, assume there is some default in
+  // downstream implementation.
+  if (_sdf->HasElement("uri"))
+  {
+    this->dataPtr->uri = _sdf->Get<std::string>("uri", "__default__").first;
+  }
+
   return errors;
 }
 
@@ -232,9 +232,6 @@ sdf::ElementPtr Sky::ToElement() const
   sdf::initFile("scene.sdf", sceneElem);
   sdf::ElementPtr elem = sceneElem->GetElement("sky");
 
-  sdf::ElementPtr uriElem = elem->GetElement("uri");
-  uriElem->Set(this->Uri());
-
   elem->GetElement("time")->Set(this->Time());
   elem->GetElement("sunrise")->Set(this->Sunrise());
   elem->GetElement("sunset")->Set(this->Sunset());
@@ -245,6 +242,9 @@ sdf::ElementPtr Sky::ToElement() const
   cloudElem->GetElement("humidity")->Set(this->CloudHumidity());
   cloudElem->GetElement("mean_size")->Set(this->CloudMeanSize());
   cloudElem->GetElement("ambient")->Set(this->CloudAmbient());
+
+  sdf::ElementPtr uriElem = elem->GetElement("uri");
+  uriElem->Set(this->Uri());
 
   return elem;
 }

--- a/src/Sky.cc
+++ b/src/Sky.cc
@@ -48,6 +48,9 @@ class sdf::Sky::Implementation
   public: ignition::math::Color cloudAmbient =
       ignition::math::Color(0.8f, 0.8f, 0.8f);
 
+  /// \brief Skybox texture URI
+  public: std::string uri = "";
+
   /// \brief The SDF element pointer used during load.
   public: sdf::ElementPtr sdf;
 };
@@ -154,6 +157,18 @@ void Sky::SetCloudAmbient(const ignition::math::Color &_ambient)
   this->dataPtr->cloudAmbient = _ambient;
 }
 
+//////////////////////////////////////////////////
+std::string Sky::Uri() const
+{
+  return this->dataPtr->uri;
+}
+
+//////////////////////////////////////////////////
+void Sky::SetUri(const std::string &_uri)
+{
+  this->dataPtr->uri = _uri;
+}
+
 /////////////////////////////////////////////////
 Errors Sky::Load(ElementPtr _sdf)
 {
@@ -169,6 +184,13 @@ Errors Sky::Load(ElementPtr _sdf)
         "Attempting to load a Sky, but the provided SDF element is not a "
         "<sky>."});
     return errors;
+  }
+
+  // Optional uri element. If not provided, assume there is some default in
+  // downstream implementation.
+  if (_sdf->HasElement("uri"))
+  {
+    this->dataPtr->uri = _sdf->Get<std::string>("uri", "").first;
   }
 
   this->dataPtr->time = _sdf->Get<double>("time", this->dataPtr->time).first;
@@ -209,6 +231,9 @@ sdf::ElementPtr Sky::ToElement() const
   sdf::ElementPtr sceneElem(new sdf::Element);
   sdf::initFile("scene.sdf", sceneElem);
   sdf::ElementPtr elem = sceneElem->GetElement("sky");
+
+  sdf::ElementPtr uriElem = elem->GetElement("uri");
+  uriElem->Set(this->Uri());
 
   elem->GetElement("time")->Set(this->Time());
   elem->GetElement("sunrise")->Set(this->Sunrise());

--- a/src/Sky_TEST.cc
+++ b/src/Sky_TEST.cc
@@ -31,6 +31,7 @@ TEST(DOMSky, Construction)
   EXPECT_DOUBLE_EQ(0.5, sky.CloudMeanSize());
   EXPECT_EQ(ignition::math::Color(0.8f, 0.8f, 0.8f),
       sky.CloudAmbient());
+  EXPECT_EQ("", sky.Uri());
 }
 
 /////////////////////////////////////////////////
@@ -48,6 +49,7 @@ TEST(DOMSky, CopyConstruction)
   sky.SetCloudHumidity(0.9);
   sky.SetCloudMeanSize(0.123);
   sky.SetCloudAmbient(ignition::math::Color::Blue);
+  sky.SetUri("dummyUri");
 
   sdf::Sky sky2(sky);
   EXPECT_DOUBLE_EQ(1.0, sky2.Time());
@@ -58,6 +60,7 @@ TEST(DOMSky, CopyConstruction)
   EXPECT_DOUBLE_EQ(0.9, sky2.CloudHumidity());
   EXPECT_DOUBLE_EQ(0.123, sky2.CloudMeanSize());
   EXPECT_EQ(ignition::math::Color::Blue, sky2.CloudAmbient());
+  EXPECT_EQ("dummyUri", sky2.Uri());
 
   EXPECT_NE(nullptr, sky2.Element());
   EXPECT_EQ(sky.Element(), sky2.Element());
@@ -75,6 +78,7 @@ TEST(DOMSky, MoveConstruction)
   sky.SetCloudHumidity(0.9);
   sky.SetCloudMeanSize(0.123);
   sky.SetCloudAmbient(ignition::math::Color::Blue);
+  sky.SetUri("dummyUri");
 
   sdf::Sky sky2(std::move(sky));
   EXPECT_DOUBLE_EQ(1.0, sky2.Time());
@@ -85,6 +89,7 @@ TEST(DOMSky, MoveConstruction)
   EXPECT_DOUBLE_EQ(0.9, sky2.CloudHumidity());
   EXPECT_DOUBLE_EQ(0.123, sky2.CloudMeanSize());
   EXPECT_EQ(ignition::math::Color::Blue, sky2.CloudAmbient());
+  EXPECT_EQ("dummyUri", sky2.Uri());
 }
 
 /////////////////////////////////////////////////
@@ -99,6 +104,7 @@ TEST(DOMSky, MoveAssignmentOperator)
   sky.SetCloudHumidity(0.9);
   sky.SetCloudMeanSize(0.123);
   sky.SetCloudAmbient(ignition::math::Color::Blue);
+  sky.SetUri("dummyUri");
 
   sdf::Sky sky2;
   sky2 = std::move(sky);
@@ -110,6 +116,7 @@ TEST(DOMSky, MoveAssignmentOperator)
   EXPECT_DOUBLE_EQ(0.9, sky2.CloudHumidity());
   EXPECT_DOUBLE_EQ(0.123, sky2.CloudMeanSize());
   EXPECT_EQ(ignition::math::Color::Blue, sky2.CloudAmbient());
+  EXPECT_EQ("dummyUri", sky2.Uri());
 }
 
 /////////////////////////////////////////////////
@@ -124,6 +131,7 @@ TEST(DOMSky, AssignmentOperator)
   sky.SetCloudHumidity(0.9);
   sky.SetCloudMeanSize(0.123);
   sky.SetCloudAmbient(ignition::math::Color::Blue);
+  sky.SetUri("dummyUri");
 
   sdf::Sky sky2;
   sky2 = sky;
@@ -135,6 +143,7 @@ TEST(DOMSky, AssignmentOperator)
   EXPECT_DOUBLE_EQ(0.9, sky2.CloudHumidity());
   EXPECT_DOUBLE_EQ(0.123, sky2.CloudMeanSize());
   EXPECT_EQ(ignition::math::Color::Blue, sky2.CloudAmbient());
+  EXPECT_EQ("dummyUri", sky2.Uri());
 }
 
 /////////////////////////////////////////////////
@@ -185,6 +194,9 @@ TEST(DOMSky, Set)
   sky.SetCloudAmbient(ignition::math::Color(0.1f, 0.2f, 0.3f));
   EXPECT_EQ(ignition::math::Color(0.1f, 0.2f, 0.3f),
       sky.CloudAmbient());
+
+  sky.SetUri("dummyUri");
+  EXPECT_EQ("dummyUri", sky.Uri());
 }
 
 /////////////////////////////////////////////////
@@ -200,6 +212,7 @@ TEST(DOMSky, ToElement)
   sky.SetCloudHumidity(0.2);
   sky.SetCloudMeanSize(0.5);
   sky.SetCloudAmbient(ignition::math::Color(0.1f, 0.2f, 0.3f, 1.0f));
+  sky.SetUri("dummyUri");
 
   sdf::ElementPtr elem = sky.ToElement();
   ASSERT_NE(nullptr, elem);
@@ -215,4 +228,5 @@ TEST(DOMSky, ToElement)
   EXPECT_DOUBLE_EQ(sky.CloudHumidity(), sky2.CloudHumidity());
   EXPECT_DOUBLE_EQ(sky.CloudMeanSize(), sky2.CloudMeanSize());
   EXPECT_EQ(sky.CloudAmbient(), sky2.CloudAmbient());
+  EXPECT_EQ(sky.Uri(), sky2.Uri());
 }

--- a/test/integration/scene_dom.cc
+++ b/test/integration/scene_dom.cc
@@ -69,4 +69,5 @@ TEST(DOMScene, LoadScene)
   EXPECT_DOUBLE_EQ(0.2, sky->CloudMeanSize());
   EXPECT_DOUBLE_EQ(0.9, sky->CloudHumidity());
   EXPECT_EQ(ignition::math::Color(0.1f, 0.2f, 0.3f), sky->CloudAmbient());
+  EXPECT_EQ("dummyUri", sky->Uri());
 }

--- a/test/sdf/scene_with_sky.sdf
+++ b/test/sdf/scene_with_sky.sdf
@@ -19,6 +19,7 @@
           <humidity>0.9</humidity>
           <ambient>0.1 0.2 0.3</ambient>
         </clouds>
+        <uri>dummyUri</uri>
       </sky>
     </scene>
 


### PR DESCRIPTION
# 🎉 New feature

Add `<uri>` tag to `<sky>` tag to allow specifying skybox texture via SDF.

## Summary

Opening for visibility.
Draft status: `ToElement` test is failing... not sure why, think I'm missing something basic.
```
Error [Element.cc:1018] Missing element description for [uri]
```
Will remove draft status after fixing test.

## Test it

CI passes on tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.=