### PR TITLE
Make //plugin/@name optional

### DIFF
--- a/sdf/1.9/plugin.sdf
+++ b/sdf/1.9/plugin.sdf
@@ -1,7 +1,7 @@
 <!-- Plugin -->
 <element name="plugin" required="*">
   <description>A plugin is a dynamically loaded chunk of code. It can exist as a child of world, model, and sensor.</description>
-  <attribute name="name" type="string" default="__default__" required="1">
+  <attribute name="name" type="string" default="__default__" required="0">
     <description>A name for the plugin.</description>
   </attribute>
   <attribute name="filename" type="string" default="__default__" required="1">

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -98,11 +98,7 @@ Errors Plugin::Load(ElementPtr _sdf)
   }
 
   // Read the models's name
-  if (!loadName(_sdf, this->dataPtr->name))
-  {
-    errors.push_back({ErrorCode::ATTRIBUTE_MISSING,
-                     "A plugin name is required, but the name is not set."});
-  }
+  loadName(_sdf, this->dataPtr->name);
 
   // Read the filename
   std::pair<std::string, bool> filenamePair =


### PR DESCRIPTION
## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

We started treating plugin names as optional on `gz-sim` since https://github.com/gazebosim/gz-sim/pull/1581. This is just a quick change to suppress errors, but I haven't thought this through yet. I think this should be backwards compatible.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
