### PR TITLE
Joint: rename parent/child *LinkName APIs

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -25,6 +25,20 @@ but with improved human-readability..
 - **sdf/Types.hh**: The `Inertia` class has been deprecated. Please use the
 ￼   `Inertial` class in the `gz-math` library.
 
+- **sdf/Joint.hh**:
+   + ***Deprecation:*** const std::string &ChildLinkName() const
+   + ***Replacement:*** const std::string &ChildName() const
+   + ***Deprecation:*** const std::string &ParentLinkName() const
+   + ***Replacement:*** const std::string &ParentName() const
+   + ***Deprecation:*** void SetChildLinkName(const std::string &)
+   + ***Replacement:*** void SetChildName(const std::string &)
+   + ***Deprecation:*** void SetParentLinkName(const std::string &)
+   + ***Replacement:*** void SetParentName(const std::string &)
+
+- **sdf/parser.hh**:
+   + ***Deprecation:*** bool checkJointParentChildLinkNames(const sdf::Root \*)
+   + ***Replacement:*** bool checkJointParentChildNames(const sdf::Root \*)
+
 ## libsdformat 11.x to 12.0
 
 An error is now emitted instead of a warning for a file containing more than

--- a/include/sdf/Joint.hh
+++ b/include/sdf/Joint.hh
@@ -113,21 +113,41 @@ namespace sdf
     /// \param[in] _jointType The type of joint.
     public: void SetType(const JointType _jointType);
 
+    /// \brief Get the name of this joint's parent frame.
+    /// \return The name of the parent frame.
+    public: const std::string &ParentName() const;
+
+    /// \brief Set the name of the parent frame.
+    /// \param[in] _name Name of the parent frame.
+    public: void SetParentName(const std::string &_name);
+
+    /// \brief Get the name of this joint's child frame.
+    /// \return The name of the child frame.
+    public: const std::string &ChildName() const;
+
+    /// \brief Set the name of the child frame.
+    /// \param[in] _name Name of the child frame.
+    public: void SetChildName(const std::string &_name);
+
     /// \brief Get the name of this joint's parent link.
     /// \return The name of the parent link.
-    public: const std::string &ParentLinkName() const;
+    /// \deprecated Use ParentName.
+    public: GZ_DEPRECATED(13) const std::string &ParentLinkName() const;
 
     /// \brief Set the name of the parent link.
     /// \param[in] _name Name of the parent link.
-    public: void SetParentLinkName(const std::string &_name);
+    /// \deprecated Use SetParentName.
+    public: GZ_DEPRECATED(13) void SetParentLinkName(const std::string &_name);
 
     /// \brief Get the name of this joint's child link.
     /// \return The name of the child link.
-    public: const std::string &ChildLinkName() const;
+    /// \deprecated Use ChildName.
+    public: GZ_DEPRECATED(13) const std::string &ChildLinkName() const;
 
     /// \brief Set the name of the child link.
     /// \param[in] _name Name of the child link.
-    public: void SetChildLinkName(const std::string &_name);
+    /// \deprecated Use SetChildName.
+    public: GZ_DEPRECATED(13) void SetChildLinkName(const std::string &_name);
 
     /// \brief Resolve the name of the child link from the
     /// FrameAttachedToGraph.

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -393,6 +393,17 @@ namespace sdf
   /// \return True if all models have joints with valid parent and child
   /// link names.
   SDFORMAT_VISIBLE
+  bool checkJointParentChildNames(const sdf::Root *_root);
+
+  /// \brief Check that all joints in contained models specify parent
+  /// and child link names that match the names of sibling links.
+  /// This checks recursively and should check the files exhaustively
+  /// rather than terminating early when the first error is found.
+  /// \param[in] _root SDF Root object to check recursively.
+  /// \return True if all models have joints with valid parent and child
+  /// link names.
+  /// \deprecated Use checkJointParentChildNames.
+  SDFORMAT_VISIBLE GZ_DEPRECATED(13)
   bool checkJointParentChildLinkNames(const sdf::Root *_root);
 
   /// \brief Check that all joints in contained models specify parent

--- a/python/src/sdf/pyJoint.cc
+++ b/python/src/sdf/pyJoint.cc
@@ -19,6 +19,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <gz/utils/SuppressWarning.hh>
+
 #include "sdf/Joint.hh"
 #include "sdf/Sensor.hh"
 
@@ -45,6 +47,15 @@ void defineJoint(pybind11::object module)
          "Get the joint type")
     .def("set_type", &sdf::Joint::SetType,
          "Set the joint type.")
