### PR TITLE
Test model name as placement_frame

### DIFF
--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -736,9 +736,19 @@ void addEdgesToGraph(ScopedGraph<PoseRelativeToGraph> &_out,
     {
       ignition::math::Pose3d resolvedModelPose = item.rawPose;
 
-      sdf::Errors resolveErrors = resolveModelPoseWithPlacementFrame(
-          item.rawPose, item.placementFrameName,
-          _out.ChildModelScope(item.name), resolvedModelPose);
+      sdf::Errors resolveErrors;
+      if (item.placementFrameName == item.name)
+      {
+        resolveErrors = resolveModelPoseWithPlacementFrame(
+            item.rawPose, _out.ChildModelScope(item.name).ScopeContextName(),
+            _out.ChildModelScope(item.name), resolvedModelPose);
+      }
+      else
+      {
+        resolveErrors = resolveModelPoseWithPlacementFrame(
+            item.rawPose, item.placementFrameName,
+            _out.ChildModelScope(item.name), resolvedModelPose);
+      }
       _errors.insert(_errors.end(), resolveErrors.begin(), resolveErrors.end());
 
       _out.AddEdge({relativeToId, itemId}, resolvedModelPose);

--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -736,19 +736,9 @@ void addEdgesToGraph(ScopedGraph<PoseRelativeToGraph> &_out,
     {
       ignition::math::Pose3d resolvedModelPose = item.rawPose;
 
-      sdf::Errors resolveErrors;
-      if (item.placementFrameName == item.name)
-      {
-        resolveErrors = resolveModelPoseWithPlacementFrame(
-            item.rawPose, _out.ChildModelScope(item.name).ScopeContextName(),
-            _out.ChildModelScope(item.name), resolvedModelPose);
-      }
-      else
-      {
-        resolveErrors = resolveModelPoseWithPlacementFrame(
-            item.rawPose, item.placementFrameName,
-            _out.ChildModelScope(item.name), resolvedModelPose);
-      }
+      sdf::Errors resolveErrors = resolveModelPoseWithPlacementFrame(
+          item.rawPose, item.placementFrameName,
+          _out.ChildModelScope(item.name), resolvedModelPose);
       _errors.insert(_errors.end(), resolveErrors.begin(), resolveErrors.end());
 
       _out.AddEdge({relativeToId, itemId}, resolvedModelPose);

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -988,7 +988,7 @@ class PlacementFrame: public ::testing::Test
     }
     else if constexpr (std::is_same_v<FrameType, sdf::Model>)
     {
-      if (_testFrameName == _model ->Name())
+      if (_testFrameName == "__model__")
       {
         return _model;
       }
@@ -1090,7 +1090,7 @@ TEST_F(PlacementFrame, WorldInclude)
 
   // Test that joint names can be used for <placement_frame>
   this->TestExpectedWorldPose<sdf::Model>("placement_frame_using_model",
-                                          "placement_frame_using_model");
+                                          "__model__");
 
   // Test that the pose of an included model with placement_frame can use the
   // relative_to attribute
@@ -1140,7 +1140,11 @@ TEST_F(PlacementFrame, ModelPlacementFrameAttribute)
 
   // Test that the model name can be used for <placement_frame>
   this->TestExpectedWorldPose<sdf::Model>(
-      "model_with_model_placement_frame", "model_with_model_placement_frame");
+      "model_with_model_placement_frame", "__model__");
+
+  // Test that a nested model can be used for <placement_frame>
+  this->TestExpectedWorldPose<sdf::Model>(
+      "model_with_nested_model_placement_frame", "nested_model");
 
   // Test that the pose of a model with a placement_frame attribute can use the
   // relative_to attribute

--- a/test/sdf/placement_frame.sdf
+++ b/test/sdf/placement_frame.sdf
@@ -34,7 +34,7 @@
     <name>placement_frame_using_model</name>
     <uri>test_model_with_frames</uri>
     <pose>0 10 0 1.570796326794895 0 0</pose>
-    <placement_frame>placement_frame_using_model</placement_frame>
+    <placement_frame>__model__</placement_frame>
   </include>
 
   <frame name='frame_1'>
@@ -79,7 +79,7 @@
       <name>placement_frame_using_model</name>
       <uri>test_model_with_frames</uri>
       <pose>0 10 0 1.570796326794895 0 0</pose>
-      <placement_frame>placement_frame_using_model</placement_frame>
+      <placement_frame>__model__</placement_frame>
     </include>
 
     <include>
@@ -99,11 +99,23 @@
     </link>
   </model>
 
-  <model name='model_with_model_placement_frame' placement_frame='model_with_model_placement_frame'>
+  <model name='model_with_model_placement_frame' placement_frame='__model__'>
     <pose>0 10 0 1.570796326794895 0 0</pose>
     <link name='L4'>
       <pose>0 0 1 0 0 0</pose>
     </link>
+  </model>
+
+  <model name='model_with_nested_model_placement_frame' placement_frame='nested_model'>
+    <pose>0 10 0 1.570796326794895 0 0</pose>
+    <link name='L4'>
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <model name ='nested_model'>
+      <link name='L4'>
+        <pose>0 0 1 0 0 0</pose>
+      </link>
+    </model>
   </model>
 
   <model name='model_with_frame_placement_frame' placement_frame='F2'>

--- a/test/sdf/placement_frame.sdf
+++ b/test/sdf/placement_frame.sdf
@@ -30,6 +30,13 @@
     <placement_frame>J2</placement_frame>
   </include>
 
+  <include>
+    <name>placement_frame_using_model</name>
+    <uri>test_model_with_frames</uri>
+    <pose>0 10 0 1.570796326794895 0 0</pose>
+    <placement_frame>placement_frame_using_model</placement_frame>
+  </include>
+
   <frame name='frame_1'>
     <pose>-1 10 0 1.570796326794895 0 0</pose>
   </frame>
@@ -67,6 +74,14 @@
     <frame name='frame_1'>
       <pose>-1 10 0 1.570796326794895 0 0</pose>
     </frame>
+
+    <include>
+      <name>placement_frame_using_model</name>
+      <uri>test_model_with_frames</uri>
+      <pose>0 10 0 1.570796326794895 0 0</pose>
+      <placement_frame>placement_frame_using_model</placement_frame>
+    </include>
+
     <include>
       <name>nested_include_with_placement_frame_and_pose_relative_to</name>
       <uri>test_model_with_frames</uri>
@@ -78,6 +93,13 @@
 
   <!-- Model placement_frame attribute tests -->
   <model name='model_with_link_placement_frame' placement_frame='L4'>
+    <pose>0 10 0 1.570796326794895 0 0</pose>
+    <link name='L4'>
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+  </model>
+
+  <model name='model_with_model_placement_frame' placement_frame='model_with_model_placement_frame'>
     <pose>0 10 0 1.570796326794895 0 0</pose>
     <link name='L4'>
       <pose>0 0 1 0 0 0</pose>


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🦟 Bug fix

Fixes #1064 

## Summary
This PR makes the changes needed to allow the model name as `placement_frame`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.