### PR TITLE
urdf: fix sensor/light pose for links lumped by fixed joints

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,15 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## libsdformat 9.8.0 to 9.8.1
+
+### Modifications
+
+1. URDF parser now properly transforms poses for lights, projectors and sensors
+   from gazebo extension tags that are moved to a new link during fixed joint
+   reduction.
+    + [pull request 1114](https://github.com/osrf/sdformat/pull/1114)
+
 ## libsdformat 9.4 to 9.5
 
 ### Additions

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2539,11 +2539,12 @@ void ReduceSDFExtensionsTransform(SDFExtensionPtr _ge)
   for (std::vector<TiXmlElementPtr>::iterator blobIt = _ge->blobs.begin();
        blobIt != _ge->blobs.end(); ++blobIt)
   {
-    /// @todo make sure we are not missing any additional transform reductions
     ReduceSDFExtensionElementTransformReduction(
-        blobIt, _ge->reductionTransform, "sensor");
+        blobIt, _ge->reductionTransform, "light");
     ReduceSDFExtensionElementTransformReduction(
         blobIt, _ge->reductionTransform, "projector");
+    ReduceSDFExtensionElementTransformReduction(
+        blobIt, _ge->reductionTransform, "sensor");
   }
 }
 

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -395,8 +395,8 @@ void ReduceVisualToParent(urdf::LinkSharedPtr _parentLink,
 // collision elements of the child link into the parent link
 void ReduceFixedJoints(TiXmlElement *_root, urdf::LinkSharedPtr _link)
 {
-  // if child is attached to self by fixed _link first go up the tree,
-  //   check it's children recursively
+  // if child is attached to self by fixed joint first go up the tree,
+  //   check its children recursively
   for (unsigned int i = 0 ; i < _link->child_links.size() ; ++i)
   {
     if (FixedJointShouldBeReduced(_link->child_links[i]->parent_joint))

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -3282,8 +3282,8 @@ void ReduceSDFExtensionElementTransformReduction(
     const ignition::math::Pose3d &_reductionTransform,
     const std::string &_elementName)
 {
-  // overwrite <xyz> and <rpy> if they exist
-  if ((*_blobIt)->ValueStr() == _elementName)
+  auto element = *_blobIt;
+  if (element->ValueStr() == _elementName)
   {
     // parse it and add/replace the reduction transform
     // find first instance of xyz and rpy, replace with reduction transform
@@ -3298,12 +3298,12 @@ void ReduceSDFExtensionElementTransformReduction(
     // }
 
     {
-      TiXmlNode* oldPoseKey = (*_blobIt)->FirstChild("pose");
+      TiXmlNode* oldPoseKey = element->FirstChild("pose");
       /// @todo: FIXME:  we should read xyz, rpy and aggregate it to
       /// reductionTransform instead of just throwing the info away.
       if (oldPoseKey)
       {
-        (*_blobIt)->RemoveChild(oldPoseKey);
+        element->RemoveChild(oldPoseKey);
       }
     }
 
@@ -3329,7 +3329,7 @@ void ReduceSDFExtensionElementTransformReduction(
     TiXmlElement* poseKey = new TiXmlElement("pose");
     poseKey->LinkEndChild(poseTxt);
 
-    (*_blobIt)->LinkEndChild(poseKey);
+    element->LinkEndChild(poseKey);
   }
 }
 

--- a/test/integration/urdf_gazebo_extensions.cc
+++ b/test/integration/urdf_gazebo_extensions.cc
@@ -135,4 +135,163 @@ TEST(SDFParser, UrdfGazeboExtensionURDFTest)
       EXPECT_FALSE(link->HasElement("velocity_decay"));
     }
   }
+
+  sdf::ElementPtr link0;
+  for (sdf::ElementPtr link = model->GetElement("link"); link;
+       link = link->GetNextElement("link"))
+  {
+    const auto& linkName = link->Get<std::string>("name");
+    if (linkName == "link0")
+    {
+      link0 = link;
+      break;
+    }
+  }
+  ASSERT_TRUE(link0);
+
+  bool foundSensorNoPose {false};
+  bool foundSensorPose {false};
+  bool foundSensorPoseRelative {false};
+  bool foundSensorPoseTwoLevel {false};
+  bool foundIssue378Sensor {false};
+  bool foundIssue67Sensor {false};
+
+  for (sdf::ElementPtr sensor = link0->GetElement("sensor"); sensor;
+       sensor = sensor->GetNextElement("sensor"))
+  {
+    const auto& sensorName = sensor->Get<std::string>("name");
+    if (sensorName == "sensorNoPose")
+    {
+      foundSensorNoPose = true;
+      EXPECT_TRUE(sensor->HasElement("pose"));
+      const auto poseElem = sensor->GetElement("pose");
+
+      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+        "", ignition::math::Pose3d::Zero);
+      ASSERT_TRUE(posePair.second);
+
+      const auto& pose = posePair.first;
+
+      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+      EXPECT_DOUBLE_EQ(pose.Y(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
+      EXPECT_NEAR(pose.Yaw(), IGN_PI_2, 1e-5);
+
+      EXPECT_FALSE(poseElem->GetNextElement("pose"));
+    }
+    else if (sensorName == "sensorPose")
+    {
+      foundSensorPose = true;
+      EXPECT_TRUE(sensor->HasElement("pose"));
+      const auto poseElem = sensor->GetElement("pose");
+
+      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+        "", ignition::math::Pose3d::Zero);
+      ASSERT_TRUE(posePair.second);
+
+      const auto& pose = posePair.first;
+
+      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+      EXPECT_DOUBLE_EQ(pose.Y(), 111.0);
+      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
+      EXPECT_NEAR(pose.Yaw(), IGN_PI_2 - 1, 1e-5);
+
+      EXPECT_FALSE(poseElem->GetNextElement("pose"));
+    }
+    else if (sensorName == "sensorPoseRelative")
+    {
+      foundSensorPoseRelative = true;
+      EXPECT_TRUE(sensor->HasElement("pose"));
+      const auto poseElem = sensor->GetElement("pose");
+
+      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+        "", ignition::math::Pose3d::Zero);
+      ASSERT_TRUE(posePair.second);
+
+      const auto& pose = posePair.first;
+
+      EXPECT_DOUBLE_EQ(pose.X(), 111.0);
+      EXPECT_DOUBLE_EQ(pose.Y(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
+      EXPECT_NEAR(pose.Yaw(), -1, 1e-5);
+
+      EXPECT_FALSE(poseElem->GetNextElement("pose"));
+    }
+    else if (sensorName == "sensorPoseTwoLevel")
+    {
+      foundSensorPoseTwoLevel = true;
+      EXPECT_TRUE(sensor->HasElement("pose"));
+      const auto poseElem = sensor->GetElement("pose");
+
+      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+        "", ignition::math::Pose3d::Zero);
+      ASSERT_TRUE(posePair.second);
+
+      const auto& pose = posePair.first;
+
+      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+      EXPECT_DOUBLE_EQ(pose.Y(), 111.0);
+      EXPECT_DOUBLE_EQ(pose.Z(), 222.0);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
+      EXPECT_NEAR(pose.Yaw(), IGN_PI_2 - 1, 1e-5);
+
+      EXPECT_FALSE(poseElem->GetNextElement("pose"));
+    }
+    else if (sensorName == "issue378_sensor")
+    {
+      foundIssue378Sensor = true;
+      EXPECT_TRUE(sensor->HasElement("pose"));
+      const auto poseElem = sensor->GetElement("pose");
+
+      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+        "", ignition::math::Pose3d::Zero);
+      ASSERT_TRUE(posePair.second);
+
+      const auto& pose = posePair.first;
+
+      EXPECT_DOUBLE_EQ(pose.X(), 1);
+      EXPECT_DOUBLE_EQ(pose.Y(), 2);
+      EXPECT_DOUBLE_EQ(pose.Z(), 3);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.1);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.2);
+      EXPECT_DOUBLE_EQ(pose.Yaw(), 0.3);
+
+      EXPECT_FALSE(poseElem->GetNextElement("pose"));
+    }
+    else if (sensorName == "issue67_sensor")
+    {
+      foundIssue67Sensor = true;
+      EXPECT_TRUE(sensor->HasElement("pose"));
+      const auto poseElem = sensor->GetElement("pose");
+
+      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+        "", ignition::math::Pose3d::Zero);
+      ASSERT_TRUE(posePair.second);
+
+      const auto& pose = posePair.first;
+
+      EXPECT_GT(std::abs(pose.X() - (-0.20115)), 0.1);
+      EXPECT_GT(std::abs(pose.Y() - 0.42488), 0.1);
+      EXPECT_GT(std::abs(pose.Z() - 0.30943), 0.1);
+      EXPECT_GT(std::abs(pose.Roll() - 1.5708), 0.1);
+      EXPECT_GT(std::abs(pose.Pitch() - (-0.89012)), 0.1);
+      EXPECT_GT(std::abs(pose.Yaw() - 1.5708), 0.1);
+
+      EXPECT_FALSE(poseElem->GetNextElement("pose"));
+    }
+  }
+
+  EXPECT_TRUE(foundSensorNoPose);
+  EXPECT_TRUE(foundSensorPose);
+  EXPECT_TRUE(foundSensorPoseRelative);
+  EXPECT_TRUE(foundSensorPoseTwoLevel);
+  EXPECT_TRUE(foundIssue378Sensor);
+  EXPECT_TRUE(foundIssue67Sensor);
 }