+    .def("parent_name", &sdf::Joint::ParentName,
+         "Get the name of this joint's parent frame.")
+    .def("set_parent_name", &sdf::Joint::SetParentName,
+         "Set the name of the parent frame.")
+    .def("child_name", &sdf::Joint::ChildName,
+         "Get the name of this joint's child frame.")
+    .def("set_child_name", &sdf::Joint::SetChildName,
+         "Set the name of the child frame.")
+    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
     .def("parent_link_name", &sdf::Joint::ParentLinkName,
          "Get the name of this joint's parent link.")
     .def("set_parent_link_name", &sdf::Joint::SetParentLinkName,
@@ -53,6 +64,7 @@ void defineJoint(pybind11::object module)
          "Get the name of this joint's child link.")
     .def("set_child_link_name", &sdf::Joint::SetChildLinkName,
          "Set the name of the child link")
+    GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
     .def("resolve_child_link",
          [](const sdf::Joint &self)
          {

--- a/python/src/sdf/pyJoint.cc
+++ b/python/src/sdf/pyJoint.cc
@@ -36,6 +36,7 @@ namespace python
 void defineJoint(pybind11::object module)
 {
   pybind11::class_<sdf::Joint> jointModule(module, "Joint");
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   jointModule
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Joint>())
@@ -55,7 +56,6 @@ void defineJoint(pybind11::object module)
          "Get the name of this joint's child frame.")
     .def("set_child_name", &sdf::Joint::SetChildName,
          "Set the name of the child frame.")
-    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
     .def("parent_link_name", &sdf::Joint::ParentLinkName,
          "Get the name of this joint's parent link.")
     .def("set_parent_link_name", &sdf::Joint::SetParentLinkName,
@@ -64,7 +64,6 @@ void defineJoint(pybind11::object module)
          "Get the name of this joint's child link.")
     .def("set_child_link_name", &sdf::Joint::SetChildLinkName,
          "Set the name of the child link")
-    GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
     .def("resolve_child_link",
          [](const sdf::Joint &self)
          {
@@ -148,6 +147,7 @@ void defineJoint(pybind11::object module)
       .value("REVOLUTE2", sdf::JointType::REVOLUTE2)
       .value("SCREW", sdf::JointType::SCREW)
       .value("UNIVERSAL", sdf::JointType::UNIVERSAL);
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 }
 }  // namespace python
 }  // namespace SDF_VERSION_NAMESPACE

--- a/python/src/sdf/pyJoint.cc
+++ b/python/src/sdf/pyJoint.cc
@@ -19,8 +19,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <gz/utils/SuppressWarning.hh>
-
 #include "sdf/Joint.hh"
 #include "sdf/Sensor.hh"
 
@@ -36,7 +34,6 @@ namespace python
 void defineJoint(pybind11::object module)
 {
   pybind11::class_<sdf::Joint> jointModule(module, "Joint");
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   jointModule
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Joint>())
@@ -56,14 +53,6 @@ void defineJoint(pybind11::object module)
          "Get the name of this joint's child frame.")
     .def("set_child_name", &sdf::Joint::SetChildName,
          "Set the name of the child frame.")
-    .def("parent_link_name", &sdf::Joint::ParentLinkName,
-         "Get the name of this joint's parent link.")
-    .def("set_parent_link_name", &sdf::Joint::SetParentLinkName,
-         "Set the name of the parent link.")
-    .def("child_link_name", &sdf::Joint::ChildLinkName,
-         "Get the name of this joint's child link.")
-    .def("set_child_link_name", &sdf::Joint::SetChildLinkName,
-         "Set the name of the child link")
     .def("resolve_child_link",
          [](const sdf::Joint &self)
          {
@@ -147,7 +136,6 @@ void defineJoint(pybind11::object module)
       .value("REVOLUTE2", sdf::JointType::REVOLUTE2)
       .value("SCREW", sdf::JointType::SCREW)
       .value("UNIVERSAL", sdf::JointType::UNIVERSAL);
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 }
 }  // namespace python
 }  // namespace SDF_VERSION_NAMESPACE

--- a/python/test/pyJoint_TEST.py
+++ b/python/test/pyJoint_TEST.py
@@ -26,8 +26,8 @@ class JointTEST(unittest.TestCase):
         joint = Joint()
         self.assertFalse(joint.name())
         self.assertEqual(sdf.JointType.INVALID, joint.type())
-        self.assertFalse(joint.parent_link_name())
-        self.assertFalse(joint.child_link_name())
+        self.assertFalse(joint.parent_name())
+        self.assertFalse(joint.child_name())
         self.assertEqual(Pose3d.ZERO, joint.raw_pose())
         self.assertFalse(joint.pose_relative_to())
 
