### PR TITLE
Update return types for Plugin's Name and Filename

### DIFF
--- a/include/sdf/Plugin.hh
+++ b/include/sdf/Plugin.hh
@@ -80,7 +80,7 @@ namespace sdf
     /// The name of the plugin should be unique within the scope of its
     /// parent.
     /// \return Name of the plugin.
-    public: std::string Name() const;
+    public: const std::string &Name() const;
 
     /// \brief Set the name of the plugin.
     /// The name of the plugin should be unique within the scope of its
@@ -90,7 +90,7 @@ namespace sdf
 
     /// \brief Get the filename of the shared library.
     /// \return Filename of the shared library associated with the plugin.
-    public: std::string Filename() const;
+    public: const std::string &Filename() const;
 
     /// \brief Remove the contents of the plugin, this is everything that
     /// is a child element of the `<plugin>`.

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -125,7 +125,7 @@ Errors Plugin::Load(ElementPtr _sdf)
 }
 
 /////////////////////////////////////////////////
-std::string Plugin::Name() const
+const std::string &Plugin::Name() const
 {
   return this->dataPtr->name;
 }
@@ -137,7 +137,7 @@ void Plugin::SetName(const std::string &_name)
 }
 
 /////////////////////////////////////////////////
-std::string Plugin::Filename() const
+const std::string &Plugin::Filename() const
 {
   return this->dataPtr->filename;
 }


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

This just changes two return types from `std::string` to `const std::string &`. This will make it easier to use `sdf::Plugin` with `gazebo::ServerConfig::PluginInfo`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.