--- a/test/integration/urdf_gazebo_extensions.cc
+++ b/test/integration/urdf_gazebo_extensions.cc
@@ -149,149 +149,156 @@ TEST(SDFParser, UrdfGazeboExtensionURDFTest)
   }
   ASSERT_TRUE(link0);
 
-  bool foundSensorNoPose {false};
-  bool foundSensorPose {false};
-  bool foundSensorPoseRelative {false};
-  bool foundSensorPoseTwoLevel {false};
-  bool foundIssue378Sensor {false};
-  bool foundIssue67Sensor {false};
-
-  for (sdf::ElementPtr sensor = link0->GetElement("sensor"); sensor;
-       sensor = sensor->GetNextElement("sensor"))
+  auto checkElementPoses = [&](const std::string &_elementName) -> void
   {
-    const auto& sensorName = sensor->Get<std::string>("name");
-    if (sensorName == "sensorNoPose")
+    bool foundElementNoPose {false};
+    bool foundElementPose {false};
+    bool foundElementPoseRelative {false};
+    bool foundElementPoseTwoLevel {false};
+    bool foundIssue378Element {false};
+    bool foundIssue67Element {false};
+
+    for (sdf::ElementPtr element = link0->GetElement(_elementName); element;
+         element = element->GetNextElement(_elementName))
     {
-      foundSensorNoPose = true;
-      EXPECT_TRUE(sensor->HasElement("pose"));
-      const auto poseElem = sensor->GetElement("pose");
+      const auto& elementName = element->Get<std::string>("name");
+      if (elementName == _elementName + "NoPose")
+      {
+        foundElementNoPose = true;
+        EXPECT_TRUE(element->HasElement("pose"));
+        const auto poseElem = element->GetElement("pose");
 
-      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
-        "", ignition::math::Pose3d::Zero);
-      ASSERT_TRUE(posePair.second);
+        const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+          "", ignition::math::Pose3d::Zero);
+        ASSERT_TRUE(posePair.second);
 
-      const auto& pose = posePair.first;
+        const auto& pose = posePair.first;
 
-      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
-      EXPECT_DOUBLE_EQ(pose.Y(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
-      EXPECT_NEAR(pose.Yaw(), IGN_PI_2, 1e-5);
+        EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+        EXPECT_DOUBLE_EQ(pose.Y(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
+        EXPECT_NEAR(pose.Yaw(), IGN_PI_2, 1e-5);
 
-      EXPECT_FALSE(poseElem->GetNextElement("pose"));
+        EXPECT_FALSE(poseElem->GetNextElement("pose"));
+      }
+      else if (elementName == _elementName + "Pose")
+      {
+        foundElementPose = true;
+        EXPECT_TRUE(element->HasElement("pose"));
+        const auto poseElem = element->GetElement("pose");
+
+        const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+          "", ignition::math::Pose3d::Zero);
+        ASSERT_TRUE(posePair.second);
+
+        const auto& pose = posePair.first;
+
+        EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+        EXPECT_DOUBLE_EQ(pose.Y(), 111.0);
+        EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
+        EXPECT_NEAR(pose.Yaw(), IGN_PI_2 - 1, 1e-5);
+
+        EXPECT_FALSE(poseElem->GetNextElement("pose"));
+      }
+      else if (elementName == _elementName + "PoseRelative")
+      {
+        foundElementPoseRelative = true;
+        EXPECT_TRUE(element->HasElement("pose"));
+        const auto poseElem = element->GetElement("pose");
+
+        const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+          "", ignition::math::Pose3d::Zero);
+        ASSERT_TRUE(posePair.second);
+
+        const auto& pose = posePair.first;
+
+        EXPECT_DOUBLE_EQ(pose.X(), 111.0);
+        EXPECT_DOUBLE_EQ(pose.Y(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
+        EXPECT_NEAR(pose.Yaw(), -1, 1e-5);
+
+        EXPECT_FALSE(poseElem->GetNextElement("pose"));
+      }
+      else if (elementName == _elementName + "PoseTwoLevel")
+      {
+        foundElementPoseTwoLevel = true;
+        EXPECT_TRUE(element->HasElement("pose"));
+        const auto poseElem = element->GetElement("pose");
+
+        const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+          "", ignition::math::Pose3d::Zero);
+        ASSERT_TRUE(posePair.second);
+
+        const auto& pose = posePair.first;
+
+        EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+        EXPECT_DOUBLE_EQ(pose.Y(), 111.0);
+        EXPECT_DOUBLE_EQ(pose.Z(), 222.0);
+        EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+        EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
+        EXPECT_NEAR(pose.Yaw(), IGN_PI_2 - 1, 1e-5);
+
+        EXPECT_FALSE(poseElem->GetNextElement("pose"));
+      }
+      else if (elementName == "issue378_" + _elementName)
+      {
+        foundIssue378Element = true;
+        EXPECT_TRUE(element->HasElement("pose"));
+        const auto poseElem = element->GetElement("pose");
+
+        const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+          "", ignition::math::Pose3d::Zero);
+        ASSERT_TRUE(posePair.second);
+
+        const auto& pose = posePair.first;
+
+        EXPECT_DOUBLE_EQ(pose.X(), 1);
+        EXPECT_DOUBLE_EQ(pose.Y(), 2);
+        EXPECT_DOUBLE_EQ(pose.Z(), 3);
+        EXPECT_DOUBLE_EQ(pose.Roll(), 0.1);
+        EXPECT_DOUBLE_EQ(pose.Pitch(), 0.2);
+        EXPECT_DOUBLE_EQ(pose.Yaw(), 0.3);
+
+        EXPECT_FALSE(poseElem->GetNextElement("pose"));
+      }
+      else if (elementName == "issue67_" + _elementName)
+      {
+        foundIssue67Element = true;
+        EXPECT_TRUE(element->HasElement("pose"));
+        const auto poseElem = element->GetElement("pose");
+
+        const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
+          "", ignition::math::Pose3d::Zero);
+        ASSERT_TRUE(posePair.second);
+
+        const auto& pose = posePair.first;
+
+        EXPECT_GT(std::abs(pose.X() - (-0.20115)), 0.1);
+        EXPECT_GT(std::abs(pose.Y() - 0.42488), 0.1);
+        EXPECT_GT(std::abs(pose.Z() - 0.30943), 0.1);
+        EXPECT_GT(std::abs(pose.Roll() - 1.5708), 0.1);
+        EXPECT_GT(std::abs(pose.Pitch() - (-0.89012)), 0.1);
+        EXPECT_GT(std::abs(pose.Yaw() - 1.5708), 0.1);
+
+        EXPECT_FALSE(poseElem->GetNextElement("pose"));
+      }
     }