@@ -55,11 +55,11 @@ class JointTEST(unittest.TestCase):
         joint.set_name("test_joint")
         self.assertEqual("test_joint", joint.name())
 
-        joint.set_parent_link_name("parent")
-        self.assertEqual("parent", joint.parent_link_name())
+        joint.set_parent_name("parent")
+        self.assertEqual("parent", joint.parent_name())
 
-        joint.set_child_link_name("child")
-        self.assertEqual("child", joint.child_link_name())
+        joint.set_child_name("child")
+        self.assertEqual("child", joint.child_name())
 
         errors, resolveChildLink = joint.resolve_child_link()
         self.assertEqual(1, len(errors))

--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -383,7 +383,7 @@ struct JointWrapper : public WrapperBase
       : WrapperBase{_joint.Name(), "Joint", FrameType::JOINT},
         rawPose(_joint.RawPose()),
         rawRelativeTo(_joint.PoseRelativeTo()),
-        childName(_joint.ChildLinkName()),
+        childName(_joint.ChildName()),
         relativeTo(rawRelativeTo.empty() ? childName : rawRelativeTo)
   {
   }

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -27,8 +27,14 @@ TEST(DOMJoint, Construction)
   sdf::Joint joint;
   EXPECT_TRUE(joint.Name().empty());
   EXPECT_EQ(sdf::JointType::INVALID, joint.Type());
+
+  EXPECT_TRUE(joint.ParentName().empty());
+  EXPECT_TRUE(joint.ChildName().empty());
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   EXPECT_TRUE(joint.ParentLinkName().empty());
   EXPECT_TRUE(joint.ChildLinkName().empty());
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
   EXPECT_EQ(gz::math::Pose3d::Zero, joint.RawPose());
   EXPECT_TRUE(joint.PoseRelativeTo().empty());
   EXPECT_EQ(nullptr, joint.Element());
@@ -59,11 +65,23 @@ TEST(DOMJoint, Construction)
   joint.SetName("test_joint");
   EXPECT_EQ("test_joint", joint.Name());
 
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   joint.SetParentLinkName("parent");
   EXPECT_EQ("parent", joint.ParentLinkName());
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+  EXPECT_EQ("parent", joint.ParentName());
 
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   joint.SetChildLinkName("child");
   EXPECT_EQ("child", joint.ChildLinkName());
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+  EXPECT_EQ("child", joint.ChildName());
+
+  joint.SetParentName("parent2");
+  EXPECT_EQ("parent2", joint.ParentName());
+
+  joint.SetChildName("child2");
+  EXPECT_EQ("child2", joint.ChildName());
 
   std::string body;
   EXPECT_FALSE(joint.ResolveChildLink(body).empty());
@@ -260,8 +278,8 @@ TEST(DOMJoint, ToElement)
   joint.SetRawPose({-1, -2, -3, 0, GZ_PI, 0});
   joint.SetPoseRelativeTo("link");
   joint.SetName("test_joint");
-  joint.SetParentLinkName("parent");
-  joint.SetChildLinkName("child");
+  joint.SetParentName("parent");
+  joint.SetChildName("child");
   joint.SetType(sdf::JointType::BALL);
   sdf::JointAxis axis;
   EXPECT_TRUE(axis.SetXyz(gz::math::Vector3d(1, 0, 0)).empty());
@@ -295,8 +313,8 @@ TEST(DOMJoint, ToElement)
             joint2.RawPose());
   EXPECT_EQ("link", joint2.PoseRelativeTo());
   EXPECT_EQ("test_joint", joint2.Name());
-  EXPECT_EQ("parent", joint2.ParentLinkName());
-  EXPECT_EQ("child", joint2.ChildLinkName());
+  EXPECT_EQ("parent", joint2.ParentName());
+  EXPECT_EQ("child", joint2.ChildName());
   EXPECT_EQ(sdf::JointType::BALL, joint2.Type());
   ASSERT_TRUE(nullptr != joint2.Axis(0));
   ASSERT_TRUE(nullptr != joint2.Axis(1));
@@ -308,12 +326,12 @@ TEST(DOMJoint, ToElement)
     EXPECT_NE(nullptr, joint.SensorByIndex(i));
 
   // make changes to DOM and verify ToElement produces updated values
-  joint2.SetParentLinkName("new_parent");
+  joint2.SetParentName("new_parent");
   sdf::ElementPtr joint2Elem = joint2.ToElement();
   EXPECT_NE(nullptr, joint2Elem);
   sdf::Joint joint3;
   joint3.Load(joint2Elem);
