### PR TITLE
Wrap sdf::Errors with exceptions in all python bindings

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -77,6 +77,7 @@ pybind11_add_module(sdformat SHARED
   src/sdf/pySurface.cc
   src/sdf/pyVisual.cc
   src/sdf/pyWorld.cc
+  src/sdf/pybind11_helpers.cc
 )
 
 target_link_libraries(sdformat PRIVATE

--- a/python/src/sdf/pyFrame.cc
+++ b/python/src/sdf/pyFrame.cc
@@ -21,6 +21,7 @@
 
 #include "sdf/Frame.hh"
 #include "pyExceptions.hh"
+#include "pybind11_helpers.hh"
 
 using namespace pybind11::literals;
 
@@ -64,11 +65,7 @@ void defineFrame(pybind11::object module)
          [](const sdf::Frame &self)
          {
            std::string body;
-           auto errors = self.ResolveAttachedToBody(body);
-           if (!errors.empty())
-           {
-             throw PySDFErrorsException(errors);
-           }
+           ThrowIfErrors(self.ResolveAttachedToBody(body));
            return body;
          },
          "Resolve the attached-to body of this frame from the "

--- a/python/src/sdf/pyJoint.cc
+++ b/python/src/sdf/pyJoint.cc
@@ -21,6 +21,7 @@
 
 #include "sdf/Joint.hh"
 #include "sdf/Sensor.hh"
+#include "pybind11_helpers.hh"
 
 using namespace pybind11::literals;
 
@@ -57,8 +58,8 @@ void defineJoint(pybind11::object module)
          [](const sdf::Joint &self)
          {
            std::string link;
-           auto errors = self.ResolveChildLink(link);
-           return std::make_tuple(errors, link);
+           ThrowIfErrors(self.ResolveChildLink(link));
+           return link;
          },
          "Resolve the name of the child link from the "
          "FrameAttachedToGraph.")
@@ -66,8 +67,8 @@ void defineJoint(pybind11::object module)
          [](const sdf::Joint &self)
          {
            std::string link;
-           auto errors = self.ResolveParentLink(link);
-           return std::make_tuple(errors, link);
+           ThrowIfErrors(self.ResolveParentLink(link));
+           return link;
          },
          "Resolve the name of the parent link from the "
          "FrameAttachedToGraph. It will return the name of a link or "

--- a/python/src/sdf/pyJointAxis.cc
+++ b/python/src/sdf/pyJointAxis.cc
@@ -20,6 +20,7 @@
 #include <pybind11/stl.h>
 
 #include "sdf/JointAxis.hh"
+#include "pybind11_helpers.hh"
 
 
 using namespace pybind11::literals;
@@ -38,7 +39,10 @@ void defineJointAxis(pybind11::object module)
     .def(pybind11::init<sdf::JointAxis>())
     .def("xyz", &sdf::JointAxis::Xyz,
          "Get the x,y,z components of the axis unit vector.")