-    else if (sensorName == "sensorPose")
-    {
-      foundSensorPose = true;
-      EXPECT_TRUE(sensor->HasElement("pose"));
-      const auto poseElem = sensor->GetElement("pose");
 
-      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
-        "", ignition::math::Pose3d::Zero);
-      ASSERT_TRUE(posePair.second);
+    EXPECT_TRUE(foundElementNoPose) << _elementName;
+    EXPECT_TRUE(foundElementPose) << _elementName;
+    EXPECT_TRUE(foundElementPoseRelative) << _elementName;
+    EXPECT_TRUE(foundElementPoseTwoLevel) << _elementName;
+    EXPECT_TRUE(foundIssue378Element) << _elementName;
+    EXPECT_TRUE(foundIssue67Element) << _elementName;
+  };
 
-      const auto& pose = posePair.first;
-
-      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
-      EXPECT_DOUBLE_EQ(pose.Y(), 111.0);
-      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
-      EXPECT_NEAR(pose.Yaw(), IGN_PI_2 - 1, 1e-5);
-
-      EXPECT_FALSE(poseElem->GetNextElement("pose"));
-    }
-    else if (sensorName == "sensorPoseRelative")
-    {
-      foundSensorPoseRelative = true;
-      EXPECT_TRUE(sensor->HasElement("pose"));
-      const auto poseElem = sensor->GetElement("pose");
-
-      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
-        "", ignition::math::Pose3d::Zero);
-      ASSERT_TRUE(posePair.second);
-
-      const auto& pose = posePair.first;
-
-      EXPECT_DOUBLE_EQ(pose.X(), 111.0);
-      EXPECT_DOUBLE_EQ(pose.Y(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
-      EXPECT_NEAR(pose.Yaw(), -1, 1e-5);
-
-      EXPECT_FALSE(poseElem->GetNextElement("pose"));
-    }
-    else if (sensorName == "sensorPoseTwoLevel")
-    {
-      foundSensorPoseTwoLevel = true;
-      EXPECT_TRUE(sensor->HasElement("pose"));
-      const auto poseElem = sensor->GetElement("pose");
-
-      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
-        "", ignition::math::Pose3d::Zero);
-      ASSERT_TRUE(posePair.second);
-
-      const auto& pose = posePair.first;
-
-      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
-      EXPECT_DOUBLE_EQ(pose.Y(), 111.0);
-      EXPECT_DOUBLE_EQ(pose.Z(), 222.0);
-      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
-      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
-      EXPECT_NEAR(pose.Yaw(), IGN_PI_2 - 1, 1e-5);
-
-      EXPECT_FALSE(poseElem->GetNextElement("pose"));
-    }
-    else if (sensorName == "issue378_sensor")
-    {
-      foundIssue378Sensor = true;
-      EXPECT_TRUE(sensor->HasElement("pose"));
-      const auto poseElem = sensor->GetElement("pose");
-
-      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
-        "", ignition::math::Pose3d::Zero);
-      ASSERT_TRUE(posePair.second);
-
-      const auto& pose = posePair.first;
-
-      EXPECT_DOUBLE_EQ(pose.X(), 1);
-      EXPECT_DOUBLE_EQ(pose.Y(), 2);
-      EXPECT_DOUBLE_EQ(pose.Z(), 3);
-      EXPECT_DOUBLE_EQ(pose.Roll(), 0.1);
-      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.2);
-      EXPECT_DOUBLE_EQ(pose.Yaw(), 0.3);
-
-      EXPECT_FALSE(poseElem->GetNextElement("pose"));
-    }
-    else if (sensorName == "issue67_sensor")
-    {
-      foundIssue67Sensor = true;
-      EXPECT_TRUE(sensor->HasElement("pose"));
-      const auto poseElem = sensor->GetElement("pose");
-
-      const auto& posePair = poseElem->Get<ignition::math::Pose3d>(
-        "", ignition::math::Pose3d::Zero);
-      ASSERT_TRUE(posePair.second);
-
-      const auto& pose = posePair.first;
-
-      EXPECT_GT(std::abs(pose.X() - (-0.20115)), 0.1);
-      EXPECT_GT(std::abs(pose.Y() - 0.42488), 0.1);
-      EXPECT_GT(std::abs(pose.Z() - 0.30943), 0.1);
-      EXPECT_GT(std::abs(pose.Roll() - 1.5708), 0.1);
-      EXPECT_GT(std::abs(pose.Pitch() - (-0.89012)), 0.1);
-      EXPECT_GT(std::abs(pose.Yaw() - 1.5708), 0.1);
-
-      EXPECT_FALSE(poseElem->GetNextElement("pose"));
-    }
-  }
-
-  EXPECT_TRUE(foundSensorNoPose);
-  EXPECT_TRUE(foundSensorPose);
-  EXPECT_TRUE(foundSensorPoseRelative);
-  EXPECT_TRUE(foundSensorPoseTwoLevel);
-  EXPECT_TRUE(foundIssue378Sensor);
-  EXPECT_TRUE(foundIssue67Sensor);
+  checkElementPoses("light");
+  checkElementPoses("projector");
+  checkElementPoses("sensor");
 }

