### PR TITLE
Prepare for 12.6.0~pre1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat12 VERSION 12.5.0)
+project (sdformat12 VERSION 12.6.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software
@@ -25,7 +25,7 @@ if (BUILD_SDF)
   ign_configure_project(
     NO_IGNITION_PREFIX
     REPLACE_IGNITION_INCLUDE_PATH sdf
-    VERSION_SUFFIX)
+    VERSION_SUFFIX pre1)
 
   #################################################
   # Find tinyxml2.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,49 @@
 ## libsdformat 12.X
 
+### libsdformat 12.6.0 (2022-09-07)
+
+1. Add camera `optical_frame_id` element
+    * [Pull request #1109](https://github.com/gazebosim/sdformat/pull/1109)
+
+1. urdf: fix sensor/light pose for links lumped by fixed joints
+    * [Pull request #1114](https://github.com/gazebosim/sdformat/pull/1114)
+
+1. Removed USD component from SDFormat and move to gz-usd
+    * [Pull request #1094](https://github.com/gazebosim/sdformat/pull/1094)
+
+1. Fix URDF fixed joint reduction of SDF joints
+    * [Pull request #1089](https://github.com/gazebosim/sdformat/pull/1089)
+
+1. Test model name as `placement_frame`
+    * [Pull request #1079](https://github.com/gazebosim/sdformat/pull/1079)
+
+1. Test using `__model__`, `world` in `@attached_to`, `@relative_to`
+    * [Pull request #1066](https://github.com/gazebosim/sdformat/pull/1066)
+
+1. Remove unused sdf.hh.in template
+    * [Pull request #1081](https://github.com/gazebosim/sdformat/pull/1081)
+
+1. Readme: Ignition -> Gazebo
+    * [Pull request #1080](https://github.com/gazebosim/sdformat/pull/1080)
+
+1. Document major and minor SDFormat version numbers
+    * [Pull request #1065](https://github.com/gazebosim/sdformat/pull/1065)
+
+1. Add skybox URI
+    * [Pull request #1037](https://github.com/gazebosim/sdformat/pull/1037)
+
+1. Bash completion for flags
+    * [Pull request #1042](https://github.com/gazebosim/sdformat/pull/1042)
+
+1. Fix bug with resolving poses for joint sensors.
+    * [Pull request #1033](https://github.com/gazebosim/sdformat/pull/1033)
+
+1. sdf::Joint: Mutable versions of SensorByName and SensorByIndex
+    * [Pull request #1031](https://github.com/gazebosim/sdformat/pull/1031)
+
+1. Add Link::ResolveInertial API
+    * [Pull request #1012](https://github.com/gazebosim/sdformat/pull/1012)
+
 ### libsdformat 12.5.0 (2022-05-12)
 
 1. Add visibility mask to Lidar / Ray sensor

--- a/Migration.md
+++ b/Migration.md
@@ -19,6 +19,11 @@ but with improved human-readability..
 1. USD component now is living in https://github.com/gazebosim/gz-usd as an
    independent package.
 
+1. URDF parser now properly transforms poses for lights, projectors and sensors
+   from gazebo extension tags that are moved to a new link during fixed joint
+   reduction.
+    + [pull request 1114](https://github.com/osrf/sdformat/pull/1114)
+
 ## libsdformat 11.x to 12.0
 
 An error is now emitted instead of a warning for a file containing more than


### PR DESCRIPTION
# 🎈 12.6.0~pre1 Preelease

Preparation for 12.6.0~pre1 prerelease.

Comparison to 12.5.0: https://github.com/gazebosim/sdformat/compare/sdformat12_12.5.0...sdf12

Needed by https://github.com/gazebosim/gz-sensors/pull/259

## Checklist
- [X] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [X] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
