### PR TITLE
Param: update calls to use sdf::Errors parameters

### DIFF
--- a/src/Param.cc
+++ b/src/Param.cc
@@ -1473,7 +1473,7 @@ bool Param::ValidateValue(sdf::Errors &_errors) const
               std::ostringstream oss;
               oss << "The value [" << _val
                   << "] is less than the minimum allowed value of ["
-                  << *this->GetMinValueAsString() << "] for key ["
+                  << *this->GetMinValueAsString(_errors) << "] for key ["
                   << this->GetKey() << "]";
               _errors.push_back({ErrorCode::PARAMETER_ERROR, oss.str()});
               return false;
@@ -1486,7 +1486,7 @@ bool Param::ValidateValue(sdf::Errors &_errors) const
               std::ostringstream oss;
               oss << "The value [" << _val
                   << "] is greater than the maximum allowed value of ["
-                  << *this->GetMaxValueAsString() << "] for key ["
+                  << *this->GetMaxValueAsString(_errors) << "] for key ["
                   << this->GetKey() << "]";
               _errors.push_back({ErrorCode::PARAMETER_ERROR, oss.str()});
               return false;


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🎉 New feature

Work towards https://github.com/gazebosim/sdformat/issues/820.

## Summary
Adds missing `Errors` structure parameters in a few calls on the Param class.

## Test it

Using the Param class should report all errors through `sdf::Errors`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.