### PR TITLE
ParamPassing: sdfwarns to sdf::Errors when warnings policy set to sdf::EnforcementPolicy::ERR

### DIFF
--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -569,7 +569,7 @@ void modifyAttributes(tinyxml2::XMLElement *_xml,
 
 //////////////////////////////////////////////////
 void modifyChildren(tinyxml2::XMLElement *_xml,
-                    const sdf::ParserConfig _config, ElementPtr _elem,
+                    const sdf::ParserConfig &_config, ElementPtr _elem,
                     Errors &_errors)
 {
   for (tinyxml2::XMLElement *xmlChild = _xml->FirstChildElement();
@@ -636,7 +636,7 @@ void modifyChildren(tinyxml2::XMLElement *_xml,
 }
 
 //////////////////////////////////////////////////
-void modify(tinyxml2::XMLElement *_xml,  const sdf::ParserConfig _config,
+void modify(tinyxml2::XMLElement *_xml,  const sdf::ParserConfig &_config,
             ElementPtr _elem, Errors &_errors)
 {
   modifyAttributes(_xml, _elem, _errors);
@@ -662,7 +662,7 @@ void modify(tinyxml2::XMLElement *_xml,  const sdf::ParserConfig _config,
 }
 
 //////////////////////////////////////////////////
-void remove(const tinyxml2::XMLElement *_xml, const sdf::ParserConfig _config,
+void remove(const tinyxml2::XMLElement *_xml, const sdf::ParserConfig &_config,
             ElementPtr _elem, Errors &_errors)
 {
   if (_xml->NoChildren())

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -587,7 +587,8 @@ void modifyChildren(tinyxml2::XMLElement *_xml,
       continue;
     }
 
-    ElementPtr elemChild = getElementByName(_elem, xmlChild, _config, _errors, true);
+    ElementPtr elemChild = getElementByName(_elem, xmlChild,
+                                            _config, _errors, true);
     ParamPtr paramChild = elemChild->GetValue();
 
     if (xmlChild->GetText())

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -24,6 +24,7 @@
 
 #include "ParamPassing.hh"
 #include "parser_private.hh"
+#include "Utils.hh"
 #include "XmlUtils.hh"
 
 namespace sdf
@@ -176,11 +177,11 @@ void updateParams(const ParserConfig &_config,
     }
     else if (actionStr == "modify")
     {
-      modify(childElemXml, elem, _errors);
+      modify(childElemXml, _config, elem, _errors);
     }
     else if (actionStr == "remove")
     {
-      remove(childElemXml, elem, _errors);
+      remove(childElemXml, _config, elem, _errors);
     }
     else if (actionStr == "replace")
     {
@@ -292,6 +293,8 @@ bool isValidAction(const std::string &_action)
 //////////////////////////////////////////////////
 ElementPtr getElementByName(const ElementPtr _elem,
                             const tinyxml2::XMLElement *_xml,
+                            const sdf::ParserConfig _config,
+                            sdf::Errors &_errors,
                             const bool _isModifyAction)
 {
   std::string elemName = _xml->Name();
@@ -324,10 +327,14 @@ ElementPtr getElementByName(const ElementPtr _elem,
   else if (elem->HasAttribute("name")
             && elem->GetAttribute("name")->GetRequired())
   {
-    sdfwarn << "The original element [" << elemName << "] contains the "
-            << "attribute 'name' but none was provided in the element modifier."
-            << " The assumed element to be modified is: <" << elemName
-            << " name='" << elem->Get<std::string>("name") << "'>\n";
+    std::stringstream ss;
+    ss << "The original element [" << elemName << "] contains the "
+       << "attribute 'name' but none was provided in the element modifier."
+       << " The assumed element to be modified is: <" << elemName
+       << " name='" << elem->Get<std::string>("name") << "'>";
+    Error err(ErrorCode::WARNING, ss.str());
+    enforceConfigurablePolicyCondition(
+        _config.WarningsPolicy(), err, _errors);
   }
 
   return elem;
@@ -397,7 +404,7 @@ void handleIndividualChildActions(const ParserConfig &_config,
 
     if (actionStr == "remove")
     {
-      ElementPtr e = getElementByName(_elem, xmlChild);
+      ElementPtr e = getElementByName(_elem, xmlChild, _config, _errors);
       if (e == nullptr)
       {
         _errors.push_back({ErrorCode::ELEMENT_MISSING,
@@ -409,14 +416,14 @@ void handleIndividualChildActions(const ParserConfig &_config,
       }
       else
       {
-        remove(xmlChild, e, _errors);
+        remove(xmlChild, _config, e, _errors);
       }
 
       continue;
     }
     else if (actionStr == "modify")
     {
-      ElementPtr e = getElementByName(_elem, xmlChild, true);
+      ElementPtr e = getElementByName(_elem, xmlChild, _config, _errors, true);
       if (e == nullptr)
       {
         _errors.push_back({ErrorCode::ELEMENT_MISSING,
@@ -428,7 +435,7 @@ void handleIndividualChildActions(const ParserConfig &_config,
       }
       else
       {
-        modify(xmlChild, e, _errors);
+        modify(xmlChild, _config, e, _errors);
       }
 
       continue;
@@ -472,7 +479,7 @@ void handleIndividualChildActions(const ParserConfig &_config,
     }
     else if (actionStr == "replace")
     {
-      ElementPtr e = getElementByName(_elem, xmlChild);
+      ElementPtr e = getElementByName(_elem, xmlChild, _config, _errors);
       if (e == nullptr)
       {
         _errors.push_back({ErrorCode::ELEMENT_MISSING,
@@ -562,7 +569,8 @@ void modifyAttributes(tinyxml2::XMLElement *_xml,
 
 //////////////////////////////////////////////////
 void modifyChildren(tinyxml2::XMLElement *_xml,
-                    ElementPtr _elem, Errors &_errors)
+                    const sdf::ParserConfig _config, ElementPtr _elem,
+                    Errors &_errors)
 {
   for (tinyxml2::XMLElement *xmlChild = _xml->FirstChildElement();
        xmlChild;
@@ -579,7 +587,7 @@ void modifyChildren(tinyxml2::XMLElement *_xml,
       continue;
     }
 
-    ElementPtr elemChild = getElementByName(_elem, xmlChild, true);
+    ElementPtr elemChild = getElementByName(_elem, xmlChild, _config, _errors, true);
     ParamPtr paramChild = elemChild->GetValue();
 
     if (xmlChild->GetText())
@@ -609,21 +617,26 @@ void modifyChildren(tinyxml2::XMLElement *_xml,
       else
       {
         // sdf has child elements but no children were specified in xml
-        sdfwarn << "No modifications for element "
-                << ElementToString(xmlChild)
-                << " provided, skipping modification for:\n"
-                << ElementToString(_xml) << "\n";
+        std::stringstream ss;
+        ss << "No modifications for element "
+           << ElementToString(xmlChild)
+           << " provided, skipping modification for:\n"
+           << ElementToString(_xml);
+        Error err(ErrorCode::WARNING, ss.str());
+        enforceConfigurablePolicyCondition(
+            _config.WarningsPolicy(), err, _errors);
       }
     }
     else
     {
-      modify(xmlChild, elemChild, _errors);
+      modify(xmlChild, _config, elemChild, _errors);
     }
   }
 }
 
 //////////////////////////////////////////////////
-void modify(tinyxml2::XMLElement *_xml, ElementPtr _elem, Errors &_errors)
+void modify(tinyxml2::XMLElement *_xml,  const sdf::ParserConfig _config,
+            ElementPtr _elem, Errors &_errors)
 {
   modifyAttributes(_xml, _elem, _errors);
 
@@ -643,12 +656,13 @@ void modify(tinyxml2::XMLElement *_xml, ElementPtr _elem, Errors &_errors)
   else
   {
     // modify children elements
-    modifyChildren(_xml, _elem, _errors);
+    modifyChildren(_xml, _config, _elem, _errors);
   }
 }
 
 //////////////////////////////////////////////////
-void remove(const tinyxml2::XMLElement *_xml, ElementPtr _elem, Errors &_errors)
+void remove(const tinyxml2::XMLElement *_xml, const sdf::ParserConfig _config,
+            ElementPtr _elem, Errors &_errors)
 {
   if (_xml->NoChildren())
   {
@@ -663,7 +677,7 @@ void remove(const tinyxml2::XMLElement *_xml, ElementPtr _elem, Errors &_errors)
          xmlChild;
          xmlChild = xmlChild->NextSiblingElement())
     {
-      elemChild = getElementByName(_elem, xmlChild);
+      elemChild = getElementByName(_elem, xmlChild, _config, _errors);
       if (elemChild == nullptr)
       {
         const tinyxml2::XMLElement *xmlParent = _xml->Parent()->ToElement();

--- a/src/ParamPassing.hh
+++ b/src/ParamPassing.hh
@@ -85,6 +85,8 @@ namespace sdf
     /// \param[in] _elem The sdf (parent) element used to find the matching
     /// child element described in xml
     /// \param[in] _xml The xml element to find
+    /// \param[in] _config Custom parser configuration.
+    /// \param[out] _errors Vector of errros.
     /// \param[in] _isModifyAction Is true if the action is modify, the
     /// attribute 'name' may not be in the sdf element (i.e., may be a
     /// modified/added attribute such as //camera)
@@ -92,6 +94,8 @@ namespace sdf
     /// element could not be found
     ElementPtr getElementByName(const ElementPtr _elem,
                                 const tinyxml2::XMLElement *_xml,
+                                const sdf::ParserConfig _config,
+                                sdf::Errors &_errors,
                                 const bool _isModifyAction = false);
 
     /// \brief Initialize an sdf element description from the xml element
@@ -143,24 +147,31 @@ namespace sdf
     /// \brief Modifies the children elements of the included model
     /// \param[in] _xml Pointer to the xml element which contains the elements
     /// to be modified
+    /// \param[in] _config Custom parser configuration.
     /// \param[out] _elem The element from the included model to modify
+    /// \param[out] _errors Vector of errors.
     void modifyChildren(tinyxml2::XMLElement *_xml,
-                        ElementPtr _elem, Errors &_errors);
+                        const sdf::ParserConfig _config, ElementPtr _elem,
+                        Errors &_errors);
 
     /// \brief Modifies element values and/or attributes of an element from the
     /// included model
     /// \param[in] _xml Pointer to the xml element which contains the elements
     /// to be modified
+    /// \param[in] _config Custom parser configuration.
     /// \param[out] _elem The element from the included model to modify
     /// \param[out] _errors Captures errors found during parsing
-    void modify(tinyxml2::XMLElement *_xml, ElementPtr _elem, Errors &_errors);
+    void modify(tinyxml2::XMLElement *_xml, const sdf::ParserConfig _config,
+                ElementPtr _elem, Errors &_errors);
 
     /// \brief Removes an element specified in xml
     /// \param[in] _xml Pointer to the xml element(s) to be removed from _elem
+    /// \param[in] _config Custom parser configuration.
     /// \param[out] _elem The element from the included model to remove
     /// elements from
     /// \param[out] _errors Captures errors found during parsing
-    void remove(const tinyxml2::XMLElement *_xml, ElementPtr _elem,
+    void remove(const tinyxml2::XMLElement *_xml,
+                const sdf::ParserConfig _config, ElementPtr _elem,
                 Errors &_errors);
 
     /// \brief Replace an element with another element

--- a/src/ParamPassing.hh
+++ b/src/ParamPassing.hh
@@ -161,7 +161,7 @@ namespace sdf
     /// \param[in] _config Custom parser configuration.
     /// \param[out] _elem The element from the included model to modify
     /// \param[out] _errors Captures errors found during parsing
-    void modify(tinyxml2::XMLElement *_xml, const sdf::ParserConfig _config,
+    void modify(tinyxml2::XMLElement *_xml, const sdf::ParserConfig &_config,
                 ElementPtr _elem, Errors &_errors);
 
     /// \brief Removes an element specified in xml

--- a/src/ParamPassing.hh
+++ b/src/ParamPassing.hh
@@ -171,7 +171,7 @@ namespace sdf
     /// elements from
     /// \param[out] _errors Captures errors found during parsing
     void remove(const tinyxml2::XMLElement *_xml,
-                const sdf::ParserConfig _config, ElementPtr _elem,
+                const sdf::ParserConfig &_config, ElementPtr _elem,
                 Errors &_errors);
 
     /// \brief Replace an element with another element

--- a/src/ParamPassing.hh
+++ b/src/ParamPassing.hh
@@ -151,7 +151,7 @@ namespace sdf
     /// \param[out] _elem The element from the included model to modify
     /// \param[out] _errors Vector of errors.
     void modifyChildren(tinyxml2::XMLElement *_xml,
-                        const sdf::ParserConfig _config, ElementPtr _elem,
+                        const sdf::ParserConfig &_config, ElementPtr _elem,
                         Errors &_errors);
 
     /// \brief Modifies element values and/or attributes of an element from the


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🎉 New feature

Work towards https://github.com/gazebosim/sdformat/issues/820.

## Summary
Makes warnings to be reported through `sdf::Errors` when the warnings policy is set to `sdf::EnforcementPolicy::ERR` in the `ParamPassing` class .

Since the tests added here directly test the specific messages on the specific functions of the `ParamPassing` class, they have been added to [ParamPassing_TEST.cc](https://github.com/gazebosim/sdformat/compare/main...marcoag/sdf_error_ParamPassing?expand=1#diff-e47d14a14a2bcaefb2587e21c4702252f4b59641644e98c93145abf5fc08b678) instead of the integration test [error_output.cc](https://github.com/gazebosim/sdformat/blob/main/test/integration/error_output.cc), but let me know if you think it's should be different.

## Test it

When using the `ParamPassing` class and setting the warnings policy to `sdf::EnforcementPolicy::ERR` warnings should be reported through in the `sdf::Errors` structure, they should be printed if the policy is different.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.