### PR TITLE
Add SDF::SetRoot and deprecate non-const SDF::Root

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -39,6 +39,10 @@ but with improved human-readability..
    + ***Deprecation:*** bool checkJointParentChildLinkNames(const sdf::Root \*)
    + ***Replacement:*** bool checkJointParentChildNames(const sdf::Root \*)
 
+- **sdf/SDFImpl.hh**:
+   + ***Deprecation:*** void Root(sdf::ElementPtr)
+   + ***Replacement:*** void SetRoot(sdf::ElementPtr)
+
 ## libsdformat 11.x to 12.0
 
 An error is now emitted instead of a warning for a file containing more than

--- a/include/sdf/SDFImpl.hh
+++ b/include/sdf/SDFImpl.hh
@@ -146,7 +146,12 @@ namespace sdf
 
     /// \brief Set the root pointer
     /// \param[in] _root Root element
-    public: void Root(const ElementPtr _root);
+    public: void SetRoot(const ElementPtr _root);
+
+    /// \brief Set the root pointer
+    /// \param[in] _root Root element
+    /// \deprecated Use SetRoot
+    public: GZ_DEPRECATED(13) void Root(const ElementPtr _root);
 
     /// \brief Get the path to the SDF document on disk.
     /// \return The full path to the SDF document.

--- a/src/SDF.cc
+++ b/src/SDF.cc
@@ -367,9 +367,15 @@ ElementPtr SDF::Root() const
 }
 
 /////////////////////////////////////////////////
-void SDF::Root(const ElementPtr _root)
+void SDF::SetRoot(const ElementPtr _root)
 {
   this->dataPtr->root = _root;
+}
+
+/////////////////////////////////////////////////
+void SDF::Root(const ElementPtr _root)
+{
+  this->SetRoot(_root);
 }
 
 /////////////////////////////////////////////////

--- a/src/SDF_TEST.cc
+++ b/src/SDF_TEST.cc
@@ -277,22 +277,21 @@ TEST(SDF, ElementRemoveChild)
 ////////////////////////////////////////////////////
 TEST(SDF, SetRoot)
 {
-  sdf::SDFPtr s;
-  EXPECT_EQ(nullptr, s->Root());
+  sdf::SDF s;
 
   sdf::ElementPtr elem;
   elem.reset(new sdf::Element());
   elem->AddValue("bool", "true", "0", "description");
-  s->SetRoot(elem);
-  EXPECT_EQ(elem, s->Root());
+  s.SetRoot(elem);
+  EXPECT_EQ(elem, s.Root());
 
   // Test deprecated setter, remove in libsdformat14
-  s->SetRoot(nullptr);
-  EXPECT_EQ(nullptr, s->Root());
+  s.SetRoot(nullptr);
+  EXPECT_EQ(nullptr, s.Root());
   GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-  s->Root(elem);
+  s.Root(elem);
   GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
-  EXPECT_EQ(elem, s->Root());
+  EXPECT_EQ(elem, s.Root());
 }
 
 ////////////////////////////////////////////////////

--- a/src/SDF_TEST.cc
+++ b/src/SDF_TEST.cc
@@ -19,6 +19,7 @@
 #include <any>
 #include <gz/math.hh>
 #include <gz/utils/Environment.hh>
+#include <gz/utils/SuppressWarning.hh>
 
 #include "sdf/sdf.hh"
 
@@ -271,6 +272,27 @@ TEST(SDF, ElementRemoveChild)
   // Try to get another model element
   elem = elem->GetNextElement("model");
   EXPECT_FALSE(elem);
+}
+
+////////////////////////////////////////////////////
+TEST(SDF, SetRoot)
+{
+  sdf::SDFPtr s;
+  EXPECT_EQ(nullptr, s->Root());
+
+  sdf::ElementPtr elem;
+  elem.reset(new sdf::Element());
+  elem->AddValue("bool", "true", "0", "description");
+  s->SetRoot(elem);
+  EXPECT_EQ(elem, s->Root());
+
+  // Test deprecated setter, remove in libsdformat14
+  s->SetRoot(nullptr);
+  EXPECT_EQ(nullptr, s->Root());
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  s->Root(elem);
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+  EXPECT_EQ(elem, s->Root());
 }
 
 ////////////////////////////////////////////////////

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1601,7 +1601,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             init(includeSDFTemplate, _config);
           }
           SDFPtr includeSDF(new SDF);
-          includeSDF->Root(includeSDFTemplate->Root()->Clone());
+          includeSDF->SetRoot(includeSDFTemplate->Root()->Clone());
 
           if (!readFile(filename, _config, includeSDF, _errors))
           {

--- a/test/integration/deprecated_specs.cc
+++ b/test/integration/deprecated_specs.cc
@@ -51,7 +51,7 @@ TEST(DeprecatedElements, CanEmitErrors)
   elem->SetRequired("-1");
   elem->SetName("testElem");
   // Change the root of sdf so we can test "testElem" in isolation
-  sdf->Root(elem);
+  sdf->SetRoot(elem);
   auto config = sdf::ParserConfig::GlobalConfig();
   config.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -89,7 +89,7 @@ TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
   elem->SetRequired("-1");
   elem->SetName("testElem");
   // Change the root of sdf so we can test "testElem" in isolation
-  sdf->Root(elem);
+  sdf->SetRoot(elem);
   {
     auto config = sdf::ParserConfig::GlobalConfig();
     config.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);


### PR DESCRIPTION
# 🎉 New feature

Deprecate the setter API that doesn't start with `Set`

## Summary

I just noticed this API that should be called `SetRoot`. I've updated it here, and I don't see it used in other Garden packages, so I don't think this will introduce deprecation warnings.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