-  EXPECT_EQ("new_parent", joint3.ParentLinkName());
+  EXPECT_EQ("new_parent", joint3.ParentName());
 }
 
 /////////////////////////////////////////////////

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -58,7 +58,7 @@ extern "C" SDFORMAT_VISIBLE int cmdCheck(const char *_path)
     result = -1;
   }
 
-  if (!sdf::checkJointParentChildLinkNames(&root))
+  if (!sdf::checkJointParentChildNames(&root))
   {
     result = -1;
   }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -2483,6 +2483,12 @@ bool checkPoseRelativeToGraph(const sdf::Root *_root)
 //////////////////////////////////////////////////
 bool checkJointParentChildLinkNames(const sdf::Root *_root)
 {
+  return checkJointParentChildNames(_root);
+}
+
+//////////////////////////////////////////////////
+bool checkJointParentChildNames(const sdf::Root *_root)
+{
   Errors errors;
   checkJointParentChildNames(_root, errors);
   if (!errors.empty())
@@ -2505,7 +2511,7 @@ void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
     {
       auto joint = _model->JointByIndex(j);
 
-      const std::string &parentName = joint->ParentLinkName();
+      const std::string &parentName = joint->ParentName();
       const std::string parentLocalName = sdf::SplitName(parentName).second;
 
       if (parentName != "world" && parentLocalName != "__model__" &&
@@ -2517,7 +2523,7 @@ void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
           "] not found in model with name[" + _model->Name() + "]."});
       }
 
-      const std::string &childName = joint->ChildLinkName();
+      const std::string &childName = joint->ChildName();
       const std::string childLocalName = sdf::SplitName(childName).second;
       if (childName == "world")
       {

--- a/test/integration/includes.cc
+++ b/test/integration/includes.cc
@@ -526,14 +526,14 @@ TEST(IncludesTest, MergeInclude)
     // left_wheel_joint's axis is expressed in __model__.
     auto joint = model->JointByName("test_model_parent");
     ASSERT_NE(nullptr, joint);
-    EXPECT_EQ(prefixedFrameName, joint->ParentLinkName());
+    EXPECT_EQ(prefixedFrameName, joint->ParentName());
   }
   // Check joint child set as __model__
   {
     // left_wheel_joint's axis is expressed in __model__.
     auto joint = model->JointByName("test_model_child");
     ASSERT_NE(nullptr, joint);
-    EXPECT_EQ(prefixedFrameName, joint->ChildLinkName());
+    EXPECT_EQ(prefixedFrameName, joint->ChildName());
   }
 
   // Verify that plugins get merged

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -89,10 +89,10 @@ TEST(DOMJoint, DoublePendulum)
   ASSERT_NE(nullptr, lowerJoint);
 
   // Check the parent and child link values
-  EXPECT_EQ("base", upperJoint->ParentLinkName());
-  EXPECT_EQ("upper_link", upperJoint->ChildLinkName());
-  EXPECT_EQ("upper_link", lowerJoint->ParentLinkName());
-  EXPECT_EQ("lower_link", lowerJoint->ChildLinkName());
+  EXPECT_EQ("base", upperJoint->ParentName());
+  EXPECT_EQ("upper_link", upperJoint->ChildName());
+  EXPECT_EQ("upper_link", lowerJoint->ParentName());
+  EXPECT_EQ("lower_link", lowerJoint->ChildName());
 
   // Check that the pose relative_to values are empty
   EXPECT_TRUE(upperJoint->PoseRelativeTo().empty());
@@ -190,8 +190,8 @@ TEST(DOMJoint, LoadJointParentWorld)
   EXPECT_NE(nullptr, model->JointByIndex(0));
   EXPECT_EQ(nullptr, model->JointByIndex(1));
   ASSERT_TRUE(model->JointNameExists("joint"));
-  EXPECT_EQ("link", model->JointByName("joint")->ChildLinkName());
-  EXPECT_EQ("world", model->JointByName("joint")->ParentLinkName());
+  EXPECT_EQ("link", model->JointByName("joint")->ChildName());
+  EXPECT_EQ("world", model->JointByName("joint")->ParentName());
   std::string resolvedLinkName;
   EXPECT_TRUE(
     model->JointByName("joint")->ResolveChildLink(resolvedLinkName).empty());
@@ -250,8 +250,8 @@ TEST(DOMJoint, LoadJointParentModelFrame)
   EXPECT_EQ(1u, model->JointCount());
   auto *joint = model->JointByName("joint");
   ASSERT_NE(nullptr, joint);