--- a/test/integration/urdf_gazebo_extensions.urdf
+++ b/test/integration/urdf_gazebo_extensions.urdf
@@ -150,4 +150,182 @@
     </visual>
   </link>
 
+  <!-- Test lumping of sensors with <pose> tags. -->
+
+  <link name="linkSensorNoPose">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorNoPose" type="fixed">
+    <origin rpy="0 0 1.57079632679" xyz="333 0 0"/>
+    <parent link="link0"/>
+    <child link="linkSensorNoPose"/>
+  </joint>
+  <gazebo reference="linkSensorNoPose">
+    <sensor name="sensorNoPose" type="camera">
+      <update_rate>6.0</update_rate>
+      <camera name="cam">
+        <horizontal_fov>1.36869112579</horizontal_fov>
+        <image>
+          <width>1232</width>
+          <height>1616</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+      </camera>
+    </sensor>
+  </gazebo>
+
+  <link name="linkSensorPose">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorPose" type="fixed">
+    <origin rpy="0 0 1.57079632679" xyz="333 0 0"/>
+    <parent link="link0"/>
+    <child link="linkSensorPose"/>
+  </joint>
+  <gazebo reference="linkSensorPose">
+    <sensor name="sensorPose" type="camera">
+      <pose>111 0 0 0 0 -1</pose>
+      <update_rate>6.0</update_rate>
+      <camera name="cam">
+        <horizontal_fov>1.36869112579</horizontal_fov>
+        <image>
+          <width>1232</width>
+          <height>1616</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+      </camera>
+    </sensor>
+  </gazebo>
+
+  <link name="linkSensorPoseRelative">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorPoseRelative" type="fixed">
+    <origin rpy="0 0 1.57079632679" xyz="333 0 0"/>
+    <parent link="link0"/>
+    <child link="linkSensorPoseRelative"/>
+  </joint>
+  <gazebo reference="linkSensorPoseRelative">
+    <sensor name="sensorPoseRelative" type="camera">
+      <pose relative_to="link0">111 0 0 0 0 -1</pose>
+      <update_rate>6.0</update_rate>
+      <camera name="cam">
+        <horizontal_fov>1.36869112579</horizontal_fov>
+        <image>
+          <width>1232</width>
+          <height>1616</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+      </camera>
+    </sensor>
+  </gazebo>
+
+  <link name="linkSensorPoseTwoLevel">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorPoseTwoLevel" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 222"/>
+    <parent link="link0"/>
+    <child link="linkSensorPoseTwoLevel"/>
+  </joint>
+  <link name="linkSensorPoseTwoLevel2">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorPoseTwoLevel2" type="fixed">
+    <origin rpy="0 0 1.57079632679" xyz="333 0 0"/>
+    <parent link="linkSensorPoseTwoLevel"/>
+    <child link="linkSensorPoseTwoLevel2"/>
+  </joint>
+  <gazebo reference="linkSensorPoseTwoLevel2">
+    <sensor name="sensorPoseTwoLevel" type="camera">
+      <pose twoLevel_to="link0">111 0 0 0 0 -1</pose>
+      <update_rate>6.0</update_rate>
+      <camera name="cam">
+        <horizontal_fov>1.36869112579</horizontal_fov>
+        <image>
+          <width>1232</width>
+          <height>1616</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+      </camera>
+    </sensor>
+  </gazebo>
+
+  <!-- Issue 378 setting -->
+  <gazebo reference="issue378_link">
+    <sensor name="issue378_sensor" type="imu">
+      <always_on>1</always_on>
+      <update_rate>400</update_rate>
+      <pose>1.0 2.0 3.0 0.1 0.2 0.3</pose>
+    </sensor>
+  </gazebo>
+  <link name="issue378_link"/>
+  <joint name="issue378_link_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 -0 0"/>
+    <axis xyz="0 0 0"/>
+    <parent link="link0"/>
+    <child link="issue378_link"/>
+  </joint>
+
+  <!-- Issue 67 setting -->
+  <link name="Camera">
+    <inertial>
+      <origin xyz="-7.4418E-06 0.0043274 -0.010112" rpy="0 0 0"/>
+      <mass value="0.10621"/>
+      <inertia ixx="7.3134E-05" ixy="7.9651E-09" ixz="-8.9146E-09"
+              iyy="3.0769E-05" iyz="-3.9082E-06"
+              izz="9.2194E-05"/>
+    </inertial>
+  </link>
+  <joint name="jCamera" type="fixed">
+    <origin xyz="-0.20115 0.42488 0.30943" rpy="1.5708 -0.89012 1.5708"/>
+    <parent link="link0"/>
+    <child link="Camera"/>
+    <axis xyz="0 0 0"/>
+  </joint>
+  <gazebo reference="Camera">
+    <sensor name="issue67_sensor" type="camera">
+      <visualize>true</visualize>
+      <pose>1 1 1 1.570796 1.570796 1.570796</pose>
+      <camera>
+      </camera>
+    </sensor>
+  </gazebo>
+
 </robot>

