### PR TITLE
Fix URDF fixed joint reduction of SDF joints

### DIFF
--- a/test/integration/fixed_joint_reduction.cc
+++ b/test/integration/fixed_joint_reduction.cc
@@ -36,6 +36,8 @@ const char SDF_TEST_FILE_COLLISION_VISUAL_EXTENSION_EMPTY_ROOT[] =
     "fixed_joint_reduction_collision_visual_empty_root.urdf";
 const char SDF_TEST_FILE_COLLISION_VISUAL_EXTENSION_EMPTY_ROOT_SDF[] =
     "fixed_joint_reduction_collision_visual_empty_root.sdf";
+const char SDF_TEST_FILE_JOINT_FRAME_EXTENSION[] =
+    "fixed_joint_reduction_joint_frame_extension.urdf";
 const char SDF_TEST_FILE_PLUGIN_FRAME_EXTENSION[] =
     "fixed_joint_reduction_plugin_frame_extension.urdf";
 
@@ -735,6 +737,33 @@ TEST(SDFParser, FixedJointReductionSimple)
     EXPECT_NEAR(ixz, mapIxyIxzIyz[linkName].Y(), gc_tolerance);
     EXPECT_NEAR(iyz, mapIxyIxzIyz[linkName].Z(), gc_tolerance);
   }
+}
+
+/////////////////////////////////////////////////
+// This test uses a urdf that has an SDFormat ball joint embedded in a
+// <gazebo> tag, and the parent link part of a chain of fixed joints
+// that reduces to the base_link.
+// Test to make sure that the parent link name changes appropriately.
+TEST(SDFParser, FixedJointReductionJointFrameExtensionTest)
+{
+  sdf::Root root;
+  auto errors =
+      root.Load(GetFullTestFilePath(SDF_TEST_FILE_JOINT_FRAME_EXTENSION));
+  EXPECT_TRUE(errors.empty()) << errors[0].Message();
+
+  // Get the first model
+  const sdf::Model *model = root.Model();
+  ASSERT_NE(nullptr, model);
+  EXPECT_EQ("chained_fixed_joint_links", model->Name());
+
+  EXPECT_EQ(3u, model->JointCount());
+  const std::string ball_joint_name = "sdf_ball_joint";
+  EXPECT_TRUE(model->JointNameExists(ball_joint_name));
+  const sdf::Joint *joint = model->JointByName(ball_joint_name);
+  ASSERT_NE(nullptr, joint);
+
+  EXPECT_EQ("link3", joint->ChildLinkName());
+  EXPECT_EQ("base_link", joint->ParentLinkName());
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/fixed_joint_reduction_joint_frame_extension.urdf
+++ b/test/integration/fixed_joint_reduction_joint_frame_extension.urdf
@@ -3,7 +3,7 @@
   <gazebo>
     <joint name="sdf_ball_joint" type="ball">
       <parent>link1</parent>
-      <child>link3</child>
+      <child>link4</child>
     </joint>
   </gazebo>
 
@@ -103,6 +103,30 @@
     </inertial>
   </link>
 
+  <!-- Link 4 -->
+  <link name="link4">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="1.0 1.0 1"/>
+      </geometry>
+    </collision>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="0.1 0.1 1"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <origin xyz="0 0 1" rpy="0 0 0"/>
+      <mass value="1"/>
+      <inertia
+        ixx="1.0" ixy="0.0" ixz="0.0"
+        iyy="1.0" iyz="0.0"
+        izz="1.0"/>
+    </inertial>
+  </link>
+
   <!-- Joint 1 -->
   <joint name="joint1" type="fixed">
     <parent link="base_link"/>
@@ -126,6 +150,14 @@
     <child link="link3"/>
     <origin rpy="0 0 0.7854" xyz="0 1.0 0.0"/>
     <axis xyz="0 1 0"/>
+    <dynamics damping="0.7"/>
+  </joint>
+
+  <!-- Joint 4 -->
+  <joint name="joint4" type="fixed">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin rpy="0 0 0.7854" xyz="0 1.0 0.0"/>
     <dynamics damping="0.7"/>
   </joint>
 

--- a/test/integration/fixed_joint_reduction_joint_frame_extension.urdf
+++ b/test/integration/fixed_joint_reduction_joint_frame_extension.urdf
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="chained_fixed_joint_links">
+  <gazebo>
+    <joint name="sdf_ball_joint" type="ball">
+      <parent>link1</parent>
+      <child>link3</child>
+    </joint>
+  </gazebo>
+
+  <!-- Base Link -->
+  <link name="base_link">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="1.0 1.0 1"/>
+      </geometry>
+    </collision>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 1.0"/>
+      <geometry>
+        <box size="0.1 0.1 2"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <origin xyz="0 0 1" rpy="0 0 0"/>
+      <mass value="1"/>
+      <inertia
+        ixx="1.0" ixy="0.0" ixz="0.0"
+        iyy="1.0" iyz="0.0"
+        izz="1.0"/>
+    </inertial>
+  </link>
+
+  <!-- Link 1 -->
+  <link name="link1">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="1.0 1.0 1"/>
+      </geometry>
+    </collision>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="0.1 0.1 1"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <origin xyz="0 0 1" rpy="0 0 0"/>
+      <mass value="1"/>
+      <inertia
+        ixx="1.0" ixy="0.0" ixz="0.0"
+        iyy="1.0" iyz="0.0"
+        izz="1.0"/>
+    </inertial>
+  </link>
+
+  <!-- Link 2 -->
+  <link name="link2">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="1.0 1.0 1"/>
+      </geometry>
+    </collision>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="0.1 0.1 1"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <origin xyz="0 0 1" rpy="0 0 0"/>
+      <mass value="1"/>
+      <inertia
+        ixx="1.0" ixy="0.0" ixz="0.0"
+        iyy="1.0" iyz="0.0"
+        izz="1.0"/>
+    </inertial>
+  </link>
+
+  <!-- Link 3 -->
+  <link name="link3">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="1.0 1.0 1"/>
+      </geometry>
+    </collision>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0.0"/>
+      <geometry>
+        <box size="0.1 0.1 1"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <origin xyz="0 0 1" rpy="0 0 0"/>
+      <mass value="1"/>
+      <inertia
+        ixx="1.0" ixy="0.0" ixz="0.0"
+        iyy="1.0" iyz="0.0"
+        izz="1.0"/>
+    </inertial>
+  </link>
+
+  <!-- Joint 1 -->
+  <joint name="joint1" type="fixed">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin rpy="0 0 0.7854" xyz="0 1.0 0.0"/>
+    <dynamics damping="0.7"/>
+  </joint>
+
+  <!-- Joint 2 -->
+  <joint name="joint2" type="continuous">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin rpy="0 0 0.7854" xyz="0 1.0 0.0"/>
+    <axis xyz="0 1 0"/>
+    <dynamics damping="0.7"/>
+  </joint>
+
+  <!-- Joint 3 -->
+  <joint name="joint3" type="continuous">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin rpy="0 0 0.7854" xyz="0 1.0 0.0"/>
+    <axis xyz="0 1 0"/>
+    <dynamics damping="0.7"/>
+  </joint>
+
+</robot>
+


### PR DESCRIPTION
# 🦟 Bug fix

Part of #746, fixes bug in URDF parsing for libsdformat10+

## Summary

This fixes the `ReduceSDFExtensionJointFrameReplace` function in the URDF parser and in a similar manner to #745. A test is added that fails without the fix in https://github.com/gazebosim/sdformat/commit/5aabef4c32b59dc2644b53e145817c7530fff9c6.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
