### PR TITLE
Require eigen3 component of gz-math

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,6 +1,6 @@
 libignition-cmake3-dev
 libignition-common5-dev
-libignition-math7-dev
+libignition-math7-eigen3-dev
 libignition-tools2-dev
 libignition-utils2-dev
 libignition-utils2-cli-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ if (BUILD_SDF)
   ########################################
   # Find ignition math
   # Set a variable for generating ProjectConfig.cmake
-  gz_find_package(ignition-math7 VERSION REQUIRED)
+  gz_find_package(ignition-math7 REQUIRED COMPONENTS eigen3)
   set(IGN_MATH_VER ${ignition-math7_VERSION_MAJOR})
 
   ########################################

--- a/Migration.md
+++ b/Migration.md
@@ -14,6 +14,12 @@ but with improved human-readability..
 
 ## libsdformat 12.x to 13.x
 
+### Modifications
+
+- The `eigen3` component of `gz-math` is now required and exported as a
+  target dependency of the core library so that Eigen types may be used
+  in the libsdformat API.
+
 ### Deprecations
 
 - The `ignition` namespace is deprecated and will be removed in future versions.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,7 +110,7 @@ gz_create_core_library(SOURCES ${sources}
 
 target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PUBLIC
-    ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER}
+    ignition-math${IGN_MATH_VER}::eigen3
     ignition-utils${IGN_UTILS_VER}::ignition-utils${IGN_UTILS_VER}
   PRIVATE
     TINYXML2::TINYXML2


### PR DESCRIPTION
# 🎉 New feature

Motivated by https://github.com/gazebosim/gz-math/pull/442

## Summary

Require and export the `eigen3` component of `gz-math` as a target dependency so that Eigen types may be used in the public API.

## Test it

Check that CI passes

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
