### PR TITLE
Install python3-gz-math7 instead of ignition

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -9,7 +9,7 @@ liburdfdom-dev
 libxml2-utils
 python3-dev
 python3-distutils
-python3-ignition-math7
+python3-gz-math7
 python3-psutil
 python3-pybind11
 python3-pytest


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

That `ignition` there messes up with the `sed` command we have searching for `gz` in the install tutorial:

https://github.com/gazebosim/docs/blob/master/garden/install_ubuntu_src.md#install-dependencies

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
