### PR TITLE
Add Error enums and update Migration guide

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -51,6 +51,10 @@ but with improved human-readability..
 
 ### Removals
 
+- **sdf/InterfaceElements.hh**: The deprecated data members from the
+   `NestedInclude` class have been removed. Instead use the corresponding
+   member functions.
+
 - **sdf/Types.hh**: The `SDF_DEPRECATED` and `SDF_SUPPRESS_*` macros have been
   removed in favor of `GZ_DEPRECATED` and `GZ_UTILS_WARN_*`.
 

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -85,6 +85,9 @@ namespace sdf
     /// expected, and an element of a different type was received.
     ELEMENT_INCORRECT_TYPE,
 
+    /// \brief Generic error type for Elements
+    ELEMENT_ERROR,
+
     /// \brief A URI is invalid.
     URI_INVALID,
 
@@ -134,6 +137,9 @@ namespace sdf
 
     /// \brief The pose relative-to graph has an internal error.
     POSE_RELATIVE_TO_GRAPH_ERROR,
+
+    /// \brief The rotation snap config provided is not valid.
+    ROTATION_SNAP_CONFIG_ERROR,
 
     /// \brief Indicates that reading an SDF string failed.
     STRING_READ,

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -1896,7 +1896,7 @@ TEST(inertial_stats, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   }
 
   expectedOutput =
-          "Error Code 18: Msg: A link named link has invalid inertia.\n\n"
+          "Error Code 19: Msg: A link named link has invalid inertia.\n\n"
           "Inertial statistics for model: model\n"
           "---\n"
           "Total mass of the model: 0\n"


### PR DESCRIPTION
# 🎉 New feature

Includes API-breaking portions of #1095 and #1098

## Summary

I forgot to include an update to the Migration guide for changes in #1097, so I've added that here.

I've also added the API-breaking changes from #1095 and #1098, which are new `enum` values inserted in the middle rather than at the end. If this is not merged in time, they can be appended to the `enum` instead, but the values are more organized this way.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
