### PR TITLE
Don't include the gz/math.hh header from library code

### DIFF
--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <gz/math/Inertial.hh>
 #include <gz/math/Pose3.hh>
 #include <gz/utils/ImplPtr.hh>
 #include "sdf/Element.hh"

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -33,7 +33,12 @@
 #include <variant>
 #include <vector>
 
-#include <gz/math.hh>
+#include <gz/math/Angle.hh>
+#include <gz/math/Color.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector2.hh>
+#include <gz/math/Vector3.hh>
 
 #include "sdf/Console.hh"
 #include "sdf/PrintConfig.hh"

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -25,7 +25,10 @@
 #include <utility>
 #include <vector>
 
-#include <gz/math.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector3.hh>
 
 #include <urdf_model/model.h>
 #include <urdf_model/link.h>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Don't include the gz/math.hh header from library code. Using overly-broad include statements leads to slower builds and bloated object code. This commit swaps it out the `gz/math.hh` "everything" header for more targets files, instead.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests (n/a)
- [x] Updated documentation (n/a)
- [x] Updated migration guide (n/a)
- [x] Consider updating Python bindings (n/a)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

