### PR TITLE
Find GzURDFDOM, fix warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if (BUILD_SDF)
   #  2. if USE_INTERNAL_URDF is set to True, use the internal copy
   #  3. if USE_INTERNAL_URDF is set to False, force to search system installation, fail on error
   if (NOT DEFINED USE_INTERNAL_URDF OR NOT USE_INTERNAL_URDF)
-    gz_find_package(GZURDFDOM VERSION 1.0 QUIET)
+    gz_find_package(GzURDFDOM VERSION 1.0 QUIET)
     if (NOT GzURDFDOM_FOUND)
       if (NOT DEFINED USE_INTERNAL_URDF)
         # fallback to internal urdf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,8 @@ if (BUILD_SDF)
   #  2. if USE_INTERNAL_URDF is set to True, use the internal copy
   #  3. if USE_INTERNAL_URDF is set to False, force to search system installation, fail on error
   if (NOT DEFINED USE_INTERNAL_URDF OR NOT USE_INTERNAL_URDF)
-    gz_find_package(IgnURDFDOM VERSION 1.0 QUIET)
-    if (NOT IgnURDFDOM_FOUND)
+    gz_find_package(GZURDFDOM VERSION 1.0 QUIET)
+    if (NOT GzURDFDOM_FOUND)
       if (NOT DEFINED USE_INTERNAL_URDF)
         # fallback to internal urdf
         set(USE_INTERNAL_URDF ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ if (USE_INTERNAL_URDF)
   endif()
 else()
   target_link_libraries(using_parser_urdf INTERFACE
-    IgnURDFDOM::IgnURDFDOM)
+    GzURDFDOM::GzURDFDOM)
 endif()
 
 if (BUILD_TESTING)


### PR DESCRIPTION
# 🦟 Bug fix

Fix deprecation warning from https://github.com/gazebosim/gz-cmake/pull/273



## Summary

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-main-focal-amd64&build=100)](https://build.osrfoundation.org/view/ign-garden/job/sdformat-ci-main-focal-amd64/100/) https://build.osrfoundation.org/view/ign-garden/job/sdformat-ci-main-focal-amd64/100/cmake/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
