### PR TITLE
Remove unused macros from config.hh

### DIFF
--- a/include/sdf/config.hh.in
+++ b/include/sdf/config.hh.in
@@ -45,8 +45,6 @@
 
 #define SDF_VERSION_HEADER "Simulation Description Format (SDF), version ${SDF_PROTOCOL_VERSION}\nCopyright (C) 2014 Open Source Robotics Foundation.\nReleased under the Apache 2 License.\nhttp://gazebosim.org/sdf\n\n"
 
-#cmakedefine HAVE_URDFDOM 1
-#cmakedefine USE_INTERNAL_URDF 1
 #cmakedefine SDFORMAT_DISABLE_CONSOLE_LOGFILE 1
 
 #define SDF_SHARE_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/"


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1025 

## Summary

There are still two unused macros in `config.hh.in` as noted in #1025, so remove them.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
