### PR TITLE
Converter: add sdf::Errors output to API methods

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -168,6 +168,12 @@ namespace sdf
 
     /// \brief Generic warning saved as error due to WarningsPolicy config
     WARNING,
+
+    /// \brief SDF conversion generic error.
+    CONVERSION_ERROR,
+
+    /// \brief Generic error during parsing.
+    PARSING_ERROR,
   };
 
   class SDFORMAT_VISIBLE Error

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -337,16 +337,15 @@ namespace sdf
                    const ParserConfig &_config, SDFPtr _sdf);
 
   /// \brief Convert an SDF file to a specific SDF version.
+  /// \param[out] _sdf Pointer to the converted SDF document.
   /// \param[in] _filename Name of the SDF file to convert.
   /// \param[in] _version Version to convert _filename to.
   /// \param[in] _config Custom parser configuration
-  /// \param[out] _sdf Pointer to the converted SDF document.
-  /// \param[out] _errors Vector of errors.
-  /// \return True on success.
+  /// \return Vector of errors, successful when vector is empty.
   SDFORMAT_VISIBLE
-  bool convertFile(const std::string &_filename, const std::string &_version,
-                   const ParserConfig &_config, SDFPtr _sdf,
-                   sdf::Errors &_errors);
+  sdf::Errors convertFile(
+      SDFPtr _sdf, const std::string &_filename, const std::string &_version,
+      const ParserConfig &_config = ParserConfig::GlobalConfig());
 
   /// \brief Convert an SDF string to a specific SDF version.
   /// \param[in] _sdfString The SDF string to convert.
@@ -368,16 +367,15 @@ namespace sdf
                      const ParserConfig &_config, SDFPtr _sdf);
 
   /// \brief Convert an SDF string to a specific SDF version.
+  /// \param[out] _sdf Pointer to the converted SDF document.
   /// \param[in] _sdfString The SDF string to convert.
   /// \param[in] _version Version to convert _filename to.
   /// \param[in] _config Custom parser configuration
-  /// \param[out] _sdf Pointer to the converted SDF document.
-  /// \param[out] _errors Vector of errors.
-  /// \return True on success.
+  /// \return Vector of errors, successful when vector is empty.
   SDFORMAT_VISIBLE
-  bool convertString(const std::string &_sdfString, const std::string &_version,
-                     const ParserConfig &_config, SDFPtr _sdf,
-                     sdf::Errors &_errors);
+  sdf::Errors convertString(
+      SDFPtr _sdf, const std::string &_sdfString, const std::string &_version,
+      const ParserConfig &_config = ParserConfig::GlobalConfig());
 
   /// \brief Check that for each model, the canonical_link attribute value
   /// matches the name of a link in the model if the attribute is set and

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -333,6 +333,7 @@ namespace sdf
   SDFORMAT_VISIBLE
   bool convertFile(const std::string &_filename, const std::string &_version,
                    const ParserConfig &_config, SDFPtr _sdf);
+
   /// \brief Convert an SDF file to a specific SDF version.
   /// \param[in] _filename Name of the SDF file to convert.
   /// \param[in] _version Version to convert _filename to.

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -38,6 +38,8 @@ namespace sdf
   // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   //
+  // TODO(marcoag): Deprecate function overloads that do not use sdf::Errors,
+  // see: https://github.com/gazebosim/sdformat/issues/1186
   class Root;
 
   /// \brief Initialize the SDF interface from the embedded root spec file

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -333,6 +333,17 @@ namespace sdf
   SDFORMAT_VISIBLE
   bool convertFile(const std::string &_filename, const std::string &_version,
                    const ParserConfig &_config, SDFPtr _sdf);
+  /// \brief Convert an SDF file to a specific SDF version.
+  /// \param[in] _filename Name of the SDF file to convert.
+  /// \param[in] _version Version to convert _filename to.
+  /// \param[in] _config Custom parser configuration
+  /// \param[out] _sdf Pointer to the converted SDF document.
+  /// \param[out] _errors Vector of errors.
+  /// \return True on success.
+  SDFORMAT_VISIBLE
+  bool convertFile(const std::string &_filename, const std::string &_version,
+                   const ParserConfig &_config, SDFPtr _sdf,
+                   sdf::Errors &_errors);
 
   /// \brief Convert an SDF string to a specific SDF version.
   /// \param[in] _sdfString The SDF string to convert.
@@ -352,6 +363,18 @@ namespace sdf
   SDFORMAT_VISIBLE
   bool convertString(const std::string &_sdfString, const std::string &_version,
                      const ParserConfig &_config, SDFPtr _sdf);