-  EXPECT_EQ("child_link", model->JointByName("joint")->ChildLinkName());
-  EXPECT_EQ("__model__", model->JointByName("joint")->ParentLinkName());
+  EXPECT_EQ("child_link", model->JointByName("joint")->ChildName());
+  EXPECT_EQ("__model__", model->JointByName("joint")->ParentName());
   std::string resolvedLinkName;
   EXPECT_TRUE(joint->ResolveParentLink(resolvedLinkName).empty());
   EXPECT_EQ("base_link", resolvedLinkName);
@@ -282,8 +282,8 @@ TEST(DOMJoint, LoadJointChildModelFrame)
   EXPECT_EQ(1u, model->JointCount());
   auto *joint = model->JointByName("joint");
   ASSERT_NE(nullptr, joint);
-  EXPECT_EQ("__model__", model->JointByName("joint")->ChildLinkName());
-  EXPECT_EQ("parent_link", model->JointByName("joint")->ParentLinkName());
+  EXPECT_EQ("__model__", model->JointByName("joint")->ChildName());
+  EXPECT_EQ("parent_link", model->JointByName("joint")->ParentName());
   std::string resolvedLinkName;
   EXPECT_TRUE(joint->ResolveChildLink(resolvedLinkName).empty());
   EXPECT_EQ("base_link", resolvedLinkName);
@@ -333,8 +333,8 @@ TEST(DOMJoint, LoadJointParentFrame)
   EXPECT_NE(nullptr, model->JointByIndex(0));
   EXPECT_EQ(nullptr, model->JointByIndex(1));
   ASSERT_TRUE(model->JointNameExists("joint"));
