### PR TITLE
Param::Set: fix truncation of floating-point values

### DIFF
--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -682,7 +682,7 @@ namespace sdf
     try
     {
       std::stringstream ss;
-      ss << _value;
+      ss << ParamStreamer<T>{_value, std::numeric_limits<int>::max()};
       return this->SetFromString(ss.str(), true, _errors);
     }
     catch(...)
@@ -777,7 +777,8 @@ namespace sdf
 
     try
     {
-      ss << ParamStreamer{this->dataPtr->defaultValue};
+      ss << ParamStreamer{this->dataPtr->defaultValue,
+                          std::numeric_limits<int>::max()};
       ss >> _value;
     }
     catch(...)

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -99,6 +99,89 @@ TEST(Param, Bool)
 }
 
 ////////////////////////////////////////////////////
+/// Test getting and setting a floating point value
+TEST(Param, Double)
+{
+  sdf::Param doubleParam("key", "double", "0.0", false, "description");
+  double value = -1.0;
+  EXPECT_TRUE(doubleParam.Get<double>(value));
+  EXPECT_DOUBLE_EQ(0.0, value);
+
+  doubleParam.Set(1.0);
+  EXPECT_TRUE(doubleParam.Get<double>(value));
+  EXPECT_DOUBLE_EQ(1.0, value);
+
+  const double sixteenDigits = 12345678.87654321;
+  doubleParam.Set(sixteenDigits);
+  EXPECT_TRUE(doubleParam.Get<double>(value));
+  EXPECT_DOUBLE_EQ(sixteenDigits, value);
+}
+
+////////////////////////////////////////////////////
+/// Test getting and setting a Vector3d
+TEST(Param, Vector3d)
+{
+  sdf::Param vectorParam("key", "vector3", "0 0 0", false, "description");
+  gz::math::Vector3d value{1.0, 2.0, 3.0};
+  EXPECT_TRUE(vectorParam.Get<gz::math::Vector3d>(value));
+  EXPECT_DOUBLE_EQ(0.0, value.X());
+  EXPECT_DOUBLE_EQ(0.0, value.Y());
+  EXPECT_DOUBLE_EQ(0.0, value.Z());
+
+  vectorParam.Set(gz::math::Vector3d::One);
+  EXPECT_TRUE(vectorParam.Get<gz::math::Vector3d>(value));
+  EXPECT_DOUBLE_EQ(1.0, value.X());
+  EXPECT_DOUBLE_EQ(1.0, value.Y());
+  EXPECT_DOUBLE_EQ(1.0, value.Z());
+
+  const double fifteenDigits = 0.123456789012345;
+  const gz::math::Vector3d manyDigits{
+      fifteenDigits, 1.0 + fifteenDigits, 2.0 + fifteenDigits};
+  vectorParam.Set(manyDigits);
+  EXPECT_TRUE(vectorParam.Get<gz::math::Vector3d>(value));
+  EXPECT_DOUBLE_EQ(0.0 + fifteenDigits, value.X());
+  EXPECT_DOUBLE_EQ(1.0 + fifteenDigits, value.Y());
+  EXPECT_DOUBLE_EQ(2.0 + fifteenDigits, value.Z());
+}
+
+////////////////////////////////////////////////////
+/// Test getting and setting a Pose3d
+TEST(Param, Pose3d)
+{
+  sdf::Param poseParam("key", "pose", "0 0 0 0 0 0", false, "description");
+  gz::math::Pose3d value{1.0, 2.0, 3.0, 0.1, 0.2, 0.3};
+  EXPECT_TRUE(poseParam.Get<gz::math::Pose3d>(value));
+  EXPECT_DOUBLE_EQ(0.0, value.Pos().X());
+  EXPECT_DOUBLE_EQ(0.0, value.Pos().Y());
+  EXPECT_DOUBLE_EQ(0.0, value.Pos().Z());
+  EXPECT_DOUBLE_EQ(0.0, value.Rot().Euler().X());
+  EXPECT_DOUBLE_EQ(0.0, value.Rot().Euler().Y());
+  EXPECT_DOUBLE_EQ(0.0, value.Rot().Euler().Z());
+
+  poseParam.Set(gz::math::Pose3d(1, 2, 3, 0.1, 0.2, 0.3));
+  EXPECT_TRUE(poseParam.Get<gz::math::Pose3d>(value));
+  EXPECT_DOUBLE_EQ(1.0, value.Pos().X());
+  EXPECT_DOUBLE_EQ(2.0, value.Pos().Y());
+  EXPECT_DOUBLE_EQ(3.0, value.Pos().Z());
+  EXPECT_DOUBLE_EQ(0.1, value.Rot().Euler().X());
+  EXPECT_DOUBLE_EQ(0.2, value.Rot().Euler().Y());
+  EXPECT_DOUBLE_EQ(0.3, value.Rot().Euler().Z());
+
+  const double fifteenDigits = 0.123456789012345;
+  const gz::math::Pose3d manyDigits{
+      fifteenDigits, 1.0 + fifteenDigits, 2.0 + fifteenDigits,
+      0.5 * fifteenDigits, fifteenDigits, 2.0 * fifteenDigits};
+  poseParam.Set(manyDigits);
+  EXPECT_TRUE(poseParam.Get<gz::math::Pose3d>(value));
+  EXPECT_DOUBLE_EQ(0.0 + fifteenDigits, value.Pos().X());
+  EXPECT_DOUBLE_EQ(1.0 + fifteenDigits, value.Pos().Y());
+  EXPECT_DOUBLE_EQ(2.0 + fifteenDigits, value.Pos().Z());
+  EXPECT_DOUBLE_EQ(0.5 * fifteenDigits, value.Rot().Euler().X());
+  EXPECT_DOUBLE_EQ(1.0 * fifteenDigits, value.Rot().Euler().Y());
+  EXPECT_DOUBLE_EQ(2.0 * fifteenDigits, value.Rot().Euler().Z());
+}
+
+////////////////////////////////////////////////////
 /// Test decimal number
 TEST(SetFromString, Decimals)
 {

--- a/src/World_TEST.cc
+++ b/src/World_TEST.cc
@@ -596,8 +596,8 @@ TEST(DOMWorld, ToElement)
     "  <elevation>0</elevation>\n"
     "  <heading_deg>0</heading_deg>\n"
     "  <world_frame_orientation>ENU</world_frame_orientation>\n"
-    "  <surface_axis_equatorial>6378140</surface_axis_equatorial>\n"
-    "  <surface_axis_polar>6356750</surface_axis_polar>\n"
+    "  <surface_axis_equatorial>6378137</surface_axis_equatorial>\n"
+    "  <surface_axis_polar>6356752.3142449996</surface_axis_polar>\n"
     "</spherical_coordinates>\n";
 
   EXPECT_EQ(sphericalCoordsSdf,

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -42,6 +42,7 @@ set(tests
   plugin_bool.cc
   plugin_include.cc
   pose_1_9_sdf.cc
+  precision.cc
   print_config.cc
   provide_feedback.cc
   root_dom.cc

--- a/test/integration/precision.cc
+++ b/test/integration/precision.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+#include <string>
+#include "sdf/sdf.hh"
+
+std::string get_sdf_string()
+{
+  std::ostringstream stream;
+  stream
+    << "<sdf version='" << SDF_VERSION << "'>"
+    << "<model name=\"test\">"
+    << "  <link name=\"link\">"
+    << "    <visual name=\"visual\">"
+    << "      <geometry>"
+    << "        <sphere><radius>182536.87</radius></sphere>"
+    << "      </geometry>"
+    << "    </visual>"
+    << "  </link>"
+    << "</model>"
+    << "</sdf>";
+  return stream.str();
+}
+
+////////////////////////////////////////
+// make sure that XML errors get caught
+TEST(Precision, StringToDouble)
+{
+  sdf::SDFPtr model(new sdf::SDF());
+  sdf::init(model);
+  ASSERT_TRUE(sdf::readString(get_sdf_string(), model));
+
+  sdf::ElementPtr modelElem = model->Root()->GetElement("model");
+  EXPECT_TRUE(modelElem->HasElement("link"));
+  sdf::ElementPtr linkElem = modelElem->GetElement("link");
+  EXPECT_TRUE(linkElem->HasElement("visual"));
+  sdf::ElementPtr visualElem = linkElem->GetElement("visual");
+  EXPECT_TRUE(visualElem->HasElement("geometry"));
+  sdf::ElementPtr geomElem = visualElem->GetElement("geometry");
+  EXPECT_TRUE(geomElem->HasElement("sphere"));
+  sdf::ElementPtr sphereElem = geomElem->GetElement("sphere");
+  EXPECT_TRUE(sphereElem->HasElement("radius"));
+  sdf::ElementPtr radiusElem = sphereElem->GetElement("radius");
+
+  std::cout << std::setprecision(10) << radiusElem->Get<double>() << std::endl;
+
+  EXPECT_DOUBLE_EQ(radiusElem->Get<double>(), 182536.87);
+}


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1136, #103

## Summary

As noted in #1136, the `Param::Set` API currently truncates floating point values, demonstrated by the failing test added in https://github.com/gazebosim/sdformat/commit/f45d3710ac627cceeabd155e32b012d37f0ea477. In https://github.com/gazebosim/sdformat/commit/1107f212efaabfc6769bc5f287f1ba22955c0003, the `ParamStreamer` helper is used in `Param::Set` with maximum digits to prevent truncation. The expected values in a test are adjusted in https://github.com/gazebosim/sdformat/commit/9ef6cd70248322265f3d110d497448eb698754b2 to expect more precision.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