+
+  /// \brief Convert an SDF string to a specific SDF version.
+  /// \param[in] _sdfString The SDF string to convert.
+  /// \param[in] _version Version to convert _filename to.
+  /// \param[in] _config Custom parser configuration
+  /// \param[out] _sdf Pointer to the converted SDF document.
+  /// \param[out] _errors Vector of errors.
+  /// \return True on success.
+  SDFORMAT_VISIBLE
+  bool convertString(const std::string &_sdfString, const std::string &_version,
+                     const ParserConfig &_config, SDFPtr _sdf,
+                     sdf::Errors &_errors);
 
   /// \brief Check that for each model, the canonical_link attribute value
   /// matches the name of a link in the model if the attribute is set and

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,8 @@ if (BUILD_TESTING)
     target_sources(UNIT_Converter_TEST PRIVATE
       Converter.cc
       EmbeddedSdf.cc
-      XmlUtils.cc)
+      XmlUtils.cc
+      Utils.cc)
   endif()
 
   if (TARGET UNIT_FrameSemantics_TEST)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,8 +57,8 @@ if (BUILD_TESTING)
     target_sources(UNIT_Converter_TEST PRIVATE
       Converter.cc
       EmbeddedSdf.cc
-      XmlUtils.cc
-      Utils.cc)
+      Utils.cc
+      XmlUtils.cc)
   endif()
 
   if (TARGET UNIT_FrameSemantics_TEST)

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -321,7 +321,7 @@ void Converter::ConvertImpl(tinyxml2::XMLElement *_elem,
       ss << "Unknown convert element["
          << name
          << "]";
-      _errors.push_back({ErrorCode::FATAL_ERROR, ss.str()});
+      _errors.push_back({ErrorCode::CONVERSION_ERROR, ss.str()});
     }
   }
 }

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -542,8 +542,8 @@ bool Converter::FindNewModelElements(tinyxml2::XMLElement *_elem,
             if (expressIn.compare(0, newModelNameSize, newModelName) != 0)
             {
               std::stringstream ss;
-              ss << "Error: <xyz>'s attribute 'expressed_in' does not start with "
-                 << newModelName;
+              ss << "Error: <xyz>'s attribute 'expressed_in' does not start "
+                 << "with " << newModelName;
               _errors.push_back({ErrorCode::FATAL_ERROR, ss.str()});
               return false;
             }

--- a/src/Converter.hh
+++ b/src/Converter.hh
@@ -23,6 +23,7 @@
 #include <tuple>
 
 #include <sdf/sdf_config.h>
+#include <sdf/Types.hh>
 #include "sdf/system_util.hh"
 
 namespace sdf
@@ -36,10 +37,14 @@ namespace sdf
   {
     /// \brief Convert SDF to the specified version.
     /// \param[in] _doc SDF xml doc
-    /// \param[in] _toVersion Version number in string format
-    /// \param[in] _quiet False to be more verbose
+    /// \param[in] _toVersion Version number in string format.
+    /// \param[out] _errors Vector of errors.
+    /// \param[in] _config Parser configuration.
+    /// \param[in] _quiet False to be more verbose.
     public: static bool Convert(tinyxml2::XMLDocument *_doc,
                                 const std::string &_toVersion,
+                                sdf::Errors &_errors,
+                                const ParserConfig &_config,
                                 bool _quiet = false);
 
     /// \cond
@@ -48,86 +53,114 @@ namespace sdf
     /// given Convert file.
     /// \param[in] _doc SDF xml doc
     /// \param[in] _convertDoc Convert xml doc
+    /// \param[out] _errors Vector of errors.
+    /// \param[in] _config Parser configuration.
     public: static void Convert(tinyxml2::XMLDocument *_doc,
-                                tinyxml2::XMLDocument *_convertDoc);
+                                tinyxml2::XMLDocument *_convertDoc,
+                                sdf::Errors &_errors,
+                                const ParserConfig &_config);
     /// \endcond
 
     /// \brief Implementation of Convert functionality.
     /// \param[in] _elem SDF xml element tree to convert.
     /// \param[in] _convert Convert xml element tree.
+    /// \param[out] _errors Vector of errors.
+    /// \param[in] _config Parser configuration.
     private: static void ConvertImpl(tinyxml2::XMLElement *_elem,
-                                     tinyxml2::XMLElement *_convert);
+                                     tinyxml2::XMLElement *_convert,
+                                     sdf::Errors &_errors,
+                                     const ParserConfig &_config);
 
     /// \brief Recursive helper function for ConvertImpl that converts
     /// elements named by the descendant_name attribute.
     /// \param[in] _e SDF xml element tree to convert.
     /// \param[in] _c Convert xml element tree.
+    /// \param[out] _errors Vector of errors.
+    /// \param[in] _config Parser configuration.
     private: static void ConvertDescendantsImpl(tinyxml2::XMLElement *_e,
-                                                tinyxml2::XMLElement *_c);
+                                                tinyxml2::XMLElement *_c,
+                                                sdf::Errors &_errors,
+                                                const ParserConfig &_config);
 
     /// \brief Rename an element or attribute.
     /// \param[in] _elem The element to be renamed, or the element which
     /// has the attribute to be renamed.
-    /// \param[in] _renameElem A 'convert' element that describes the rename
+    /// \param[in] _renameElem A 'convert' element that describes the rename.
+    /// \param[out] _errors Vector of errors.
     /// operation.
     private: static void Rename(tinyxml2::XMLElement *_elem,
-                                tinyxml2::XMLElement *_renameElem);
+                                tinyxml2::XMLElement *_renameElem,
+                                sdf::Errors &_errors);
 
     /// \brief Map values from one element or attribute to another.
     /// \param[in] _elem Ancestor element of the element or attribute to
     /// be mapped.
     /// \param[in] _mapElem A 'convert' element that describes the map
+    /// \param[out] _errors Vector of errors.
     /// operation.
     private: static void Map(tinyxml2::XMLElement *_elem,
-                             tinyxml2::XMLElement *_mapElem);
+                             tinyxml2::XMLElement *_mapElem,
+                             sdf::Errors &_errors);
 
     /// \brief Move an element or attribute within a common ancestor element.
     /// \param[in] _elem Ancestor element of the element or attribute to
     /// be moved.
     /// \param[in] _moveElem A 'convert' element that describes the move
     /// operation.
+    /// \param[out] _errors Vector of errors.
     /// \param[in] _copy True to copy the element
     private: static void Move(tinyxml2::XMLElement *_elem,
                               tinyxml2::XMLElement *_moveElem,
-                              const bool _copy);
+                              const bool _copy,
+                              sdf::Errors &_errors);
 
     /// \brief Add an element or attribute to an element.
     /// \param[in] _elem The element to receive the value.
     /// \param[in] _addElem A 'convert' element that describes the add
+    /// \param[out] _errors Vector of Errors.
     /// operation.
     private: static void Add(tinyxml2::XMLElement *_elem,
-                             tinyxml2::XMLElement *_addElem);
+                             tinyxml2::XMLElement *_addElem,
+                             sdf::Errors &_errors);
 
     /// \brief Remove an attribute or elements.
     /// \param[in] _elem The element from which data may be removed.
     /// \param[in] _removeElem The metadata about what to remove.
+    /// \param[out] _errors Vector of Errors.
     /// \param[in] _removeOnlyEmpty If true, only remove an attribute
     /// containing an empty string or elements that contain neither value nor
     /// child elements nor attributes.
     private: static void Remove(tinyxml2::XMLElement *_elem,
                                 tinyxml2::XMLElement *_removeElem,
+                                sdf::Errors &_errors,
                                 bool _removeOnlyEmpty = false);
 
     /// \brief Unflatten an element (conversion from SDFormat <= 1.7 to 1.8)
     /// \param[in] _elem The element to unflatten
-    private: static void Unflatten(tinyxml2::XMLElement *_elem);
+    /// \param[out] _errors Vector of errors
+    private: static void Unflatten(tinyxml2::XMLElement *_elem,
+                                   sdf::Errors &_errors);
 
     /// \brief Finds all elements related to the unflattened model
     /// \param[in] _elem The element to unflatten
     /// \param[in] _newModel The new unflattened model element
     /// \param[in] _childNameIdx The beginning index of child element names
