### PR TITLE
Move stream operator implementations to Plugin.cc

### DIFF
--- a/include/sdf/Plugin.hh
+++ b/include/sdf/Plugin.hh
@@ -160,33 +160,13 @@ namespace sdf
     /// \param[in] _out The output stream
     /// \param[in] _plugin Plugin to output
     public: friend std::ostream &operator<<(std::ostream& _out,
-                                            const sdf::Plugin &_plugin)
-    {
-      return _out << _plugin.ToElement()->ToString("");
-    }
+                                            const sdf::Plugin &_plugin);
 
     /// \brief Input stream operator for a Plugin.
     /// \param[in] _out The output stream
     /// \param[in] _plugin Plugin to output
     public: friend std::istream &operator>>(std::istream &_in,
-                                            sdf::Plugin &_plugin)
-    {
-      std::ostringstream stream;
-      stream << "<sdf version='" << SDF_VERSION << "'>";
-      stream << std::string(std::istreambuf_iterator<char>(_in), {});
-      stream << "</sdf>";
-
-      sdf::SDFPtr sdfParsed(new sdf::SDF());
-      sdf::init(sdfParsed);
-      bool result = sdf::readString(stream.str(), sdfParsed);
-      if (!result)
-        return _in;
-
-      _plugin.ClearContents();
-      _plugin.Load(sdfParsed->Root()->GetFirstElement());
-
-      return _in;
-    }
+                                            sdf::Plugin &_plugin);
 
     /// \brief Private data pointer.
     std::unique_ptr<sdf::PluginPrivate> dataPtr;
@@ -194,6 +174,12 @@ namespace sdf
 
   /// \brief A vector of Plugin.
   using Plugins = std::vector<Plugin>;
+
+  SDFORMAT_VISIBLE std::ostream &operator<<(std::ostream& _out,
+                                            const sdf::Plugin &_plugin);
+
+  SDFORMAT_VISIBLE std::istream &operator>>(std::istream &_in,
+                                            sdf::Plugin &_plugin);
 }
 }
 

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -272,3 +272,30 @@ bool Plugin::operator!=(const Plugin &_plugin) const
 {
   return !(*this == _plugin);
 }
+
+/////////////////////////////////////////////////
+std::ostream &sdf::operator<<(std::ostream& _out,
+                              const sdf::Plugin &_plugin)
+{
+  return _out << _plugin.ToElement()->ToString("");
+}
+
+/////////////////////////////////////////////////
+std::istream &sdf::operator>>(std::istream &_in, sdf::Plugin &_plugin)
+{
+  std::ostringstream stream;
+  stream << "<sdf version='" << SDF_VERSION << "'>";
+  stream << std::string(std::istreambuf_iterator<char>(_in), {});
+  stream << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  bool result = sdf::readString(stream.str(), sdfParsed);
+  if (!result)
+    return _in;
+
+  _plugin.ClearContents();
+  _plugin.Load(sdfParsed->Root()->GetFirstElement());
+
+  return _in;
+}


### PR DESCRIPTION
# 🦟 Bug fix

Split out from #1021.

## Summary

This moves stream operator implementations from `Plugin.hh` to `Plugin.cc`. It was included in #1021, but there are strange ABI complaints, so I'm targeting it as a separate pull request.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
