### PR TITLE
Remove unused sdf.hh.in template

### DIFF
--- a/include/sdf/sdf.hh.in
+++ b/include/sdf/sdf.hh.in
@@ -1,3 +1,0 @@
-// Automatically generated
-${sdf_headers}
-#include <sdf/sdf_config.h>


### PR DESCRIPTION
# 🦟 Bug fix

Remove unused file.

## Summary

The `sdf.hh.in` header file template has not been used since `sdf10` and up were migrated to use `ign-cmake2`, so it can be safely removed.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
