### PR TITLE
World: sdfwarns to sdf::Errors when warnings policy set to sdf::EnforcementPolicy::ERR

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -165,6 +165,9 @@ namespace sdf
     /// \brief Generic error to be thrown with SDF_ASSERT by the caller.
     /// This has been created to help preserve behavior.
     FATAL_ERROR,
+
+    /// \brief Generic warning saved as error due to WarningsPolicy config
+    WARNING,
   };
 
   class SDFORMAT_VISIBLE Error

--- a/src/World.cc
+++ b/src/World.cc
@@ -206,20 +206,13 @@ Errors World::Load(sdf::ElementPtr _sdf, const ParserConfig &_config)
   {
     if (size > 1)
     {
-      sdfwarn << "Non-unique name[" << name << "] detected " << size
-              << " times in XML children of world with name[" << this->Name()
-              << "].\n";
-    }
-  }
-
-  for (const auto &[name, size] :
-       _sdf->CountNamedElements("", Element::NameUniquenessExceptions()))
-  {
-    if (size > 1)
-    {
-      sdfwarn << "Non-unique name[" << name << "] detected " << size
-              << " times in XML children of world with name[" << this->Name()
-              << "].\n";
+      std::stringstream ss;
+      ss << "Non-unique name[" << name << "] detected " << size
+         << " times in XML children of world with name[" << this->Name()
+         << "].";
+      Error err(ErrorCode::WARNING, ss.str());
+      enforceConfigurablePolicyCondition(
+          _config.WarningsPolicy(), err, errors);
     }
   }
 
@@ -288,10 +281,14 @@ Errors World::Load(sdf::ElementPtr _sdf, const ParserConfig &_config)
       {
         frameName = frame.Name() + "_frame" + std::to_string(i++);
       }
-      sdfwarn << "Frame with name [" << frame.Name() << "] "
-              << "in world with name [" << this->Name() << "] "
-              << "has a name collision, changing frame name to ["
-              << frameName << "].\n";
+      std::stringstream ss;
+      ss << "Frame with name [" << frame.Name() << "] "
+          << "in world with name [" << this->Name() << "] "
+          << "has a name collision, changing frame name to ["
+          << frameName << "].\n";
+      Error err(ErrorCode::WARNING, ss.str());
+      enforceConfigurablePolicyCondition(
+          _config.WarningsPolicy(), err, errors);
       frame.SetName(frameName);
     }
     frameNames.insert(frameName);

--- a/test/integration/error_output.cc
+++ b/test/integration/error_output.cc
@@ -247,19 +247,14 @@ TEST(ErrorOutput, PrintConfigErrorOutput)
 }
 
 ////////////////////////////////////////
-// Test Model class for sdf::Errors outputs
-TEST(ErrorOutput, ModelErrorOutput)
+// Test World class for sdf::Errors outputs
+TEST(ErrorOutput, WorldErrorOutput)
 {
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
     sdf::Console::Instance()->GetMsgStream(), &buffer);
 
   sdf::Errors errors;
-
-  std::function findFileCb = [](const std::string &_uri)
-  {
-    return sdf::testing::TestFile("integration", "model", _uri);
-  };
 
   std::ostringstream stream;
   stream << "<?xml version=\"1.0\"?>"
@@ -282,7 +277,6 @@ TEST(ErrorOutput, ModelErrorOutput)
 
   sdf::ParserConfig parserConfig;
   parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
-  parserConfig.SetFindCallback(findFileCb);
   sdf::readString(stream.str(), parserConfig, sdfParsed, errors);
   EXPECT_TRUE(errors.empty());
 


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🎉 New feature

Work towards https://github.com/gazebosim/sdformat/issues/820.

## Summary
Makes warnings to be reported through `sdf::Errors` when using the `Load` method of the `World` class and the warnings policy is set to `sdf::EnforcementPolicy::ERR`.

@azeey found [this duplicated code](https://github.com/gazebosim/sdformat/blob/2bdad1b4d2db71bdd9cabee1213b2bfac18f015a/src/World.cc#L215). It seems do the same exact check than the previous loop so I removed one of them in this PR. It seems to keep passing tests but maybe better to double check in case I'm missing something there.

## Test it

When using the `Load` method of the World class and setting the warnings policy to `sdf::EnforcementPolicy::ERR` warnings should be reported through in the `sdf::Errors` structure.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.