### PR TITLE
Sensor: add sdf::Errors output to API methods

### DIFF
--- a/include/sdf/Sensor.hh
+++ b/include/sdf/Sensor.hh
@@ -214,6 +214,14 @@ namespace sdf
     /// \return SDF element pointer with updated sensor values.
     public: sdf::ElementPtr ToElement() const;
 
+    /// \brief Create and return an SDF element filled with data from this
+    /// sensor.
+    /// Note that parameter passing functionality is not captured with this
+    /// function.
+    /// \param[in] _errors Vector of errors.
+    /// \return SDF element pointer with updated sensor values.
+    public: sdf::ElementPtr ToElement(sdf::Errors &_errors) const;
+
     /// \brief Get the sensor type.
     /// \return The sensor type.
     public: SensorType Type() const;

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -692,12 +692,21 @@ Imu *Sensor::ImuSensor()
 /////////////////////////////////////////////////
 sdf::ElementPtr Sensor::ToElement() const
 {
+  sdf::Errors errors;
+  auto result = this->ToElement(errors);
+  sdf::throwOrPrintErrors(errors);
+  return result;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Sensor::ToElement(sdf::Errors &_errors) const
+{
   sdf::ElementPtr elem(new sdf::Element);
   sdf::initFile("sensor.sdf", elem);
 
-  elem->GetAttribute("type")->Set<std::string>(this->TypeStr());
-  elem->GetAttribute("name")->Set<std::string>(this->Name());
-  sdf::ElementPtr poseElem = elem->GetElement("pose");
+  elem->GetAttribute("type")->Set<std::string>(this->TypeStr(), _errors);
+  elem->GetAttribute("name")->Set<std::string>(this->Name(), _errors);
+  sdf::ElementPtr poseElem = elem->GetElement("pose", _errors);
   if (!this->dataPtr->poseRelativeTo.empty())
   {
     poseElem->GetAttribute("relative_to")->Set<std::string>(
@@ -760,8 +769,10 @@ sdf::ElementPtr Sensor::ToElement() const
   }
   else
   {
-    std::cout << "Conversion of sensor type: [" << this->TypeStr() << "] from "
-      << "SDF DOM to Element is not supported yet." << std::endl;
+    std::stringstream ss;
+    ss << "Conversion of sensor type: [" << this->TypeStr() << "] from SDF "
+       << "DOM to Element is not supported yet." << this->Name();
+    _errors.push_back({ErrorCode::ELEMENT_INVALID, ss.str()});
   }
 
   // Add in the plugins

--- a/test/integration/error_output.cc
+++ b/test/integration/error_output.cc
@@ -299,7 +299,7 @@ TEST(ErrorOutput, WorldErrorOutput)
 }
 
 ////////////////////////////////////////
-//Test Sensor class for sdf::Errors outputs
+// Test Sensor class for sdf::Errors outputs
 TEST(ErrorOutput, SensorErrorOutput)
 {
   std::stringstream buffer;

--- a/test/integration/error_output.cc
+++ b/test/integration/error_output.cc
@@ -23,6 +23,7 @@
 #include "sdf/Element.hh"
 #include "sdf/Error.hh"
 #include "sdf/Param.hh"
+#include "sdf/Sensor.hh"
 #include "sdf/Types.hh"
 #include "sdf/World.hh"
 #include "test_utils.hh"
@@ -293,6 +294,28 @@ TEST(ErrorOutput, WorldErrorOutput)
   EXPECT_NE(std::string::npos, errors[2].Message().find(
     "Frame with name [common_name] in world with name [test_world] has a name"
     " collision, changing frame name to [common_name_frame]."));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
+}
+
+////////////////////////////////////////
+//Test Sensor class for sdf::Errors outputs
+TEST(ErrorOutput, SensorErrorOutput)
+{
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+    sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::Errors errors;
+  sdf::Sensor sensor;
+  sensor.ToElement(errors);
+  ASSERT_EQ(errors.size(), 2u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Empty string used when setting a required parameter. Key[name]"));
+  EXPECT_NE(std::string::npos, errors[1].Message().find(
+    "Conversion of sensor type: [none] from SDF DOM to Element is not"
+    " supported yet."));
+
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 }


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🎉 New feature

Work towards https://github.com/gazebosim/sdformat/issues/820.

## Summary
Makes errors to be reported through `sdf::Errors` when using the `ToElement(sdf::Errors &_errors)` method of the `Sensor` class.

## Test it

Using the `ToElement(sdf::Errors &_errors)` method of the `Sensor` class should report all errors through `sdf::Errors`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.