-  EXPECT_EQ("child_link", model->JointByName("joint")->ChildLinkName());
-  EXPECT_EQ("parent_frame", model->JointByName("joint")->ParentLinkName());
+  EXPECT_EQ("child_link", model->JointByName("joint")->ChildName());
+  EXPECT_EQ("parent_frame", model->JointByName("joint")->ParentName());
 
   std::string resolvedLinkName;
   EXPECT_TRUE(
@@ -425,8 +425,8 @@ TEST(DOMJoint, LoadJointChildFrame)
   EXPECT_NE(nullptr, model->JointByIndex(0));
   EXPECT_EQ(nullptr, model->JointByIndex(1));
   ASSERT_TRUE(model->JointNameExists("joint"));
-  EXPECT_EQ("child_frame", model->JointByName("joint")->ChildLinkName());
-  EXPECT_EQ("parent_link", model->JointByName("joint")->ParentLinkName());
+  EXPECT_EQ("child_frame", model->JointByName("joint")->ChildName());
+  EXPECT_EQ("parent_link", model->JointByName("joint")->ParentName());
 
   std::string resolvedLinkName;
   EXPECT_TRUE(
@@ -844,8 +844,8 @@ TEST(DOMJoint, LoadJointNestedParentChild)
   {
     const sdf::Joint *j1 = model->JointByName("J1");
     ASSERT_NE(nullptr, j1);
-    EXPECT_EQ("M1::L1", j1->ParentLinkName());
-    EXPECT_EQ("L1", j1->ChildLinkName());
+    EXPECT_EQ("M1::L1", j1->ParentName());
+    EXPECT_EQ("L1", j1->ChildName());
 
     std::string resolvedLinkName;
     EXPECT_TRUE(j1->ResolveParentLink(resolvedLinkName).empty());
@@ -860,8 +860,8 @@ TEST(DOMJoint, LoadJointNestedParentChild)
   {
     const sdf::Joint *j2 = model->JointByName("J2");
     ASSERT_NE(nullptr, j2);
-    EXPECT_EQ("F1", j2->ParentLinkName());
-    EXPECT_EQ("L1", j2->ChildLinkName());
+    EXPECT_EQ("F1", j2->ParentName());
+    EXPECT_EQ("L1", j2->ChildName());
 
     std::string resolvedLinkName;
     EXPECT_TRUE(j2->ResolveParentLink(resolvedLinkName).empty());
@@ -876,8 +876,8 @@ TEST(DOMJoint, LoadJointNestedParentChild)
   {
     const sdf::Joint *j3 = model->JointByName("J3");
     ASSERT_NE(nullptr, j3);
-    EXPECT_EQ("L1", j3->ParentLinkName());
-    EXPECT_EQ("M1::L2", j3->ChildLinkName());
+    EXPECT_EQ("L1", j3->ParentName());
+    EXPECT_EQ("M1::L2", j3->ChildName());
 
     std::string resolvedLinkName;
     EXPECT_TRUE(j3->ResolveParentLink(resolvedLinkName).empty());
@@ -892,8 +892,8 @@ TEST(DOMJoint, LoadJointNestedParentChild)
   {
     const sdf::Joint *j4 = model->JointByName("J4");
     ASSERT_NE(nullptr, j4);
-    EXPECT_EQ("L1", j4->ParentLinkName());
-    EXPECT_EQ("M1::F1", j4->ChildLinkName());
+    EXPECT_EQ("L1", j4->ParentName());
+    EXPECT_EQ("M1::F1", j4->ChildName());
 
     std::string resolvedLinkName;
     EXPECT_TRUE(j4->ResolveParentLink(resolvedLinkName).empty());
@@ -908,8 +908,8 @@ TEST(DOMJoint, LoadJointNestedParentChild)
   {
     const sdf::Joint *j5 = model->JointByName("J5");
     ASSERT_NE(nullptr, j5);
-    EXPECT_EQ("L1", j5->ParentLinkName());
-    EXPECT_EQ("M1::M2", j5->ChildLinkName());
+    EXPECT_EQ("L1", j5->ParentName());
+    EXPECT_EQ("M1::M2", j5->ChildName());
 
     std::string resolvedLinkName;
     EXPECT_TRUE(j5->ResolveParentLink(resolvedLinkName).empty());
@@ -924,8 +924,8 @@ TEST(DOMJoint, LoadJointNestedParentChild)
   {
     const sdf::Joint *j6 = model->JointByName("J6");
     ASSERT_NE(nullptr, j6);
-    EXPECT_EQ("M1::__model__", j6->ParentLinkName());
-    EXPECT_EQ("L1", j6->ChildLinkName());
+    EXPECT_EQ("M1::__model__", j6->ParentName());
+    EXPECT_EQ("L1", j6->ChildName());
 
     std::string resolvedLinkName;
     EXPECT_TRUE(j6->ResolveParentLink(resolvedLinkName).empty());
@@ -940,8 +940,8 @@ TEST(DOMJoint, LoadJointNestedParentChild)
   {
     const sdf::Joint *j7 = model->JointByName("J7");
     ASSERT_NE(nullptr, j7);
-    EXPECT_EQ("L1", j7->ParentLinkName());
-    EXPECT_EQ("M1::__model__", j7->ChildLinkName());
+    EXPECT_EQ("L1", j7->ParentName());
+    EXPECT_EQ("M1::__model__", j7->ChildName());
 
     std::string resolvedLinkName;
     EXPECT_TRUE(j7->ResolveParentLink(resolvedLinkName).empty());

--- a/test/integration/sdf_dom_conversion.cc
+++ b/test/integration/sdf_dom_conversion.cc
@@ -568,8 +568,8 @@ TEST(SDFDomConversion, Joints)
   EXPECT_EQ("joint", joint->Name());
   EXPECT_EQ(1u, joint->SensorCount());
 
-  EXPECT_EQ("link1", joint->ParentLinkName());
-  EXPECT_EQ("link2", joint->ChildLinkName());
+  EXPECT_EQ("link1", joint->ParentName());
+  EXPECT_EQ("link2", joint->ChildName());
   EXPECT_EQ(sdf::JointType::FIXED, joint->Type());
 
   // Get the force_torque sensor

--- a/usd/src/sdf_parser/Joint.cc
+++ b/usd/src/sdf_parser/Joint.cc
@@ -71,7 +71,7 @@ namespace usd
     UsdErrors errors;
 
     gz::math::Pose3d parentToJoint;
-    if (_joint.ParentLinkName() == "world")
+    if (_joint.ParentName() == "world")
     {
       gz::math::Pose3d modelToJoint;
       auto poseErrors = usd::PoseWrtParent(_joint, modelToJoint);
@@ -90,13 +90,13 @@ namespace usd
     else
     {
       auto poseResolutionErrors =
-        _joint.SemanticPose().Resolve(parentToJoint, _joint.ParentLinkName());
+        _joint.SemanticPose().Resolve(parentToJoint, _joint.ParentName());
       if (!poseResolutionErrors.empty())
       {
         errors.push_back(UsdError(
               sdf::Error(sdf::ErrorCode::POSE_RELATIVE_TO_INVALID,
               "Unable to get the pose of joint [" + _joint.Name() +
-              "] w.r.t. its parent link [" + _joint.ParentLinkName() + "].")));
+              "] w.r.t. its parent link [" + _joint.ParentName() + "].")));
         for (const auto &e : poseResolutionErrors)
           errors.push_back(UsdError(e));
         return errors;
@@ -105,13 +105,13 @@ namespace usd
 
     gz::math::Pose3d childToJoint;
     auto poseResolutionErrors = _joint.SemanticPose().Resolve(childToJoint,
-        _joint.ChildLinkName());
+        _joint.ChildName());
     if (!poseResolutionErrors.empty())
     {
       errors.push_back(UsdError(
           sdf::Error(sdf::ErrorCode::POSE_RELATIVE_TO_INVALID,
             "Unable to get the pose of joint [" + _joint.Name() +
-            "] w.r.t. its child [" + _joint.ChildLinkName() + "].")));
+            "] w.r.t. its child [" + _joint.ChildName() + "].")));
       for (const auto &e : poseResolutionErrors)
         errors.push_back(UsdError(e));
       return errors;
@@ -318,24 +318,24 @@ namespace usd
     // the joint's parent may be "world". If this is the case, the joint's
     // parent should be set to the world prim, not a link
     auto parentLinkPath = _worldPath;
-    if (_joint.ParentLinkName() != "world")
+    if (_joint.ParentName() != "world")
     {
-      const auto it = _linkToUsdPath.find(_joint.ParentLinkName());
+      const auto it = _linkToUsdPath.find(_joint.ParentName());
       if (it == _linkToUsdPath.end())
       {
         errors.push_back(UsdError(sdf::usd::UsdErrorCode::INVALID_PRIM_PATH,
-              "Unable to find a USD path for link [" + _joint.ParentLinkName() +
+              "Unable to find a USD path for link [" + _joint.ParentName() +
               "], which is the parent link of joint [" + _joint.Name() + "]."));
         return errors;
       }
       parentLinkPath = it->second;
     }
 
-    const auto it = _linkToUsdPath.find(_joint.ChildLinkName());
+    const auto it = _linkToUsdPath.find(_joint.ChildName());
     if (it == _linkToUsdPath.end())
     {
       errors.push_back(UsdError(sdf::usd::UsdErrorCode::INVALID_PRIM_PATH,
-            "Unable to find a USD path for link [" + _joint.ParentLinkName() +
+            "Unable to find a USD path for link [" + _joint.ParentName() +
             "], which is the child link of joint [" + _joint.Name() + "]."));
       return errors;
     }

--- a/usd/src/sdf_parser/Joint_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Joint_Sdf2Usd_TEST.cc
@@ -274,19 +274,19 @@ TEST_F(UsdJointStageFixture, RevoluteJoints)
 
     // make sure joint is pointing to the proper parent/child links
     this->CheckParentLinkPath(&usdRevoluteJoint,
-        this->modelPath + "/" + sdfJoint->ParentLinkName());
+        this->modelPath + "/" + sdfJoint->ParentName());
     this->CheckChildLinkPath(&usdRevoluteJoint,
-        this->modelPath + "/" + sdfJoint->ChildLinkName());
+        this->modelPath + "/" + sdfJoint->ChildName());
 
     // check joint's pose w.r.t. parent and child links
     gz::math::Pose3d parentToJointPose;
     auto poseErrors = sdfJoint->SemanticPose().Resolve(parentToJointPose,
-          sdfJoint->ParentLinkName());
+          sdfJoint->ParentName());
     EXPECT_TRUE(poseErrors.empty());
     poseErrors.clear();
     gz::math::Pose3d childToJointPose;
     poseErrors = sdfJoint->SemanticPose().Resolve(childToJointPose,
-          sdfJoint->ChildLinkName());
+          sdfJoint->ChildName());
     EXPECT_TRUE(poseErrors.empty());
     this->CheckRelativeLinkPoses(&usdRevoluteJoint, parentToJointPose,
         childToJointPose);
@@ -368,7 +368,7 @@ TEST_F(UsdJointStageFixture, JointParentIsWorld)
     // The parent in this test should be the world
     this->CheckParentLinkPath(&usdFixedJoint, this->worldPath.GetString());
     this->CheckChildLinkPath(&usdFixedJoint,
-        this->modelPath + "/" + sdfJoint->ChildLinkName());
+        this->modelPath + "/" + sdfJoint->ChildName());
 
     // check joint's pose w.r.t. parent and child links. For this test case,
     // we need to get the joint pose w.r.t. the world
@@ -383,7 +383,7 @@ TEST_F(UsdJointStageFixture, JointParentIsWorld)
     poseErrors.clear();
     gz::math::Pose3d childToJointPose;
     poseErrors = sdfJoint->SemanticPose().Resolve(childToJointPose,
-          sdfJoint->ChildLinkName());
+          sdfJoint->ChildName());
     EXPECT_TRUE(poseErrors.empty());
     this->CheckRelativeLinkPoses(&usdFixedJoint, worldToJointPose,
         childToJointPose);
