### PR TITLE
Use pytest to generate junit xml files for python tests

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -12,4 +12,5 @@ python3-distutils
 python3-ignition-math7
 python3-psutil
 python3-pybind11
+python3-pytest
 ruby-dev

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -137,10 +137,25 @@ if (BUILD_TESTING)
     pyVisual_TEST
     pyWorld_TEST
   )
+  execute_process(COMMAND "${Python3_EXECUTABLE}" -m pytest --version
+    OUTPUT_VARIABLE PYTEST_output
+    ERROR_VARIABLE  PYTEST_error
+    RESULT_VARIABLE PYTEST_result)
+  if(${PYTEST_result} EQUAL 0)
+    set(pytest_FOUND TRUE)
+  else()
+    message("")
+    message(WARNING "Pytest package not available: ${PYTEST_error}")
+  endif()
 
   foreach (test ${python_tests})
-    add_test(NAME ${test}.py COMMAND
-      "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/python/test/${test}.py")
+    if (pytest_FOUND)
+      add_test(NAME ${test}.py COMMAND
+        "${Python3_EXECUTABLE}" -m pytest "${CMAKE_SOURCE_DIR}/python/test/${test}.py" --junitxml "${CMAKE_BINARY_DIR}/test_results/${test}.xml")
+    else()
+      add_test(NAME ${test}.py COMMAND
+        "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/python/test/${test}.py")
+    endif()
     set(_env_vars)
     list(APPEND _env_vars "PYTHONPATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/python/:${CMAKE_BINARY_DIR}/lib:$ENV{PYTHONPATH}")
     list(APPEND _env_vars "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}:$ENV{LD_LIBRARY_PATH}")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Python unit tests currently don't generate junit xml files for consumption by Jenkins. I couldn't find a way to generate these files using the builtin `unittest` python library, so I have added a dependency on `pytest`. If `pytest` is not available, a CMake warning is emitted.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