--- a/test/integration/urdf_gazebo_extensions.urdf
+++ b/test/integration/urdf_gazebo_extensions.urdf
@@ -165,6 +165,8 @@
     <child link="linkSensorNoPose"/>
   </joint>
   <gazebo reference="linkSensorNoPose">
+    <light name="lightNoPose" type="point"/>
+    <projector name="projectorNoPose"/>
     <sensor name="sensorNoPose" type="camera">
       <update_rate>6.0</update_rate>
       <camera name="cam">
@@ -195,6 +197,12 @@
     <child link="linkSensorPose"/>
   </joint>
   <gazebo reference="linkSensorPose">
+    <light name="lightPose" type="point">
+      <pose>111 0 0 0 0 -1</pose>
+    </light>
+    <projector name="projectorPose">
+      <pose>111 0 0 0 0 -1</pose>
+    </projector>
     <sensor name="sensorPose" type="camera">
       <pose>111 0 0 0 0 -1</pose>
       <update_rate>6.0</update_rate>
@@ -226,6 +234,12 @@
     <child link="linkSensorPoseRelative"/>
   </joint>
   <gazebo reference="linkSensorPoseRelative">
+    <light name="lightPoseRelative" type="point">
+      <pose relative_to="link0">111 0 0 0 0 -1</pose>
+    </light>
+    <projector name="projectorPoseRelative">
+      <pose relative_to="link0">111 0 0 0 0 -1</pose>
+    </projector>
     <sensor name="sensorPoseRelative" type="camera">
       <pose relative_to="link0">111 0 0 0 0 -1</pose>
       <update_rate>6.0</update_rate>
