### PR TITLE
Surface::ToElement: add //friction/ode/mu

### DIFF
--- a/src/Collision_TEST.cc
+++ b/src/Collision_TEST.cc
@@ -184,6 +184,11 @@ TEST(DOMCollision, ToElement)
   sdf::Contact contact;
   contact.SetCollideBitmask(123u);
   surface.SetContact(contact);
+  sdf::Friction friction;
+  sdf::ODE ode;
+  ode.SetMu(1.23);
+  friction.SetODE(ode);
+  surface.SetFriction(friction);
   collision.SetSurface(surface);
 
   sdf::ElementPtr elem = collision.ToElement();
@@ -199,4 +204,7 @@ TEST(DOMCollision, ToElement)
   ASSERT_NE(nullptr, surface2);
   ASSERT_NE(nullptr, surface2->Contact());
   EXPECT_EQ(123u, surface2->Contact()->CollideBitmask());
+  ASSERT_NE(nullptr, surface2->Friction());
+  ASSERT_NE(nullptr, surface2->Friction()->ODE());
+  EXPECT_DOUBLE_EQ(1.23, surface2->Friction()->ODE()->Mu());
 }

--- a/src/Surface.cc
+++ b/src/Surface.cc
@@ -399,5 +399,9 @@ sdf::ElementPtr Surface::ToElement() const
   contactElem->GetElement("collide_bitmask")->Set(
       this->dataPtr->contact.CollideBitmask());
 
+  sdf::ElementPtr frictionElem = elem->GetElement("friction");
+  frictionElem->GetElement("ode")->GetElement("mu")->Set(
+      this->dataPtr->friction.ODE()->Mu());
+
   return elem;
 }


### PR DESCRIPTION
# 🎉 New feature

Follow-up to #1036

## Summary

The `mjcf_to_sdformat` converter in [gz-mujoco](https://github.com/gazebosim/gz-mujoco) constructs DOME objects programmatically and then uses `Root::ToElement` serialize to an XML file. Currently the `Surface` class adds elements for `//contact/collide_bitmask` in `Surface::ToElement`, and this pull request adds `//friction/ode/mu` as a minimal approach to supporting friction parameters.

## Test it

Run `UNIT_Collision_TEST`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
