### PR TITLE
Warn by default on unrecognized elements

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -20,6 +20,11 @@ but with improved human-readability..
     + Details about the 1.9 to 1.10 transition are explained below in this same
       document
 
+### Modifications
+
+1. ParserConfig defaults to WARN instead of LOG when parsing unrecognized
+   elements.
+
 ### Deprecations
 
 - The `ignition` namespace is deprecated and will be removed in future versions.

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -36,7 +36,7 @@ class sdf::ParserConfig::Implementation
   /// treated.
   /// Default is to ignore them for compatibility with legacy behavior
   public: EnforcementPolicy unrecognizedElementsPolicy =
-    EnforcementPolicy::LOG;
+    EnforcementPolicy::WARN;
 
   /// \brief Policy indicating how deprecated elements are treated.
   /// Defaults to the value of `warningsPolicy`. It can be overriden by the user

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -65,6 +65,54 @@ std::string custom_exec_str(std::string _cmd)
 }
 
 /////////////////////////////////////////////////
+TEST(checkUnrecognizedElements, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+{
+  std::string pathBase = PROJECT_SOURCE_PATH;
+  pathBase += "/test/sdf";
+
+  // Check an SDFormat file with unrecognized elements
+  {
+    std::string path = pathBase +"/unrecognized_elements.sdf";
+
+    std::string output =
+      custom_exec_str(GzCommand() + " sdf -k " + path + SdfVersion());
+    EXPECT_NE(std::string::npos, output.find(
+        "XML Attribute[some_attribute] in element[model] not defined in SDF."))
+      << output;
+    EXPECT_NE(std::string::npos, output.find(
+        "XML Element[not_a_link_element], child of element[link], not "
+        "defined in SDF."))
+      << output;
+    EXPECT_NE(std::string::npos, output.find(
+        "XML Element[not_a_model_element], child of element[model], not "
+        "defined in SDF."))
+      << output;
+    EXPECT_NE(std::string::npos, output.find(
+        "XML Element[not_an_sdf_element], child of element[sdf], not "
+        "defined in SDF."))
+      << output;
+    EXPECT_NE(std::string::npos, output.find("Valid."))
+      << output;
+  }
+
+  // Check an SDFormat file with unrecognized elements with XML namespaces
+  {
+    std::string path = pathBase +"/unrecognized_elements_with_namespace.sdf";
+
+    std::string output =
+      custom_exec_str(GzCommand() + " sdf -k " + path + SdfVersion());
+    EXPECT_NE(std::string::npos, output.find(
+        "XML Attribute[some_attribute] in element[model] not defined in SDF."))
+      << output;
+    EXPECT_EQ(std::string::npos, output.find(
+        "XML Element["))
+      << output;
+    EXPECT_NE(std::string::npos, output.find("Valid."))
+      << output;
+  }
+}
+
+/////////////////////////////////////////////////
 TEST(check, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 {
   std::string pathBase = PROJECT_SOURCE_PATH;


### PR DESCRIPTION
# 🎉 New feature

Addresses the concern motivating https://github.com/gazebosim/sdformat/issues/1035

## Summary

It is common practice to add elements to a released version of the SDFormat spec without any changes to the spec version number. This results in different versions of the SDFormat specification being embedded in different versions of `libsdformat`. For example, `//material/shininess` was added to SDFormat 1.7 in libsdformat 9.8.0 and to 1.7-1.9 in libsdformat 12.5.0, but the tag is not recognized by libsdformat 12.4.0. I think this can lead to significant user confusion, especially if model and world files begin to proliferate that use elements that aren't recognized by a version of libsdformat shipped with Ubuntu that does not receive feature updates.

I have been brainstorming how to address this concern by adding patch numbers to the SDFormat specification in https://github.com/gazebosim/sdformat/issues/1035, but it's a bit complicated. I think an easier intermediate step would be to generate warnings by default when unrecognized elements are found by the parser, which is what this pull request does.

## Test it

~~~
$ gz sdf --check test/sdf/unrecognized_elements.sdf
Warning [Utils.cc:129] [/sdf/model[@name="joint_incorrect_tags"][@some_attribute="staheousth"]:/Users/scpeters/ws/sdformat/src/sdformat/test/sdf/unrecognized_elements.sdf:L3]: XML Attribute[some_attribute] in element[model] not defined in SDF.
Warning [Utils.cc:129] [/sdf/model[@name="joint_incorrect_tags"]/link[@name="link"]/not_a_link_element:/Users/scpeters/ws/sdformat/src/sdformat/test/sdf/unrecognized_elements.sdf:L6]: XML Element[not_a_link_element], child of element[link], not defined in SDF. Copying[not_a_link_element] as children of [link].
Warning [Utils.cc:129] [/sdf/model[@name="joint_incorrect_tags"]/not_a_model_element:/Users/scpeters/ws/sdformat/src/sdformat/test/sdf/unrecognized_elements.sdf:L8]: XML Element[not_a_model_element], child of element[model], not defined in SDF. Copying[not_a_model_element] as children of [model].
Warning [Utils.cc:129] [/sdf/not_an_sdf_element:/Users/scpeters/ws/sdformat/src/sdformat/test/sdf/unrecognized_elements.sdf:L10]: XML Element[not_an_sdf_element], child of element[sdf], not defined in SDF. Copying[not_an_sdf_element] as children of [sdf].
Valid.
~~~

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