+    /// \param[out] _errors Vector of errors
     /// (e.g., in newModelName::childName then _childNameIdx = 14)
     /// \return True if unflattened new model elements
     private: static bool FindNewModelElements(tinyxml2::XMLElement *_elem,
                                               tinyxml2::XMLElement *_newModel,
-                                              const size_t &_childNameIdx);
+                                              const size_t &_childNameIdx,
+                                              sdf::Errors &_errors);
 
     private: static const char *GetValue(const char *_valueElem,
                                          const char *_valueAttr,
                                          tinyxml2::XMLElement *_elem);
 
     private: static void CheckDeprecation(tinyxml2::XMLElement *_elem,
-                                          tinyxml2::XMLElement *_convert);
+                                          tinyxml2::XMLElement *_convert,
+                                          sdf::Errors &_errors,
+                                          const ParserConfig &_config);
   };
   }
 }

--- a/src/Converter.hh
+++ b/src/Converter.hh
@@ -36,14 +36,14 @@ namespace sdf
   class Converter
   {
     /// \brief Convert SDF to the specified version.
+    /// \param[out] _errors Vector of errors.
     /// \param[in] _doc SDF xml doc
     /// \param[in] _toVersion Version number in string format.
-    /// \param[out] _errors Vector of errors.
     /// \param[in] _config Parser configuration.
     /// \param[in] _quiet False to be more verbose.
-    public: static bool Convert(tinyxml2::XMLDocument *_doc,
+    public: static bool Convert(sdf::Errors &_errors,
+                                tinyxml2::XMLDocument *_doc,
                                 const std::string &_toVersion,
-                                sdf::Errors &_errors,
                                 const ParserConfig &_config,
                                 bool _quiet = false);
 
@@ -51,36 +51,36 @@ namespace sdf
     /// This is an internal function.
     /// \brief Generic convert function that converts the SDF based on the
     /// given Convert file.
+    /// \param[out] _errors Vector of errors.
     /// \param[in] _doc SDF xml doc
     /// \param[in] _convertDoc Convert xml doc
-    /// \param[out] _errors Vector of errors.
     /// \param[in] _config Parser configuration.
-    public: static void Convert(tinyxml2::XMLDocument *_doc,
+    public: static void Convert(sdf::Errors &_errors,
+                                tinyxml2::XMLDocument *_doc,
                                 tinyxml2::XMLDocument *_convertDoc,
-                                sdf::Errors &_errors,
                                 const ParserConfig &_config);
     /// \endcond
 
     /// \brief Implementation of Convert functionality.
     /// \param[in] _elem SDF xml element tree to convert.
     /// \param[in] _convert Convert xml element tree.
-    /// \param[out] _errors Vector of errors.
     /// \param[in] _config Parser configuration.
+    /// \param[out] _errors Vector of errors.
     private: static void ConvertImpl(tinyxml2::XMLElement *_elem,
                                      tinyxml2::XMLElement *_convert,
-                                     sdf::Errors &_errors,
-                                     const ParserConfig &_config);
+                                     const ParserConfig &_config,
+                                     sdf::Errors &_errors);
 
     /// \brief Recursive helper function for ConvertImpl that converts
     /// elements named by the descendant_name attribute.
     /// \param[in] _e SDF xml element tree to convert.
     /// \param[in] _c Convert xml element tree.
-    /// \param[out] _errors Vector of errors.
     /// \param[in] _config Parser configuration.
+    /// \param[out] _errors Vector of errors.
     private: static void ConvertDescendantsImpl(tinyxml2::XMLElement *_e,
                                                 tinyxml2::XMLElement *_c,
-                                                sdf::Errors &_errors,
-                                                const ParserConfig &_config);
+                                                const ParserConfig &_config,
+                                                sdf::Errors &_errors);
 
     /// \brief Rename an element or attribute.
     /// \param[in] _elem The element to be renamed, or the element which
@@ -107,8 +107,8 @@ namespace sdf
     /// be moved.
     /// \param[in] _moveElem A 'convert' element that describes the move
     /// operation.
-    /// \param[out] _errors Vector of errors.
     /// \param[in] _copy True to copy the element
+    /// \param[out] _errors Vector of errors.
     private: static void Move(tinyxml2::XMLElement *_elem,
                               tinyxml2::XMLElement *_moveElem,
                               const bool _copy,
@@ -124,15 +124,15 @@ namespace sdf
                              sdf::Errors &_errors);
 
     /// \brief Remove an attribute or elements.
+    /// \param[out] _errors Vector of Errors.
     /// \param[in] _elem The element from which data may be removed.
     /// \param[in] _removeElem The metadata about what to remove.
-    /// \param[out] _errors Vector of Errors.
     /// \param[in] _removeOnlyEmpty If true, only remove an attribute
     /// containing an empty string or elements that contain neither value nor
     /// child elements nor attributes.
-    private: static void Remove(tinyxml2::XMLElement *_elem,
+    private: static void Remove(sdf::Errors &_errors,
+                                tinyxml2::XMLElement *_elem,
                                 tinyxml2::XMLElement *_removeElem,
-                                sdf::Errors &_errors,
                                 bool _removeOnlyEmpty = false);
 
     /// \brief Unflatten an element (conversion from SDFormat <= 1.7 to 1.8)
@@ -159,8 +159,8 @@ namespace sdf
 
     private: static void CheckDeprecation(tinyxml2::XMLElement *_elem,
                                           tinyxml2::XMLElement *_convert,
-                                          sdf::Errors &_errors,
-                                          const ParserConfig &_config);
+                                          const ParserConfig &_config,
+                                          sdf::Errors &_errors);
   };
   }
 }

--- a/src/Converter_TEST.cc
+++ b/src/Converter_TEST.cc
@@ -20,8 +20,10 @@
 #include <sstream>
 #include "sdf/Exception.hh"
 #include "sdf/Filesystem.hh"
+#include "sdf/ParserConfig.hh"
 
 #include "Converter.hh"
+#include "test_utils.hh"
 #include "XmlUtils.hh"
 
 #include "test_config.hh"
@@ -98,7 +100,18 @@ TEST(Converter, MoveElemElem)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -136,7 +149,18 @@ TEST(Converter, MoveElemAttr)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc2;
   convertXmlDoc2.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc2, &convertXmlDoc2);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc2, &convertXmlDoc2, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc2.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -174,7 +198,18 @@ TEST(Converter, MoveAttrAttr)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc3;
   convertXmlDoc3.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc3.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -215,7 +250,18 @@ TEST(Converter, MoveAttrElem)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc4;
   convertXmlDoc4.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc4, &convertXmlDoc4);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc4, &convertXmlDoc4, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc4.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -254,7 +300,18 @@ TEST(Converter, MoveElemElemMultipleLevels)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc5;
   convertXmlDoc5.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc5, &convertXmlDoc5);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc5, &convertXmlDoc5, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc5.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -289,7 +346,18 @@ TEST(Converter, MoveAttrAttrMultipleLevels)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc6;
   convertXmlDoc6.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc6, &convertXmlDoc6);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc6, &convertXmlDoc6, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc6.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -327,7 +395,18 @@ TEST(Converter, MoveElemAttrMultipleLevels)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc7;
   convertXmlDoc7.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc7, &convertXmlDoc7);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc7, &convertXmlDoc7, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc7.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -362,7 +441,18 @@ TEST(Converter, MoveAttrElemMultipleLevels)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc8;
   convertXmlDoc8.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc8, &convertXmlDoc8);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc8, &convertXmlDoc8, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc8.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -420,7 +510,18 @@ TEST(Converter, Add)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -463,7 +564,21 @@ TEST(Converter, AddNoElem)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+      "Exactly one 'element' or 'attribute' must be specified in <add>"));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   // Verify the xml
   tinyxml2::XMLElement *childElem = xmlDoc.FirstChildElement();