@@ -449,19 +449,19 @@ TEST_F(UsdJointStageFixture, BallPrismaticJoint)
 
     // make sure joint is pointing to the proper parent/child links
     this->CheckParentLinkPath(&usdJoint,
-        this->modelPath + "/" + sdfJoint->ParentLinkName());
+        this->modelPath + "/" + sdfJoint->ParentName());
     this->CheckChildLinkPath(&usdJoint,
-        this->modelPath + "/" + sdfJoint->ChildLinkName());
+        this->modelPath + "/" + sdfJoint->ChildName());
 
     // check joint's pose w.r.t. parent and child links
     gz::math::Pose3d parentToJointPose;
     auto poseErrors = sdfJoint->SemanticPose().Resolve(parentToJointPose,
-          sdfJoint->ParentLinkName());
+          sdfJoint->ParentName());
     EXPECT_TRUE(poseErrors.empty());
     poseErrors.clear();
     gz::math::Pose3d childToJointPose;
     poseErrors = sdfJoint->SemanticPose().Resolve(childToJointPose,
-          sdfJoint->ChildLinkName());
+          sdfJoint->ChildName());
     EXPECT_TRUE(poseErrors.empty());
     this->CheckRelativeLinkPoses(&usdJoint, parentToJointPose,
         childToJointPose);