-    .def("set_xyz", &sdf::JointAxis::SetXyz,
+    .def("set_xyz", [](JointAxis &self, const gz::math::Vector3d &_xyz)
+         {
+           ThrowIfErrors(self.SetXyz(_xyz));
+         },
          "Set the x,y,z components of the axis unit vector.")
     .def("damping", &sdf::JointAxis::Damping,
          "Get the physical velocity dependent viscous damping coefficient "
@@ -104,8 +108,12 @@ void defineJointAxis(pybind11::object module)
          "Set the name of the coordinate frame in which this joint axis's "
          "unit vector is expressed. An empty value implies the parent (joint) "
          "frame.")
-    .def("resolve_xyz", &sdf::JointAxis::ResolveXyz,
-         pybind11::arg("_xyz"),
+    .def("resolve_xyz", [](const JointAxis &self, const std::string &_resolveTo)
+         {
+           gz::math::Vector3d xyz;
+           ThrowIfErrors(self.ResolveXyz(xyz, _resolveTo));
+           return xyz;
+         },
          pybind11::arg("_resolveTo") = "",
          "Express xyz unit vector of this axis in the coordinates of "
          "another named frame.")

--- a/python/src/sdf/pyModel.cc
+++ b/python/src/sdf/pyModel.cc
@@ -24,6 +24,8 @@
 #include "sdf/Link.hh"
 #include "sdf/Model.hh"
 
+#include "pybind11_helpers.hh"
+
 using namespace pybind11::literals;
 
 namespace sdf
@@ -38,7 +40,10 @@ void defineModel(pybind11::object module)
   pybind11::class_<sdf::Model>(module, "Model")
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Model>())
-    .def("validate_graphs", &sdf::Model::ValidateGraphs,
+    .def("validate_graphs", [](const sdf::Model &self)
+         {
+           ThrowIfErrors(self.ValidateGraphs());
+         },
          "Check that the FrameAttachedToGraph and PoseRelativeToGraph "
          "are valid.")
     .def("name", &sdf::Model::Name,

--- a/python/src/sdf/pyRoot.cc
+++ b/python/src/sdf/pyRoot.cc
@@ -23,6 +23,7 @@
 #include "sdf/Model.hh"
 #include "sdf/Root.hh"
 #include "sdf/World.hh"
+#include "pybind11_helpers.hh"
 
 using namespace pybind11::literals;
 
@@ -38,23 +39,32 @@ void defineRoot(pybind11::object module)
   pybind11::class_<sdf::Root>(module, "Root")
     .def(pybind11::init<>())
     .def("load",
-         pybind11::overload_cast<const std::string &>(&sdf::Root::Load),
+         [](Root &self, const std::string &_filename)
+         {
+           ThrowIfErrors(self.Load(_filename));
+         },
          "Parse the given SDF file, and generate objects based on types "
          "specified in the SDF file.")
     .def("load",
-          pybind11::overload_cast<
-            const std::string &, const ParserConfig &>(&sdf::Root::Load),
+         [](Root &self, const std::string &_filename, 
+            const ParserConfig &_config)
+         {
+           ThrowIfErrors(self.Load(_filename, _config));
+         },
          "Parse the given SDF file, and generate objects based on types "
          "specified in the SDF file.")
    .def("load_sdf_string",
-         pybind11::overload_cast<const std::string &>(
-           &sdf::Root::LoadSdfString),
+         [](Root &self, const std::string &_sdf)
+         {
+           ThrowIfErrors(self.LoadSdfString(_sdf));
+         },
          "Parse the given SDF string, and generate objects based on types "
          "specified in the SDF file.")
     .def("load_sdf_string",
-          pybind11::overload_cast<
-            const std::string &, const ParserConfig &>(
-              &sdf::Root::LoadSdfString),
+         [](Root &self, const std::string &_sdf, const ParserConfig &_config)
+         {
+           ThrowIfErrors(self.LoadSdfString(_sdf, _config));
+         },
          "Parse the given SDF string, and generate objects based on types "
          "specified in the SDF file.")
     .def("version", &sdf::Root::Version,
@@ -84,11 +94,17 @@ void defineRoot(pybind11::object module)
     .def("set_light", &sdf::Root::SetLight,
          "Set the light object. This will override any existing model, "
          "actor, and light object.")
-    .def("add_world", &sdf::Root::AddWorld,
+    .def("add_world", [](Root &self, const World &_world)
+         {
+           ThrowIfErrors(self.AddWorld(_world));
+         },
          "Add a world to the root.")
     .def("clear_worlds", &sdf::Root::ClearWorlds,
          "Remove all worlds.")
-    .def("update_graphs", &sdf::Root::UpdateGraphs,
+    .def("update_graphs", [](Root &self)
+         {
+           ThrowIfErrors(self.UpdateGraphs());
+         },
          "Recreate the frame and pose graphs for the worlds and model "
          "that are children of this Root object. You can call this function "
          "to build new graphs when the DOM was created programmatically, or "

--- a/python/src/sdf/pySemanticPose.cc
+++ b/python/src/sdf/pySemanticPose.cc
@@ -21,6 +21,7 @@
 #include <gz/math/Pose3.hh>
 
 #include "sdf/SemanticPose.hh"
+#include "pybind11_helpers.hh"
 
 using namespace pybind11::literals;
 
@@ -41,8 +42,13 @@ void defineSemanticPose(pybind11::object module)
          "Get the name of the coordinate frame relative to which this "
          "object's pose is expressed. An empty value indicates that the frame "
          "is relative to the default parent object.")
-    .def("resolve", &sdf::SemanticPose::Resolve,
-         pybind11::arg("_pose"),
+    .def("resolve",
+         [](const sdf::SemanticPose &self, const std::string &_resolveTo)
+         {
+           gz::math::Pose3d pose;
+           ThrowIfErrors(self.Resolve(pose, _resolveTo));
+           return pose;
+         },
          pybind11::arg("_resolveTo") = "",
          "Resolve pose of this object with respect to another named frame. "
          "If there are any errors resolving the pose, the output will not be "

--- a/python/src/sdf/pybind11_helpers.cc
+++ b/python/src/sdf/pybind11_helpers.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "pybind11_helpers.hh"
+
+namespace sdf
+{
+// Inline bracket to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE
+{
+namespace python
+{
+/////////////////////////////////////////////////
+void ThrowIfErrors(const sdf::Errors &_errors)
+{
+  if (!_errors.empty())
+  {
+    throw PySDFErrorsException(_errors);
+  }
+}
+}  // namespace python
+}  // namespace SDF_VERSION_NAMESPACE
+}  // namespace sdf
+

--- a/python/src/sdf/pybind11_helpers.hh
+++ b/python/src/sdf/pybind11_helpers.hh
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <sdf/sdf_config.h>
+
+#include <sdf/Types.hh>
+
+#include "pyExceptions.hh"
+
+namespace sdf
+{
+// Inline bracket to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE
+{
+namespace python
+{
+/// \brief Throw an exception if the `_errors` container is not empty.
+/// \param[in] _errors The list of errors to check.
+/// \throws PySDFErrorsException
+void ThrowIfErrors(const sdf::Errors &_errors);
+}  // namespace python
+}  // namespace SDF_VERSION_NAMESPACE
+}  // namespace sdf

--- a/python/test/pyCollision_TEST.py
+++ b/python/test/pyCollision_TEST.py
@@ -15,7 +15,7 @@
 import copy
 from ignition.math import Pose3d
 from sdformat import (Box, Collision, Contact, Cylinder, Error, Geometry,
-                      Plane, Surface, Sphere)
+                      Plane, Surface, Sphere, SDFErrorsException)
 import sdformat as sdf
 import unittest
 import math
@@ -35,10 +35,9 @@ class CollisionTEST(unittest.TestCase):
         semanticPose = collision.semantic_pose()
         self.assertEqual(collision.raw_pose(), semanticPose.raw_pose())
         self.assertTrue(not semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        semanticPose.resolve(pose)
-        # self.assertFalse()
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         collision.set_raw_pose(Pose3d(-10, -20, -30, math.pi, math.pi, math.pi))
         self.assertEqual(Pose3d(-10, -20, -30, math.pi, math.pi, math.pi),
@@ -50,9 +49,9 @@ class CollisionTEST(unittest.TestCase):
         semanticPose = collision.semantic_pose()
         self.assertEqual(collision.raw_pose(), semanticPose.raw_pose())
         self.assertEqual("link", semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        # self.assertFalse(semanticPose.resolve(pose).empty())
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         self.assertNotEqual(None, collision.geometry())
         self.assertEqual(sdf.GeometryType.EMPTY, collision.geometry().type())

--- a/python/test/pyFrame_TEST.py
+++ b/python/test/pyFrame_TEST.py
@@ -34,9 +34,9 @@ class FrameTest(unittest.TestCase):
         semanticPose = frame.semantic_pose()
         self.assertEqual(Pose3d.ZERO, semanticPose.raw_pose())
         self.assertFalse(semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertTrue(semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         frame.set_attached_to("attachment")
         self.assertEqual("attachment", frame.attached_to())
@@ -48,9 +48,9 @@ class FrameTest(unittest.TestCase):
         semanticPose = frame.semantic_pose()
         self.assertEqual(frame.raw_pose(), semanticPose.raw_pose())
         self.assertEqual("attachment", semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertTrue(semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         frame.set_pose_relative_to("link")
         self.assertEqual("link", frame.pose_relative_to())
@@ -58,9 +58,9 @@ class FrameTest(unittest.TestCase):
         semanticPose = frame.semantic_pose()
         self.assertEqual(frame.raw_pose(), semanticPose.raw_pose())
         self.assertEqual("link", semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertEqual(1, len(semanticPose.resolve(pose)))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         with self.assertRaises(SDFErrorsException) as cm:
             resolveAttachedToBody = frame.resolve_attached_to_body()

--- a/python/test/pyJoint_TEST.py
+++ b/python/test/pyJoint_TEST.py
@@ -14,7 +14,8 @@
 
 import copy
 from ignition.math import Pose3d, Vector3d
-from sdformat import Joint, JointAxis, Error, SemanticPose, Sensor
+from sdformat import (Joint, JointAxis, Error, SemanticPose, Sensor,
+                      SDFErrorsException)
 import sdformat as sdf
 import math
 import unittest
@@ -34,9 +35,9 @@ class JointTEST(unittest.TestCase):
         semanticPose = joint.semantic_pose()
         self.assertEqual(Pose3d.ZERO, semanticPose.raw_pose())
         self.assertFalse(semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose without graph
-        self.assertTrue(semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         joint.set_raw_pose(Pose3d(-1, -2, -3, math.pi, math.pi, 0))
         self.assertEqual(Pose3d(-1, -2, -3, math.pi, math.pi, 0),
@@ -48,9 +49,9 @@ class JointTEST(unittest.TestCase):
         semanticPose = joint.semantic_pose()
         self.assertEqual(joint.raw_pose(), semanticPose.raw_pose())
         self.assertEqual("link", semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose without graph
-        self.assertTrue(semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         joint.set_name("test_joint")
         self.assertEqual("test_joint", joint.name())
@@ -61,12 +62,11 @@ class JointTEST(unittest.TestCase):
         joint.set_child_name("child")
         self.assertEqual("child", joint.child_name())
 
-        errors, resolveChildLink = joint.resolve_child_link()
-        self.assertEqual(1, len(errors))
-        self.assertFalse(resolveChildLink)
-        errors, resolveParentLink = joint.resolve_parent_link()
-        self.assertEqual(1, len(errors))
-        self.assertFalse(resolveParentLink)
+        with self.assertRaises(SDFErrorsException):
+            joint.resolve_child_link()
+
+        with self.assertRaises(SDFErrorsException):
+            joint.resolve_parent_link()
 
         joint.set_type(sdf.JointType.BALL)
         self.assertEqual(sdf.JointType.BALL, joint.type())
@@ -88,10 +88,10 @@ class JointTEST(unittest.TestCase):
         self.assertEqual(None, joint.axis(0))
         self.assertEqual(None, joint.axis(1))
         axis = JointAxis()
-        self.assertEqual(0, len(axis.set_xyz(Vector3d(1, 0, 0))))
+        axis.set_xyz(Vector3d(1, 0, 0))
         joint.set_axis(0, axis)
         axis1 = JointAxis()
-        self.assertEqual(0, len(axis1.set_xyz(Vector3d(0, 1, 0))))
+        axis1.set_xyz(Vector3d(0, 1, 0))
         joint.set_axis(1, axis1)
         self.assertNotEqual(None, joint.axis(0))
         self.assertNotEqual(None, joint.axis(1))
@@ -114,10 +114,10 @@ class JointTEST(unittest.TestCase):
         joint = Joint()
         joint.set_name("test_joint")
         axis = JointAxis()
-        self.assertEqual(0, len(axis.set_xyz(Vector3d(1, 0, 0))))
+        axis.set_xyz(Vector3d(1, 0, 0))
         joint.set_axis(0, axis)
         axis1 = JointAxis()
-        self.assertEqual(0, len(axis1.set_xyz(Vector3d(0, 1, 0))))
+        axis1.set_xyz(Vector3d(0, 1, 0))
         joint.set_axis(1, axis1)
 
         joint2 = Joint(joint)
@@ -139,10 +139,10 @@ class JointTEST(unittest.TestCase):
         joint = Joint()
         joint.set_name("test_joint")
         axis = JointAxis()
-        self.assertEqual(0, len(axis.set_xyz(Vector3d(1, 0, 0))))
+        axis.set_xyz(Vector3d(1, 0, 0))
         joint.set_axis(0, axis)
         axis1 = JointAxis()
-        self.assertEqual(0, len(axis1.set_xyz(Vector3d(0, 1, 0))))
+        axis1.set_xyz(Vector3d(0, 1, 0))
         joint.set_axis(1, axis1)
 
         joint2 = copy.deepcopy(joint)

--- a/python/test/pyLight_TEST.py
+++ b/python/test/pyLight_TEST.py
@@ -14,7 +14,7 @@
 
 import copy
 from ignition.math import Angle, Color, Pose3d, Vector3d
-from sdformat import Light
+from sdformat import Light, SDFErrorsException
 import sdformat as sdf
 import math
 import unittest
@@ -36,9 +36,9 @@ class LightColor(unittest.TestCase):
         semanticPose = light.semantic_pose()
         self.assertEqual(light.raw_pose(), semanticPose.raw_pose())
         self.assertFalse(semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertEqual(1, len(semanticPose.resolve(pose)))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         light.set_raw_pose(Pose3d(1, 2, 3, 0, 0, math.pi))
         self.assertEqual(Pose3d(1, 2, 3, 0, 0, math.pi), light.raw_pose())
@@ -49,9 +49,9 @@ class LightColor(unittest.TestCase):
         semanticPose = light.semantic_pose()
         self.assertEqual(light.raw_pose(), semanticPose.raw_pose())
         self.assertEqual("world", semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertTrue(1, len(semanticPose.resolve(pose)))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         self.assertTrue(light.light_on())
         light.set_light_on(False)

--- a/python/test/pyLink_TEST.py
+++ b/python/test/pyLink_TEST.py
@@ -14,7 +14,8 @@
 
 import copy
 from ignition.math import Pose3d, Inertiald, MassMatrix3d, Vector3d
-from sdformat import (Collision, Light, Link, Sensor, Visual)
+from sdformat import (Collision, Light, Link, Sensor, Visual,
+                      SDFErrorsException)
 import unittest
 import math
 
@@ -66,9 +67,9 @@ class LinkTEST(unittest.TestCase):
         semantic_pose = link.semantic_pose()
         self.assertEqual(Pose3d.ZERO, semantic_pose.raw_pose())
         self.assertFalse(semantic_pose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertFalse(not semantic_pose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semantic_pose.resolve()
 
         link.set_raw_pose(Pose3d(10, 20, 30, 0, math.pi, 0))
         self.assertEqual(Pose3d(10, 20, 30, 0, math.pi, 0), link.raw_pose())
@@ -79,9 +80,9 @@ class LinkTEST(unittest.TestCase):
         semantic_pose = link.semantic_pose()
         self.assertEqual(link.raw_pose(), semantic_pose.raw_pose())
         self.assertEqual("model", semantic_pose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertFalse(not semantic_pose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semantic_pose.resolve()
 
         # Get the default inertial
         inertial = link.inertial()

--- a/python/test/pyModel_TEST.py
+++ b/python/test/pyModel_TEST.py
@@ -14,7 +14,8 @@
 
 import copy
 from ignition.math import Pose3d, Vector3d
-from sdformat import Plugin, Model, Joint, Link, Error, Frame, SemanticPose
+from sdformat import (Plugin, Model, Joint, Link, Error, Frame, SemanticPose,
+                      SDFErrorsException)
 import sdformat as sdf
 import math
 import unittest
@@ -116,9 +117,9 @@ class ModelTEST(unittest.TestCase):
         semanticPose = model.semantic_pose()
         self.assertEqual(model.raw_pose(), semanticPose.raw_pose())
         self.assertFalse(semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertEqual(1, len(semanticPose.resolve(pose)))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         model.set_raw_pose(Pose3d(1, 2, 3, 0, 0, math.pi))
         self.assertEqual(Pose3d(1, 2, 3, 0, 0, math.pi), model.raw_pose())
@@ -129,11 +130,13 @@ class ModelTEST(unittest.TestCase):
         semanticPose = model.semantic_pose()
         self.assertEqual(model.raw_pose(), semanticPose.raw_pose())
         self.assertEqual("world", semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertNotEqual(0, semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
-        errors = model.validate_graphs()
+        with self.assertRaises(SDFErrorsException) as cm:
+            model.validate_graphs()
+        errors = cm.exception.errors
         self.assertEqual(2, len(errors))
         self.assertEqual(errors[0].code(), sdf.ErrorCode.FRAME_ATTACHED_TO_GRAPH_ERROR)
         self.assertEqual(errors[0].message(),

--- a/python/test/pySensor_TEST.py
+++ b/python/test/pySensor_TEST.py
@@ -16,7 +16,7 @@ import copy
 from ignition.math import Pose3d
 from sdformat import (AirPressure, Altimeter, Camera, IMU, ForceTorque, Lidar,
                       Magnetometer, NavSat, Noise, Plugin, SemanticPose,
-                      Sensor)
+                      Sensor, SDFErrorsException)
 import sdformat as sdf
 import unittest
 
@@ -40,9 +40,9 @@ class SensorTEST(unittest.TestCase):
         semanticPose = sensor.semantic_pose()
         self.assertEqual(sensor.raw_pose(), semanticPose.raw_pose())
         self.assertFalse(semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertTrue(semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         sensor.set_raw_pose(Pose3d(1, 2, 3, 0, 0, 0))
         self.assertEqual(Pose3d(1, 2, 3, 0, 0, 0), sensor.raw_pose())
@@ -53,9 +53,9 @@ class SensorTEST(unittest.TestCase):
         semanticPose = sensor.semantic_pose()
         self.assertEqual(sensor.raw_pose(), semanticPose.raw_pose())
         self.assertEqual("a_frame", semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertTrue(semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         self.assertAlmostEqual(0.0, sensor.update_rate())
 

--- a/python/test/pyVisual_TEST.py
+++ b/python/test/pyVisual_TEST.py
@@ -14,7 +14,7 @@
 
 import copy
 from ignition.math import Pose3d, Color
-from sdformat import Geometry, Material, Visual, Plugin
+from sdformat import Geometry, Material, Visual, Plugin, SDFErrorsException
 import sdformat as sdf
 import unittest
 import math
@@ -43,9 +43,9 @@ class VisualTEST(unittest.TestCase):
         semanticPose = visual.semantic_pose()
         self.assertEqual(visual.raw_pose(), semanticPose.raw_pose())
         self.assertEqual('', semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertFalse(not semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         visual.set_raw_pose(Pose3d(0, -20, 30, math.pi/2, -math.pi, math.pi/2))
         self.assertEqual(Pose3d(0, -20, 30, math.pi/2, -math.pi, math.pi/2),
@@ -57,9 +57,9 @@ class VisualTEST(unittest.TestCase):
         semanticPose = visual.semantic_pose()
         self.assertEqual(visual.raw_pose(), semanticPose.raw_pose())
         self.assertEqual("link", semanticPose.relative_to())
-        pose = Pose3d()
         # expect errors when trying to resolve pose
-        self.assertFalse(not semanticPose.resolve(pose))
+        with self.assertRaises(SDFErrorsException):
+            semanticPose.resolve()
 
         self.assertNotEqual(None, visual.geometry())
         self.assertEqual(sdf.GeometryType.EMPTY, visual.geometry().type())


### PR DESCRIPTION
# 🎉 New feature

Toward #931 

## Summary
This is a followup on #1004. It wraps the remaining python bound functions that return `sdf::Errors` and throws an exception instead.

## Test it
Existing unit tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
