### PR TITLE
Add pybind11 module as MODULE

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -36,7 +36,7 @@ function(configure_build_install_location _library_name)
   )
 endfunction()
 
-pybind11_add_module(sdformat SHARED
+pybind11_add_module(sdformat MODULE
   src/sdf/_gz_sdformat_pybind11.cc
   src/sdf/pyAirPressure.cc
   src/sdf/pyAltimeter.cc


### PR DESCRIPTION
# 🦟 Bug fix

This fixes an issue with linking to python libraries on macOS.

## Summary

Similar to https://github.com/gazebosim/gz-math/pull/497. Uses `ci_matching_branch/*` branch name in order to get https://github.com/osrf/homebrew-simulation/commit/1f40fc071f88516e3124a3bc1b2e222652244901

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
