### PR TITLE
Added Sky Cubemap methods to Python

### DIFF
--- a/python/src/sdf/pySky.cc
+++ b/python/src/sdf/pySky.cc
@@ -66,6 +66,10 @@ void defineSky(pybind11::object module)
          "Get cloud ambient color")
     .def("set_cloud_ambient", &sdf::Sky::SetCloudAmbient,
          "Set cloud ambient color")
+    .def("cubemap_uri", &sdf::Sky::CubemapUri,
+         "Get the skybox texture URI.")
+    .def("set_cubemap_uri", &sdf::Sky::SetCubemapUri,
+         "Set the skybox texture URI.")
     .def("__copy__", [](const sdf::Sky &self) {
       return sdf::Sky(self);
     })

--- a/python/test/pySky_TEST.py
+++ b/python/test/pySky_TEST.py
@@ -30,6 +30,7 @@ class SkyTEST(unittest.TestCase):
         self.assertAlmostEqual(0.5, sky.cloud_humidity())
         self.assertAlmostEqual(0.5, sky.cloud_mean_size())
         self.assertEqual(Color(0.8, 0.8, 0.8), sky.cloud_ambient())
+        self.assertEqual("", sky.cubemap_uri())
 
 
     def test_copy_construction(self):
@@ -42,6 +43,8 @@ class SkyTEST(unittest.TestCase):
         sky.set_cloud_humidity(0.9)
         sky.set_cloud_mean_size(0.123)
         sky.set_cloud_ambient(Color.BLUE)
+        self.assertEqual("", sky.cubemap_uri())
+        sky.set_cubemap_uri("dummyUri");
 
         sky2 = Sky(sky)
         self.assertAlmostEqual(1.0, sky2.time())
@@ -52,6 +55,7 @@ class SkyTEST(unittest.TestCase):
         self.assertAlmostEqual(0.9, sky2.cloud_humidity())
         self.assertAlmostEqual(0.123, sky2.cloud_mean_size())
         self.assertEqual(Color.BLUE, sky2.cloud_ambient())
+        self.assertEqual("dummyUri", sky2.cubemap_uri())
 
 
     def test_assignment(self):
@@ -64,6 +68,7 @@ class SkyTEST(unittest.TestCase):
         sky.set_cloud_humidity(0.9)
         sky.set_cloud_mean_size(0.123)
         sky.set_cloud_ambient(Color.BLUE)
+        sky.set_cubemap_uri("dummyUri");
 
         sky2 = sky
         self.assertAlmostEqual(1.0, sky2.time())
@@ -74,6 +79,7 @@ class SkyTEST(unittest.TestCase):
         self.assertAlmostEqual(0.9, sky2.cloud_humidity())
         self.assertAlmostEqual(0.123, sky2.cloud_mean_size())
         self.assertEqual(Color.BLUE, sky2.cloud_ambient())
+        self.assertEqual("dummyUri", sky2.cubemap_uri())
 
 
     def test_deepcopy(self):
@@ -86,6 +92,7 @@ class SkyTEST(unittest.TestCase):
         sky.set_cloud_humidity(0.9)
         sky.set_cloud_mean_size(0.123)
         sky.set_cloud_ambient(Color.BLUE)
+        sky.set_cubemap_uri("dummyUri");
 
         sky2 = copy.deepcopy(sky)
         self.assertAlmostEqual(1.0, sky2.time())
@@ -96,6 +103,7 @@ class SkyTEST(unittest.TestCase):
         self.assertAlmostEqual(0.9, sky2.cloud_humidity())
         self.assertAlmostEqual(0.123, sky2.cloud_mean_size())
         self.assertEqual(Color.BLUE, sky2.cloud_ambient())
+        self.assertEqual("dummyUri", sky2.cubemap_uri())
 
 
     def test_set(self):
@@ -125,6 +133,8 @@ class SkyTEST(unittest.TestCase):
         sky.set_cloud_ambient(Color(0.1, 0.2, 0.3))
         self.assertEqual(Color(0.1, 0.2, 0.3), sky.cloud_ambient())
 
+        sky.set_cubemap_uri("dummyUri");
+        self.assertEqual("dummyUri", sky.cubemap_uri())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

## Summary

Added Sky Cubemap methods to Python

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