@@ -505,7 +620,21 @@ TEST(Converter, AddNoValue)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+      errors[0].Message().find("No 'value' specified in <add>"));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *childElem = xmlDoc.FirstChildElement();
   ASSERT_NE(nullptr, childElem);
@@ -557,7 +686,18 @@ TEST(Converter, RemoveElement)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -606,7 +746,18 @@ TEST(Converter, RemoveDescendantElement)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem = xmlDoc.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -658,7 +809,18 @@ TEST(Converter, RemoveEmptyElement)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -722,7 +884,18 @@ TEST(Converter, RemoveEmptyDescendantElement)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem = xmlDoc.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -787,7 +960,19 @@ TEST(Converter, RemoveDescendantNestedElement)
 
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertString.c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   std::string expectedString = R"(
   <sdf>
@@ -846,7 +1031,18 @@ TEST(Converter, DescendantIgnorePluginOrNamespacedElements)
 
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertString.c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   // Only the elemB directly under the first elemA should be removed
   std::string expectedString = R"(
@@ -909,7 +1105,18 @@ TEST(Converter, RemoveElementSubElement)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -955,7 +1162,18 @@ TEST(Converter, RemoveAttr)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1007,7 +1225,18 @@ TEST(Converter, RemoveEmptyAttr)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1045,7 +1274,21 @@ TEST(Converter, RemoveNoElement)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Exactly one 'element' or 'attribute' must be specified in <remove>"));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *childElem =  xmlDoc.FirstChildElement();
   ASSERT_NE(nullptr, childElem);
@@ -1097,7 +1340,18 @@ TEST(Converter, MoveInvalid)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   // In this case, we had an invalid elemC:: in the conversion, which
   // means that the conversion quietly failed.  Make sure the new
@@ -1153,7 +1407,18 @@ TEST(Converter, MoveInvalidPrefix)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   // In this case, we had an invalid ::elemC in the conversion, which
   // means that the conversion quietly failed.  Make sure the new
@@ -1210,7 +1475,18 @@ TEST(Converter, CopyElemElem)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1385,7 +1661,66 @@ TEST(Converter, MapInvalid)
   tinyxml2::XMLPrinter printerBefore;
   xmlDoc.Print(&printerBefore);
 
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_EQ(errors.size(), 16u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[0].Message().find("<from> has invalid name attribute"));
+  EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[1].Message().find("<from> has invalid name attribute"));
+  EXPECT_EQ(errors[2].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[2].Message().find("<to> has invalid name attribute"));
+  EXPECT_EQ(errors[3].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[3].Message().find("<to> has invalid name attribute"));
+  EXPECT_EQ(errors[4].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[4].Message().find("<to> has invalid name attribute"));
+  EXPECT_EQ(errors[5].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[5].Message().find(
+      "<map> element requires a <from> child element."));
+  EXPECT_EQ(errors[6].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[6].Message().find(
+      "<map> element requires a <to> child element."));
+  EXPECT_EQ(errors[7].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[7].Message().find(
+      "<from> element requires a non-empty name attribute."));
+  EXPECT_EQ(errors[8].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[8].Message().find(
+      "<from> element requires a non-empty name attribute."));
+  EXPECT_EQ(errors[9].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[9].Message().find(
+      "<to> element requires a non-empty name attribute."));
+  EXPECT_EQ(errors[10].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[10].Message().find(
+      "<from> element requires at least one <value> element"));
+  EXPECT_EQ(errors[11].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[11].Message().find(
+      "<to> element requires at least one <value> element"));
+  EXPECT_EQ(errors[12].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[12].Message().find("from value must not be empty."));
+  EXPECT_EQ(errors[13].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[13].Message().find("to value must not be empty."));
+  EXPECT_EQ(errors[14].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[14].Message().find("from value must not be empty."));
+  EXPECT_EQ(errors[15].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[15].Message().find("to value must not be empty."));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
+
 
   // Only invalid conversion statements.
   // Make sure the new document is the same as the original.
@@ -1495,7 +1830,18 @@ TEST(Converter, MapElemElem)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1546,7 +1892,18 @@ TEST(Converter, MapElemAttr)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc2;
   convertXmlDoc2.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc2, &convertXmlDoc2);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc2, &convertXmlDoc2, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc2.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1589,7 +1946,18 @@ TEST(Converter, MapAttrAttr)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc3;
   convertXmlDoc3.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc3.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1639,7 +2007,18 @@ TEST(Converter, MapAttrElem)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc4;
   convertXmlDoc4.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc4, &convertXmlDoc4);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc4, &convertXmlDoc4, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc4.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1686,7 +2065,18 @@ TEST(Converter, MapElemElemMultipleLevels)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc5;
   convertXmlDoc5.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc5, &convertXmlDoc5);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc5, &convertXmlDoc5, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc5.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1730,7 +2120,18 @@ TEST(Converter, MapAttrAttrMultipleLevels)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc6;
   convertXmlDoc6.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc6, &convertXmlDoc6);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc6, &convertXmlDoc6, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc6.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -1777,7 +2178,18 @@ TEST(Converter, MapElemAttrMultipleLevels)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc7;
   convertXmlDoc7.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc7, &convertXmlDoc7);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc7, &convertXmlDoc7, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc7.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -1821,7 +2233,18 @@ TEST(Converter, MapAttrElemMultipleLevels)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc8;
   convertXmlDoc8.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc8, &convertXmlDoc8);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc8, &convertXmlDoc8, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc8.FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -1882,7 +2305,18 @@ TEST(Converter, RenameElemElem)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1920,7 +2354,18 @@ TEST(Converter, RenameAttrAttr)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc3;
   convertXmlDoc3.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc3.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1957,7 +2402,18 @@ TEST(Converter, RenameNoFrom)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc3;
   convertXmlDoc3.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  EXPECT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc3.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -1994,7 +2450,21 @@ TEST(Converter, RenameNoTo)
                 << "</convert>";
   tinyxml2::XMLDocument convertXmlDoc3;
   convertXmlDoc3.Parse(convertStream.str().c_str());
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+      errors[0].Message().find("No 'to' element name specified"));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc3.FirstChildElement();
   EXPECT_STREQ(convertedElem->Name(), "elemA");
