### PR TITLE
Make //plugin/@name optional

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -529,6 +529,10 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 
 ## SDFormat specification 1.9 to 1.10
 
+### Modifications
+
+1. **plugin.sdf**: name attribute is now optional.
+
 ## SDFormat specification 1.8 to 1.9
 
 ### Additions

--- a/Migration.md
+++ b/Migration.md
@@ -531,7 +531,7 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 
 ### Modifications
 
-1. **plugin.sdf**: name attribute is now optional.
+1. **plugin.sdf**: name attribute is now optional with empty default value.
 
 ## SDFormat specification 1.8 to 1.9
 

--- a/sdf/1.10/plugin.sdf
+++ b/sdf/1.10/plugin.sdf
@@ -1,7 +1,7 @@
 <!-- Plugin -->
 <element name="plugin" required="*">
   <description>A plugin is a dynamically loaded chunk of code. It can exist as a child of world, model, and sensor.</description>
-  <attribute name="name" type="string" default="__default__" required="1">
+  <attribute name="name" type="string" default="__default__" required="0">
     <description>A name for the plugin.</description>
   </attribute>
   <attribute name="filename" type="string" default="__default__" required="1">

--- a/sdf/1.10/plugin.sdf
+++ b/sdf/1.10/plugin.sdf
@@ -1,7 +1,7 @@
 <!-- Plugin -->
 <element name="plugin" required="*">
   <description>A plugin is a dynamically loaded chunk of code. It can exist as a child of world, model, and sensor.</description>
-  <attribute name="name" type="string" default="__default__" required="0">
+  <attribute name="name" type="string" default="" required="0">
     <description>A name for the plugin.</description>
   </attribute>
   <attribute name="filename" type="string" default="__default__" required="1">

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -98,11 +98,7 @@ Errors Plugin::Load(ElementPtr _sdf)
   }
 
   // Read the models's name
-  if (!loadName(_sdf, this->dataPtr->name))
-  {
-    errors.push_back({ErrorCode::ATTRIBUTE_MISSING,
-                     "A plugin name is required, but the name is not set."});
-  }
+  loadName(_sdf, this->dataPtr->name);
 
   // Read the filename
   std::pair<std::string, bool> filenamePair =

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -180,6 +180,62 @@ TEST(DOMPlugin, Load)
 }
 
 /////////////////////////////////////////////////
+TEST(DOMPlugin, LoadWithoutName)
+{
+  std::string pluginStr = R"(<plugin filename='MinimalScene'>
+  <gz-gui>
+    <title>3D View</title>
+    <property type='Gz.Msgs.Boolean'>false</property>
+    <property type='bool' key='showTitleBar'>0</property>
+    <property type='string' key='state'>docked</property>
+  </gz-gui>
+  <engine>ogre</engine>
+  <scene>scene</scene>
+  <ambient_light>0.4 0.4 0.4</ambient_light>
+  <background_color>0.8 0.8 0.8</background_color>
+  <camera_pose>-6 0 6 0 0.5 0</camera_pose>
+</plugin>
+)";
+
+  std::string pluginStrWithSdf = std::string("<sdf version='1.9'>") +
+    pluginStr + "</sdf>";
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("plugin.sdf", elem);
+  ASSERT_TRUE(sdf::readString(pluginStrWithSdf, elem));
+
+  sdf::Plugin plugin;
+  sdf::Errors errors;
+  errors = plugin.Load(elem);
+  ASSERT_EQ(0u, errors.size());
+
+  EXPECT_TRUE(plugin.Name().empty());
+  EXPECT_EQ("MinimalScene", plugin.Filename());
+
+  // The elements should be the same
+  EXPECT_EQ(elem->ToString(""), plugin.Element()->ToString(""));
+
+  sdf::ElementPtr toElem = plugin.ToElement();
+
+  // The elements should be the same
+  EXPECT_EQ(elem->ToString(""), toElem->ToString(""));
+  EXPECT_EQ(pluginStr, toElem->ToString(""));
+
+  // Test plugin copy
+  sdf::Plugin plugin3;
+  plugin3 = plugin;
+  plugin.ClearContents();
+  sdf::Plugin plugin4(plugin3);
+
+  toElem = plugin3.ToElement();
+  EXPECT_EQ(6u, plugin3.Contents().size());
+  EXPECT_EQ(pluginStr, toElem->ToString(""));
+
+  toElem = plugin4.ToElement();
+  EXPECT_EQ(6u, plugin4.Contents().size());
+  EXPECT_EQ(pluginStr, toElem->ToString(""));
+}
+
+/////////////////////////////////////////////////
 TEST(DOMPlugin, LoadWithChildren)
 {
   std::string pluginStr = R"(<plugin name='3D View' filename='MinimalScene'>

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -160,9 +160,8 @@ TEST(DOMPlugin, Load)
 
   // Missing name and filename attribute
   errors = plugin.Load(sdf);
-  ASSERT_EQ(2u, errors.size());
+  ASSERT_EQ(1u, errors.size()) << errors;
   EXPECT_EQ(sdf::ErrorCode::ATTRIBUTE_MISSING, errors[0].Code());
-  EXPECT_EQ(sdf::ErrorCode::ATTRIBUTE_MISSING, errors[1].Code());
 
   sdf->AddAttribute("name", "string", "__default__", true);
   sdf->GetAttribute("name")->Set<std::string>("my-plugin-name");

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -513,7 +513,7 @@ bool initXml(tinyxml2::XMLElement *_xml,
   const char *requiredString = _xml->Attribute("required");
   if (!requiredString)
   {
-    sdferr << "Element is missing the required attributed\n";
+    sdferr << "Element is missing the required attribute\n";
     return false;
   }
   _sdf->SetRequired(requiredString);


### PR DESCRIPTION
# 🎉 New feature

This retargets #1100 to garden since it looks like a breaking change to the spec to me

## Summary

From #1100:

> We started treating plugin names as optional on `gz-sim` since https://github.com/gazebosim/gz-sim/pull/1581.

I've also changed the default plugin name to be empty, updated the migration guide, and added a test.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
