### PR TITLE
Backport: Don't include the gz/math.hh header from library code (#1043)

### DIFF
--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <ignition/math/Inertial.hh>
 #include <ignition/math/Pose3.hh>
 #include "sdf/Element.hh"
 #include "sdf/SemanticPose.hh"

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -30,7 +30,12 @@
 #include <variant>
 #include <vector>
 
-#include <ignition/math.hh>
+#include <ignition/math/Angle.hh>
+#include <ignition/math/Color.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
 
 #include "sdf/Console.hh"
 #include "sdf/sdf_config.h"

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -25,7 +25,10 @@
 #include <utility>
 #include <vector>
 
-#include <ignition/math.hh>
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
 
 #include <urdf_model/model.h>
 #include <urdf_model/link.h>


### PR DESCRIPTION
Backport of #1043 with additional changes for the `ignition` -> `gz` rename.

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