@@ -2019,7 +2489,19 @@ TEST(Converter, GazeboToSDF)
 
   tinyxml2::XMLDocument xmlDoc;
   xmlDoc.Parse(xmlString.c_str());
-  EXPECT_FALSE(sdf::Converter::Convert(&xmlDoc, "1.3"));
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  EXPECT_FALSE(sdf::Converter::Convert(&xmlDoc, "1.3", errors, parserConfig));
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[0].Message().find("<sdf> element does not exist."));
 }
 
 ////////////////////////////////////////////////////
@@ -2028,12 +2510,35 @@ TEST(Converter, NullDoc)
   tinyxml2::XMLDocument xmlDoc;
   tinyxml2::XMLDocument convertXmlDoc;
 
-  ASSERT_THROW(sdf::Converter::Convert(nullptr, &convertXmlDoc),
-               sdf::AssertionInternalError);
-  ASSERT_THROW(sdf::Converter::Convert(&xmlDoc, nullptr),
-               sdf::AssertionInternalError);
-  ASSERT_THROW(sdf::Converter::Convert(nullptr, "1.4"),
-               sdf::AssertionInternalError);
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+
+  sdf::Errors errors;
+  sdf::Converter::Convert(nullptr, &convertXmlDoc, errors, parserConfig);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FATAL_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[0].Message().find("SDF XML doc is NULL"));
+  errors.clear();
+
+  sdf::Converter::Convert(&xmlDoc, nullptr, errors, parserConfig);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FATAL_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[0].Message().find("Convert XML doc is NULL"));
+  errors.clear();
+
+  sdf::Converter::Convert(nullptr, "1.4", errors, parserConfig);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FATAL_ERROR);
+  EXPECT_NE(std::string::npos,
+            errors[0].Message().find("SDF XML doc is NULL"));
+
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 }
 
 ////////////////////////////////////////////////////
@@ -2044,7 +2549,21 @@ TEST(Converter, NoVersion)
   tinyxml2::XMLDocument xmlDoc;
   xmlDoc.Parse(xmlString.c_str());
 
-  ASSERT_FALSE(sdf::Converter::Convert(&xmlDoc, "1.3"));
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+
+  sdf::Errors errors;
+  ASSERT_FALSE(sdf::Converter::Convert(&xmlDoc, "1.3", errors, parserConfig));
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+      "Unable to determine original SDF version"));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 }
 
 ////////////////////////////////////////////////////
@@ -2058,7 +2577,18 @@ TEST(Converter, SameVersion)
   tinyxml2::XMLPrinter printerBefore;
   xmlDoc.Print(&printerBefore);
 
-  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.3"));
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+
+  sdf::Errors errors;
+  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.3", errors, parserConfig));
+  ASSERT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   tinyxml2::XMLPrinter printerAfter;
   xmlDoc.Print(&printerAfter);
@@ -2075,7 +2605,18 @@ TEST(Converter, NewerVersion)
   tinyxml2::XMLDocument xmlDoc;
   xmlDoc.Parse(xmlString.c_str());
 
-  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.6"));
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+
+  sdf::Errors errors;
+  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.6", errors, parserConfig));
+  ASSERT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 }
 
 ////////////////////////////////////////////////////
@@ -2086,7 +2627,18 @@ TEST(Converter, MuchNewerVersion)
   tinyxml2::XMLDocument xmlDoc;
   xmlDoc.Parse(xmlString.c_str());
 
-  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.6"));
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+
+  sdf::Errors errors;
+  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.6", errors, parserConfig));
+  ASSERT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 }
 
 static std::string ConvertDoc_15_16()