@@ -269,8 +283,17 @@
     <child link="linkSensorPoseTwoLevel2"/>
   </joint>
   <gazebo reference="linkSensorPoseTwoLevel2">
+    <light name="lightPoseTwoLevel" type="point">
+      <!-- TwoLevel to link0 -->
+      <pose>111 0 0 0 0 -1</pose>
+    </light>
+    <projector name="projectorPoseTwoLevel">
+      <!-- TwoLevel to link0 -->
+      <pose>111 0 0 0 0 -1</pose>
+    </projector>
     <sensor name="sensorPoseTwoLevel" type="camera">
-      <pose twoLevel_to="link0">111 0 0 0 0 -1</pose>
+      <!-- TwoLevel to link0 -->
+      <pose>111 0 0 0 0 -1</pose>
       <update_rate>6.0</update_rate>
       <camera name="cam">
         <horizontal_fov>1.36869112579</horizontal_fov>
@@ -289,6 +312,12 @@
 
   <!-- Issue 378 setting -->
   <gazebo reference="issue378_link">
+    <light name="issue378_light" type="point">
+      <pose>1.0 2.0 3.0 0.1 0.2 0.3</pose>
+    </light>
+    <projector name="issue378_projector">
+      <pose>1.0 2.0 3.0 0.1 0.2 0.3</pose>
+    </projector>
     <sensor name="issue378_sensor" type="imu">
       <always_on>1</always_on>
       <update_rate>400</update_rate>
@@ -320,6 +349,12 @@
     <axis xyz="0 0 0"/>
   </joint>
   <gazebo reference="Camera">
+    <light name="issue67_light" type="point">
+      <pose>1 1 1 1.570796 1.570796 1.570796</pose>
+    </light>
+    <projector name="issue67_projector">
+      <pose>1 1 1 1.570796 1.570796 1.570796</pose>
+    </projector>
     <sensor name="issue67_sensor" type="camera">
       <visualize>true</visualize>
       <pose>1 1 1 1.570796 1.570796 1.570796</pose>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #378

## Summary

The `parser_urdf.cc` file converts a URDF file to SDFormat. When converting a fixed joint, by default it merges the contents of the child link into the parent link. As noted in #378, the `//sensor/pose` is not properly adjusted during this merge process. This issue has already been fixed in newer branches by https://github.com/gazebosim/sdformat/pull/525, so the test and that fix have been backported and refactored to reduce code duplication (about 30 lines removed from parser_urdf.cc) and also fix the treatment of `//link/light/pose`.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
