### PR TITLE
Document major and minor SDFormat version numbers

### DIFF
--- a/sdf/1.3/root.sdf
+++ b/sdf/1.3/root.sdf
@@ -2,7 +2,15 @@
   <description>SDFormat base element.</description>
 
   <attribute name="version" type="string" default="1.3" required="1">
-    <description>Version number of the SDFormat specification.</description>
+    <description>
+        Version number of the SDFormat specification, consisting of major
+        and minor versions delimited by a `.` character.
+        A major version bump is required if older versions cannot be
+        automatically converted to this version.
+        A minor version bump is required when there are breaking changes that
+        can be handled by the automatic conversion functionality encoded in the
+        `*.convert` files.
+    </description>
   </attribute>
 
   <include filename="world.sdf" required="*"/>

--- a/sdf/1.4/root.sdf
+++ b/sdf/1.4/root.sdf
@@ -2,7 +2,15 @@
   <description>SDFormat base element.</description>
 
   <attribute name="version" type="string" default="1.4" required="1">
-    <description>Version number of the SDFormat specification.</description>
+    <description>
+        Version number of the SDFormat specification, consisting of major
+        and minor versions delimited by a `.` character.
+        A major version bump is required if older versions cannot be
+        automatically converted to this version.
+        A minor version bump is required when there are breaking changes that
+        can be handled by the automatic conversion functionality encoded in the
+        `*.convert` files.
+    </description>
   </attribute>
 
   <include filename="world.sdf" required="*"/>

--- a/sdf/1.5/root.sdf
+++ b/sdf/1.5/root.sdf
@@ -2,7 +2,15 @@
   <description>SDFormat base element.</description>
 
   <attribute name="version" type="string" default="1.5" required="1">
-    <description>Version number of the SDFormat specification.</description>
+    <description>
+        Version number of the SDFormat specification, consisting of major
+        and minor versions delimited by a `.` character.
+        A major version bump is required if older versions cannot be
+        automatically converted to this version.
+        A minor version bump is required when there are breaking changes that
+        can be handled by the automatic conversion functionality encoded in the
+        `*.convert` files.
+    </description>
   </attribute>
 
   <include filename="world.sdf" required="*"/>

--- a/sdf/1.6/root.sdf
+++ b/sdf/1.6/root.sdf
@@ -2,7 +2,15 @@
   <description>SDFormat base element that can include 0-N models, actors, lights, and/or worlds. A user of multiple worlds could run parallel instances of simulation, or offer selection of a world at runtime.</description>
 
   <attribute name="version" type="string" default="1.6" required="1">
-    <description>Version number of the SDFormat specification.</description>
+    <description>
+        Version number of the SDFormat specification, consisting of major
+        and minor versions delimited by a `.` character.
+        A major version bump is required if older versions cannot be
+        automatically converted to this version.
+        A minor version bump is required when there are breaking changes that
+        can be handled by the automatic conversion functionality encoded in the
+        `*.convert` files.
+    </description>
   </attribute>
 
   <include filename="world.sdf" required="*"/>

--- a/sdf/1.7/root.sdf
+++ b/sdf/1.7/root.sdf
@@ -2,7 +2,15 @@
   <description>SDFormat base element that can include 0-N models, actors, lights, and/or worlds. A user of multiple worlds could run parallel instances of simulation, or offer selection of a world at runtime.</description>
 
   <attribute name="version" type="string" default="1.7" required="1">
-    <description>Version number of the SDFormat specification.</description>
+    <description>
+        Version number of the SDFormat specification, consisting of major
+        and minor versions delimited by a `.` character.
+        A major version bump is required if older versions cannot be
+        automatically converted to this version.
+        A minor version bump is required when there are breaking changes that
+        can be handled by the automatic conversion functionality encoded in the
+        `*.convert` files.
+    </description>
   </attribute>
 
   <include filename="world.sdf" required="*"/>

--- a/sdf/1.8/root.sdf
+++ b/sdf/1.8/root.sdf
@@ -2,7 +2,15 @@
   <description>SDFormat base element that can include one model, actor, light, or worlds. A user of multiple worlds could run parallel instances of simulation, or offer selection of a world at runtime.</description>
 
   <attribute name="version" type="string" default="1.8" required="1">
-    <description>Version number of the SDFormat specification.</description>
+    <description>
+        Version number of the SDFormat specification, consisting of major
+        and minor versions delimited by a `.` character.
+        A major version bump is required if older versions cannot be
+        automatically converted to this version.
+        A minor version bump is required when there are breaking changes that
+        can be handled by the automatic conversion functionality encoded in the
+        `*.convert` files.
+    </description>
   </attribute>
 
   <include filename="world.sdf" required="*"/>

--- a/sdf/1.9/root.sdf
+++ b/sdf/1.9/root.sdf
@@ -2,7 +2,15 @@
   <description>SDFormat base element that can include one model, actor, light, or worlds. A user of multiple worlds could run parallel instances of simulation, or offer selection of a world at runtime.</description>
 
   <attribute name="version" type="string" default="1.9" required="1">
-    <description>Version number of the SDFormat specification.</description>
+    <description>
+        Version number of the SDFormat specification, consisting of major
+        and minor versions delimited by a `.` character.
+        A major version bump is required if older versions cannot be
+        automatically converted to this version.
+        A minor version bump is required when there are breaking changes that
+        can be handled by the automatic conversion functionality encoded in the
+        `*.convert` files.
+    </description>
   </attribute>
 
   <include filename="world.sdf" required="*"/>


### PR DESCRIPTION
# 🎉 New feature

Adds documentation of current behavior in support of #1035 

## Summary

Document the current meaning of the major and minor component of the SDFormat specification version. ~~This is a draft while the wording is finalized, and then the changes will then be propagated to the other `sdf/*/root.sdf` files.~~

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