--- a/usd/src/usd_parser/USDJoints.cc
+++ b/usd/src/usd_parser/USDJoints.cc
@@ -66,24 +66,24 @@ namespace sdf
 
       if (body1.size() > 0)
       {
-        _joint.SetChildLinkName(gz::common::basename(
+        _joint.SetChildName(gz::common::basename(
           body1[0].GetString()));
       }
       else if (body0.size() > 0)
       {
-        _joint.SetParentLinkName("world");
-        _joint.SetChildLinkName(gz::common::basename(
+        _joint.SetParentName("world");
+        _joint.SetChildName(gz::common::basename(
           body0[0].GetString()));
       }
 
-      if (body0.size() > 0 && _joint.ParentLinkName().empty())
+      if (body0.size() > 0 && _joint.ParentName().empty())
       {
-        _joint.SetParentLinkName(gz::common::basename(
+        _joint.SetParentName(gz::common::basename(
           body0[0].GetString()));
       }
       else
       {
-        _joint.SetParentLinkName("world");
+        _joint.SetParentName("world");
       }
 
       std::string primName = _prim.GetName();
@@ -112,7 +112,7 @@ namespace sdf
       if (_prim.IsA<pxr::UsdPhysicsPrismaticJoint>() ||
           _prim.IsA<pxr::UsdPhysicsRevoluteJoint>())
       {
-        _joint.SetPoseRelativeTo(_joint.ParentLinkName());
+        _joint.SetPoseRelativeTo(_joint.ParentName());
 
         pxr::TfToken axis;
         if (_prim.IsA<pxr::UsdPhysicsPrismaticJoint>())

--- a/usd/src/usd_parser/USDJoints_TEST.cc
+++ b/usd/src/usd_parser/USDJoints_TEST.cc
@@ -61,8 +61,8 @@ TEST(USDJointTest, JointTest)
   EXPECT_EQ(0u, errors.size());
   EXPECT_EQ(sdf::JointType::REVOLUTE, joint1.Type());
   EXPECT_EQ("upper_joint", joint1.Name());
-  EXPECT_EQ("upper_link", joint1.ChildLinkName());
-  EXPECT_EQ("base", joint1.ParentLinkName());
+  EXPECT_EQ("upper_link", joint1.ChildName());
+  EXPECT_EQ("base", joint1.ParentName());
   EXPECT_EQ(gz::math::Pose3d(0, 0, 0.021, -1.5708, 0, 0),
             joint1.RawPose());
 
@@ -81,8 +81,8 @@ TEST(USDJointTest, JointTest)
   EXPECT_EQ(0u, errors.size());
   EXPECT_EQ(sdf::JointType::REVOLUTE, joint2.Type());
   EXPECT_EQ("lower_joint", joint2.Name());
-  EXPECT_EQ("lower_link", joint2.ChildLinkName());
-  EXPECT_EQ("upper_link", joint2.ParentLinkName());
+  EXPECT_EQ("lower_link", joint2.ChildName());
+  EXPECT_EQ("upper_link", joint2.ParentName());
   EXPECT_EQ(gz::math::Pose3d(0.0025, -0, 0.01, -0.4292, 0, 0),
             joint2.RawPose());
   axis = joint2.Axis(0);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #979

## Summary

Remove Link from the names of APIs for getting and setting the name of parent/child frames, since any frame can be specified, not just links.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [X] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