@@ -2139,7 +2691,18 @@ TEST(Converter, IMU_15_to_16)
   // Convert
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.LoadFile(ConvertDoc_15_16().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   // Check some basic elements
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
@@ -2233,7 +2796,18 @@ TEST(Converter, World_15_to_16)
   // Convert
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.LoadFile(ConvertDoc_15_16().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   // Check some basic elements
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
@@ -2289,7 +2863,18 @@ TEST(Converter, Pose_16_to_17)
   // Convert
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.LoadFile(ConvertDoc_16_17().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_TRUE(errors.empty());
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   // Check some basic elements
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
@@ -2374,7 +2959,17 @@ TEST(Converter, World_17_to_18)
   // Convert
   tinyxml2::XMLDocument convertXmlDoc;
   convertXmlDoc.LoadFile(ConvertDoc_17_18().c_str());
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+
+  sdf::Errors errors;
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_TRUE(errors.empty());
 
   // Compare converted xml with expected
   std::string convertedXmlStr = ElementToString(xmlDoc.RootElement());
@@ -2512,7 +3107,8 @@ TEST(Converter, World_17_to_18)
   xmlDoc.Clear();
   xmlDoc.Parse(xmlString.c_str());
 
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_TRUE(errors.empty());
 
   // Compare converted xml with expected
   convertedXmlStr = ElementToString(xmlDoc.RootElement());
@@ -2614,7 +3210,12 @@ TEST(Converter, World_17_to_18)
   xmlDoc.Clear();
   xmlDoc.Parse(xmlString.c_str());
 
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  ASSERT_TRUE(errors.empty());
+
+  // Check nothing has been printed during Convert calls
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 
   // Compare converted xml with expected
   convertedXmlStr = ElementToString(xmlDoc.RootElement());

--- a/src/Converter_TEST.cc
+++ b/src/Converter_TEST.cc
@@ -108,7 +108,7 @@ TEST(Converter, MoveElemElem)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -157,7 +157,7 @@ TEST(Converter, MoveElemAttr)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc2, &convertXmlDoc2, errors, parserConfig);
+  sdf::Converter::Convert(errors,  &xmlDoc2, &convertXmlDoc2, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -206,7 +206,7 @@ TEST(Converter, MoveAttrAttr)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc3, &convertXmlDoc3, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -258,7 +258,7 @@ TEST(Converter, MoveAttrElem)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc4, &convertXmlDoc4, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc4, &convertXmlDoc4, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -308,7 +308,7 @@ TEST(Converter, MoveElemElemMultipleLevels)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc5, &convertXmlDoc5, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc5, &convertXmlDoc5, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -354,7 +354,7 @@ TEST(Converter, MoveAttrAttrMultipleLevels)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc6, &convertXmlDoc6, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc6, &convertXmlDoc6, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -403,7 +403,7 @@ TEST(Converter, MoveElemAttrMultipleLevels)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc7, &convertXmlDoc7, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc7, &convertXmlDoc7, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -449,7 +449,7 @@ TEST(Converter, MoveAttrElemMultipleLevels)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc8, &convertXmlDoc8, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc8, &convertXmlDoc8, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -518,7 +518,7 @@ TEST(Converter, Add)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -572,7 +572,7 @@ TEST(Converter, AddNoElem)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
@@ -628,7 +628,7 @@ TEST(Converter, AddNoValue)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
   EXPECT_NE(std::string::npos,
@@ -694,7 +694,7 @@ TEST(Converter, RemoveElement)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -754,7 +754,7 @@ TEST(Converter, RemoveDescendantElement)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -817,7 +817,7 @@ TEST(Converter, RemoveEmptyElement)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -892,7 +892,7 @@ TEST(Converter, RemoveEmptyDescendantElement)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -969,7 +969,7 @@ TEST(Converter, RemoveDescendantNestedElement)
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1039,7 +1039,7 @@ TEST(Converter, DescendantIgnorePluginOrNamespacedElements)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1113,7 +1113,7 @@ TEST(Converter, RemoveElementSubElement)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1170,7 +1170,7 @@ TEST(Converter, RemoveAttr)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1233,7 +1233,7 @@ TEST(Converter, RemoveEmptyAttr)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1282,7 +1282,7 @@ TEST(Converter, RemoveNoElement)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
@@ -1348,7 +1348,7 @@ TEST(Converter, MoveInvalid)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1415,7 +1415,7 @@ TEST(Converter, MoveInvalidPrefix)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1483,7 +1483,7 @@ TEST(Converter, CopyElemElem)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1668,7 +1668,7 @@ TEST(Converter, MapInvalid)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_EQ(errors.size(), 16u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
   EXPECT_NE(std::string::npos,
@@ -1838,7 +1838,7 @@ TEST(Converter, MapElemElem)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1900,7 +1900,7 @@ TEST(Converter, MapElemAttr)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc2, &convertXmlDoc2, errors, parserConfig);
+  sdf::Converter::Convert(errors,  &xmlDoc2, &convertXmlDoc2, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -1954,7 +1954,7 @@ TEST(Converter, MapAttrAttr)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc3, &convertXmlDoc3, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2015,7 +2015,7 @@ TEST(Converter, MapAttrElem)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc4, &convertXmlDoc4, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc4, &convertXmlDoc4, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2073,7 +2073,7 @@ TEST(Converter, MapElemElemMultipleLevels)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc5, &convertXmlDoc5, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc5, &convertXmlDoc5, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2128,7 +2128,7 @@ TEST(Converter, MapAttrAttrMultipleLevels)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc6, &convertXmlDoc6, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc6, &convertXmlDoc6, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2186,7 +2186,7 @@ TEST(Converter, MapElemAttrMultipleLevels)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc7, &convertXmlDoc7, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc7, &convertXmlDoc7, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2241,7 +2241,7 @@ TEST(Converter, MapAttrElemMultipleLevels)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc8, &convertXmlDoc8, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc8, &convertXmlDoc8, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2313,7 +2313,7 @@ TEST(Converter, RenameElemElem)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2362,7 +2362,7 @@ TEST(Converter, RenameAttrAttr)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc3, &convertXmlDoc3, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2410,7 +2410,7 @@ TEST(Converter, RenameNoFrom)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc3, &convertXmlDoc3, parserConfig);
   EXPECT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2458,7 +2458,7 @@ TEST(Converter, RenameNoTo)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc3, &convertXmlDoc3, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc3, &convertXmlDoc3, parserConfig);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
   EXPECT_NE(std::string::npos,
@@ -2497,7 +2497,7 @@ TEST(Converter, GazeboToSDF)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  EXPECT_FALSE(sdf::Converter::Convert(&xmlDoc, "1.3", errors, parserConfig));
+  EXPECT_FALSE(sdf::Converter::Convert(errors, &xmlDoc, "1.3", parserConfig));
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
   EXPECT_NE(std::string::npos,
@@ -2518,21 +2518,21 @@ TEST(Converter, NullDoc)
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
   sdf::Errors errors;
-  sdf::Converter::Convert(nullptr, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, nullptr, &convertXmlDoc, parserConfig);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FATAL_ERROR);
   EXPECT_NE(std::string::npos,
             errors[0].Message().find("SDF XML doc is NULL"));
   errors.clear();
 
-  sdf::Converter::Convert(&xmlDoc, nullptr, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, nullptr, parserConfig);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FATAL_ERROR);
   EXPECT_NE(std::string::npos,
             errors[0].Message().find("Convert XML doc is NULL"));
   errors.clear();
 
-  sdf::Converter::Convert(nullptr, "1.4", errors, parserConfig);
+  sdf::Converter::Convert(errors, nullptr, "1.4", parserConfig);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FATAL_ERROR);
   EXPECT_NE(std::string::npos,
             errors[0].Message().find("SDF XML doc is NULL"));
@@ -2557,7 +2557,7 @@ TEST(Converter, NoVersion)
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
   sdf::Errors errors;
-  ASSERT_FALSE(sdf::Converter::Convert(&xmlDoc, "1.3", errors, parserConfig));
+  ASSERT_FALSE(sdf::Converter::Convert(errors, &xmlDoc, "1.3", parserConfig));
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::CONVERSION_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
@@ -2585,7 +2585,7 @@ TEST(Converter, SameVersion)
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
   sdf::Errors errors;
-  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.3", errors, parserConfig));
+  ASSERT_TRUE(sdf::Converter::Convert(errors, &xmlDoc, "1.3", parserConfig));
   ASSERT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2613,7 +2613,7 @@ TEST(Converter, NewerVersion)
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
   sdf::Errors errors;
-  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.6", errors, parserConfig));
+  ASSERT_TRUE(sdf::Converter::Convert(errors, &xmlDoc, "1.6", parserConfig));
   ASSERT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2635,7 +2635,7 @@ TEST(Converter, MuchNewerVersion)
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
   sdf::Errors errors;
-  ASSERT_TRUE(sdf::Converter::Convert(&xmlDoc, "1.6", errors, parserConfig));
+  ASSERT_TRUE(sdf::Converter::Convert(errors, &xmlDoc, "1.6", parserConfig));
   ASSERT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2699,7 +2699,7 @@ TEST(Converter, IMU_15_to_16)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2804,7 +2804,7 @@ TEST(Converter, World_15_to_16)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2871,7 +2871,7 @@ TEST(Converter, Pose_16_to_17)
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_TRUE(errors.empty());
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -2968,7 +2968,7 @@ TEST(Converter, World_17_to_18)
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
   sdf::Errors errors;
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_TRUE(errors.empty());
 
   // Compare converted xml with expected
@@ -3107,7 +3107,7 @@ TEST(Converter, World_17_to_18)
   xmlDoc.Clear();
   xmlDoc.Parse(xmlString.c_str());
 
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_TRUE(errors.empty());
 
   // Compare converted xml with expected
@@ -3211,7 +3211,7 @@ TEST(Converter, World_17_to_18)
   xmlDoc.Parse(xmlString.c_str());
 
 
-  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc, errors, parserConfig);
+  sdf::Converter::Convert(errors, &xmlDoc, &convertXmlDoc, parserConfig);
   ASSERT_TRUE(errors.empty());
 
   // Check nothing has been printed during Convert calls

--- a/src/Converter_TEST.cc
+++ b/src/Converter_TEST.cc
@@ -105,6 +105,15 @@ TEST(Converter, MoveElemElem)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -154,6 +163,15 @@ TEST(Converter, MoveElemAttr)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -202,6 +220,15 @@ TEST(Converter, MoveAttrAttr)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -255,6 +282,15 @@ TEST(Converter, MoveAttrElem)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -305,6 +341,15 @@ TEST(Converter, MoveElemElemMultipleLevels)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -350,6 +395,15 @@ TEST(Converter, MoveAttrAttrMultipleLevels)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -400,6 +454,15 @@ TEST(Converter, MoveElemAttrMultipleLevels)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -445,6 +508,15 @@ TEST(Converter, MoveAttrElemMultipleLevels)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -515,6 +587,15 @@ TEST(Converter, Add)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -568,6 +649,15 @@ TEST(Converter, AddNoElem)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -624,6 +714,15 @@ TEST(Converter, AddNoValue)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -691,6 +790,15 @@ TEST(Converter, RemoveElement)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -750,6 +858,15 @@ TEST(Converter, RemoveDescendantElement)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -813,6 +930,15 @@ TEST(Converter, RemoveEmptyElement)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -888,6 +1014,15 @@ TEST(Converter, RemoveEmptyDescendantElement)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -965,6 +1100,15 @@ TEST(Converter, RemoveDescendantNestedElement)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
@@ -1035,6 +1179,15 @@ TEST(Converter, DescendantIgnorePluginOrNamespacedElements)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -1110,6 +1263,15 @@ TEST(Converter, RemoveElementSubElement)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -1166,6 +1328,15 @@ TEST(Converter, RemoveAttr)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -1230,6 +1401,15 @@ TEST(Converter, RemoveEmptyAttr)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -1278,6 +1458,15 @@ TEST(Converter, RemoveNoElement)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -1344,6 +1533,15 @@ TEST(Converter, MoveInvalid)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -1412,6 +1610,15 @@ TEST(Converter, MoveInvalidPrefix)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -1479,6 +1686,15 @@ TEST(Converter, CopyElemElem)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -1665,6 +1881,15 @@ TEST(Converter, MapInvalid)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -1835,6 +2060,15 @@ TEST(Converter, MapElemElem)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -1897,6 +2131,15 @@ TEST(Converter, MapElemAttr)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -1950,6 +2193,15 @@ TEST(Converter, MapAttrAttr)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2012,6 +2264,15 @@ TEST(Converter, MapAttrElem)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -2070,6 +2331,15 @@ TEST(Converter, MapElemElemMultipleLevels)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -2124,6 +2394,15 @@ TEST(Converter, MapAttrAttrMultipleLevels)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2183,6 +2462,15 @@ TEST(Converter, MapElemAttrMultipleLevels)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -2237,6 +2525,15 @@ TEST(Converter, MapAttrElemMultipleLevels)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2310,6 +2607,15 @@ TEST(Converter, RenameElemElem)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -2359,6 +2665,15 @@ TEST(Converter, RenameAttrAttr)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -2406,6 +2721,15 @@ TEST(Converter, RenameNoFrom)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2455,6 +2779,15 @@ TEST(Converter, RenameNoTo)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -2494,6 +2827,15 @@ TEST(Converter, GazeboToSDF)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -2513,6 +2855,15 @@ TEST(Converter, NullDoc)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2553,6 +2904,15 @@ TEST(Converter, NoVersion)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
@@ -2580,6 +2940,15 @@ TEST(Converter, SameVersion)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2609,6 +2978,15 @@ TEST(Converter, NewerVersion)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
 
@@ -2630,6 +3008,15 @@ TEST(Converter, MuchNewerVersion)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2695,6 +3082,15 @@ TEST(Converter, IMU_15_to_16)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2801,6 +3197,15 @@ TEST(Converter, World_15_to_16)
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
 
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   sdf::Errors errors;
@@ -2867,6 +3272,15 @@ TEST(Converter, Pose_16_to_17)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
@@ -2963,6 +3377,15 @@ TEST(Converter, World_17_to_18)
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
       sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -952,7 +952,7 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
         && strcmp(sdfNode->Attribute("version"), SDF::Version().c_str()) != 0)
     {
       sdfdbg << "Converting a deprecated source[" << _source << "].\n";
-      Converter::Convert(_xmlDoc, SDF::Version(), _errors, _config);
+      Converter::Convert(_errors, _xmlDoc, SDF::Version(), _config);
     }
 
     auto *elemXml = _xmlDoc->FirstChildElement(_sdf->Root()->GetName().c_str());
@@ -1042,7 +1042,7 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf,
     {
       sdfdbg << "Converting a deprecated SDF source[" << _source << "].\n";
 
-      Converter::Convert(_xmlDoc, SDF::Version(), _errors, _config);
+      Converter::Convert(_errors, _xmlDoc, SDF::Version(), _config);
     }
 
     tinyxml2::XMLElement *elemXml = sdfNode;
@@ -1989,7 +1989,7 @@ bool convertFile(const std::string &_filename, const std::string &_version,
 
     _sdf->SetOriginalVersion(originalVersion);
 
-    if (sdf::Converter::Convert(&xmlDoc, _version, _errors, _config, true))
+    if (sdf::Converter::Convert(_errors, &xmlDoc, _version, _config, true))
     {
       bool result =
           sdf::readDoc(&xmlDoc, _sdf, filename, false, _config, _errors);
@@ -2051,7 +2051,7 @@ bool convertString(const std::string &_sdfString, const std::string &_version,
 
     _sdf->SetOriginalVersion(originalVersion);
 
-    if (sdf::Converter::Convert(&xmlDoc, _version, _errors, _config, true))
+    if (sdf::Converter::Convert(_errors, &xmlDoc, _version, _config, true))
     {
       bool result = sdf::readDoc(&xmlDoc, _sdf, std::string(kSdfStringSource),
                                  false, _config, _errors);

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1945,17 +1945,17 @@ bool convertFile(const std::string &_filename, const std::string &_version,
 bool convertFile(const std::string &_filename, const std::string &_version,
                  const ParserConfig &_config, SDFPtr _sdf)
 {
-  sdf::Errors errors;
-  bool result = convertFile(_filename, _version, _config, _sdf, errors);
+  sdf::Errors errors = convertFile(_sdf, _filename, _version, _config);
   throwOrPrintErrors(errors);
-  return result;
+  return errors.empty();
 }
 
 /////////////////////////////////////////////////
-bool convertFile(const std::string &_filename, const std::string &_version,
-                 const ParserConfig &_config, SDFPtr _sdf,
-                 sdf::Errors &_errors)
+sdf::Errors convertFile(SDFPtr _sdf, const std::string &_filename,
+                        const std::string &_version,
+                        const ParserConfig &_config)
 {
+  sdf::Errors errors;
   std::string filename = sdf::findFile(_filename, true, false, _config);
 
   if (filename.empty())
@@ -1964,15 +1964,15 @@ bool convertFile(const std::string &_filename, const std::string &_version,
     ss << "Error finding file ["
        << _filename
        << "].";
-    _errors.push_back({ErrorCode::FILE_READ, ss.str()});
-    return false;
+    errors.push_back({ErrorCode::FILE_READ, ss.str()});
+    return errors;
   }
 
   if (nullptr == _sdf || nullptr == _sdf->Root())
   {
-    _errors.push_back({ErrorCode::CONVERSION_ERROR,
+    errors.push_back({ErrorCode::CONVERSION_ERROR,
         "SDF pointer or its Root is null."});
-    return false;
+    return errors;
   }
 
   auto xmlDoc = makeSdfDoc();
@@ -1990,21 +1990,26 @@ bool convertFile(const std::string &_filename, const std::string &_version,
 
     _sdf->SetOriginalVersion(originalVersion);
 
-    if (sdf::Converter::Convert(_errors, &xmlDoc, _version, _config, true))
+    if (sdf::Converter::Convert(errors, &xmlDoc, _version, _config, true))
     {
       bool result =
-          sdf::readDoc(&xmlDoc, _sdf, filename, false, _config, _errors);
-      return result;
+          sdf::readDoc(&xmlDoc, _sdf, filename, false, _config, errors);
+      if (!result)
+      {
+        std::stringstream ss;
+        ss << "Error in sdf::readDoc when parsing file[" << filename << "]";
+        errors.push_back({ErrorCode::PARSING_ERROR, ss.str()});
+      }
     }
   }
   else
   {
     std::stringstream ss;
     ss << "Error parsing file[" << filename << "]";
-    _errors.push_back({ErrorCode::CONVERSION_ERROR, ss.str()});
+    errors.push_back({ErrorCode::CONVERSION_ERROR, ss.str()});
   }
 
-  return false;
+  return errors;
 }
 
 /////////////////////////////////////////////////
@@ -2019,20 +2024,22 @@ bool convertString(const std::string &_sdfString, const std::string &_version,
 bool convertString(const std::string &_sdfString, const std::string &_version,
     const ParserConfig &_config, SDFPtr _sdf)
 {
-  sdf::Errors errors;
-  bool result = convertString(_sdfString, _version, _config, _sdf, errors);
+  sdf::Errors errors = convertString(_sdf, _sdfString, _version, _config);
   throwOrPrintErrors(errors);
-  return result;
+  return errors.empty();
 }
 
 /////////////////////////////////////////////////
-bool convertString(const std::string &_sdfString, const std::string &_version,
-    const ParserConfig &_config, SDFPtr _sdf, sdf::Errors &_errors)
+sdf::Errors convertString(SDFPtr _sdf, const std::string &_sdfString,
+                          const std::string &_version,
+                          const ParserConfig &_config)
 {
+  sdf::Errors errors;
+
   if (_sdfString.empty())
   {
-    _errors.push_back({ErrorCode::CONVERSION_ERROR, "SDF string is empty."});
-    return false;
+    errors.push_back({ErrorCode::CONVERSION_ERROR, "SDF string is empty."});
+    return errors;
   }
 
   tinyxml2::XMLDocument xmlDoc;
@@ -2052,11 +2059,18 @@ bool convertString(const std::string &_sdfString, const std::string &_version,
 
     _sdf->SetOriginalVersion(originalVersion);
 
-    if (sdf::Converter::Convert(_errors, &xmlDoc, _version, _config, true))
+    if (sdf::Converter::Convert(errors, &xmlDoc, _version, _config, true))
     {
       bool result = sdf::readDoc(&xmlDoc, _sdf, std::string(kSdfStringSource),
-                                 false, _config, _errors);
-      return result;
+                                 false, _config, errors);
+      if (!result)
+      {
+        std::stringstream ss;
+        ss << "Error in sdf::readDoc when parsing XML from string["
+           << _sdfString
+           << "]";
+        errors.push_back({ErrorCode::PARSING_ERROR, ss.str()});
+      }
     }
   }
   else
@@ -2065,10 +2079,10 @@ bool convertString(const std::string &_sdfString, const std::string &_version,
     ss << "Error parsing XML from string["
        << _sdfString
        << "]";
-    _errors.push_back({ErrorCode::CONVERSION_ERROR, ss.str()});
+    errors.push_back({ErrorCode::CONVERSION_ERROR, ss.str()});
   }
 
-  return false;
+  return errors;
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🎉 New feature

Work towards https://github.com/gazebosim/sdformat/issues/820.

## Summary

It moves all error reporting in the `Converter` class to `sdf::Errors`. It also includes minimal changes to the parser so the `Converter` changes can compile and work adequately. A full update to add `sdf::Errors` support to the parser will follow up on a separate PR so this one is not to big.

After this PR is merged the parser might introduce more errors into the `sdf::Errors` structure than before. In order to reduce the time this behavior is changed it is recommended to **wait until the PR that addresses errors on the parser is ready** so it can be merged immediately after this one.

There is one warning that is still printed unless the warnings policy is set to `sdf::EnforcementPolicy::ERR`.

## Test it

Using any method of the `Converter` class should only print warnings and report all errors through `sdf::Errors`. If  the warnings policy is set to `sdf::EnforcementPolicy::ERR` warnings should be reported also in the `sdf::Errors` structure.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.