### PR TITLE
Offer an API option to display new warnings on problems with URDF to SDF conversions

### DIFF
--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -115,6 +115,21 @@ namespace sdf
   SDFORMAT_VISIBLE
   bool readFile(const std::string &_filename, SDFPtr _sdf);
 
+  /// \brief Populate the SDF values from a file
+  ///
+  /// This populates the given sdf pointer from a file. If the file is a URDF
+  /// file it is converted to SDF first. All files are converted to the latest
+  /// SDF version
+  /// \param[in] _filename Name of the SDF file
+  /// \param[in] _sdf Pointer to an SDF object.
+  /// \param[in] _enable_new_warnings Consider previous issues in debug log as
+  ///            warnings. This allow to keep log level backwards compatible
+  ///            while providing an option to increase the warnings with new
+  ///            relevant issues.
+  /// \return True if successful.
+  bool readFile(const std::string &_filename, SDFPtr _sdf,
+      bool _enable_new_warnings);
+
   /// \brief Populate the SDF values from a string
   ///
   /// This populates the sdf pointer from a string. If the string is a URDF

--- a/include/sdf/parser_urdf.hh
+++ b/include/sdf/parser_urdf.hh
@@ -42,6 +42,15 @@ namespace sdf
     /// \brief constructor
     public: URDF2SDF();
 
+    /// \brief constructor
+    /// \param[in] _enable_new_warnings Consider previous issues in debug log as
+    ///            warnings.
+    public: explicit URDF2SDF(const bool _enable_new_warnings) :
+            URDF2SDF()
+      {
+        enable_new_warnings = _enable_new_warnings;
+      };
+
     /// \brief destructor
     public: ~URDF2SDF();
 
@@ -81,6 +90,9 @@ namespace sdf
     // cppcheck-suppress unusedPrivateFunction
     // cppcheck-suppress unmatchedSuppression
     private: void ListSDFExtensions(const std::string &_reference);
+
+    /// when to raise new warnings from previous log issues
+    private: bool enable_new_warnings;
   };
   }
 }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -54,12 +54,15 @@ inline namespace SDF_VERSION_NAMESPACE {
 /// \param[in] _sdf Pointer to an SDF object.
 /// \param[in] _convert Convert to the latest version if true.
 /// \param[out] _errors Parsing errors will be appended to this variable.
+/// \param[in] _enable_new_warnings Consider previous issues in debug log as
+///            warnings.
 /// \return True if successful.
 bool readFileInternal(
     const std::string &_filename,
     SDFPtr _sdf,
     const bool _convert,
-    Errors &_errors);
+    Errors &_errors,
+    bool _enable_new_warnings);
 
 /// \brief Internal helper for readString, which populates the SDF values
 /// from a string
@@ -71,12 +74,15 @@ bool readFileInternal(
 /// \param[in] _sdf Pointer to an SDF object.
 /// \param[in] _convert Convert to the latest version if true.
 /// \param[out] _errors Parsing errors will be appended to this variable.
+/// \param[in] _enable_new_warnings Consider previous issues in debug log as
+///            warnings.
 /// \return True if successful.
 bool readStringInternal(
     const std::string &_xmlString,
     SDFPtr _sdf,
     const bool _convert,
-    Errors &_errors);
+    Errors &_errors,
+    bool _enable_new_warnings);
 
 //////////////////////////////////////////////////
 template <typename TPtr>
@@ -364,19 +370,26 @@ bool readFile(const std::string &_filename, SDFPtr _sdf)
 //////////////////////////////////////////////////
 bool readFile(const std::string &_filename, SDFPtr _sdf, Errors &_errors)
 {
-  return readFileInternal(_filename, _sdf, true, _errors);
+  return readFileInternal(_filename, _sdf, true, _errors, false);
+}
+
+//////////////////////////////////////////////////
+bool readFile(const std::string &_filename, SDFPtr _sdf, Errors &_errors,
+    const bool _enable_new_warnings)
+{
+  return readFileInternal(_filename, _sdf, true, _errors, _enable_new_warnings);
 }
 
 //////////////////////////////////////////////////
 bool readFileWithoutConversion(
     const std::string &_filename, SDFPtr _sdf, Errors &_errors)
 {
-  return readFileInternal(_filename, _sdf, false, _errors);
+  return readFileInternal(_filename, _sdf, false, _errors, false);
 }
 
 //////////////////////////////////////////////////
 bool readFileInternal(const std::string &_filename, SDFPtr _sdf,
-      const bool _convert, Errors &_errors)
+      const bool _convert, Errors &_errors, bool _enable_new_warnings)
 {
   TiXmlDocument xmlDoc;
   std::string filename = sdf::findFile(_filename, true, true);
@@ -413,7 +426,7 @@ bool readFileInternal(const std::string &_filename, SDFPtr _sdf,
   }
   else if (URDF2SDF::IsURDF(filename))
   {
-    URDF2SDF u2g;
+    URDF2SDF u2g(_enable_new_warnings);
     TiXmlDocument doc = u2g.InitModelFile(filename);
     if (sdf::readDoc(&doc, _sdf, "urdf file", _convert, _errors))
     {
@@ -447,19 +460,19 @@ bool readString(const std::string &_xmlString, SDFPtr _sdf)
 //////////////////////////////////////////////////
 bool readString(const std::string &_xmlString, SDFPtr _sdf, Errors &_errors)
 {
-  return readStringInternal(_xmlString, _sdf, true, _errors);
+  return readStringInternal(_xmlString, _sdf, true, _errors, false);
 }
 
 //////////////////////////////////////////////////
 bool readStringWithoutConversion(
     const std::string &_filename, SDFPtr _sdf, Errors &_errors)
 {
-  return readStringInternal(_filename, _sdf, false, _errors);
+  return readStringInternal(_filename, _sdf, false, _errors, false);
 }
 
 //////////////////////////////////////////////////
 bool readStringInternal(const std::string &_xmlString, SDFPtr _sdf,
-    const bool _convert, Errors &_errors)
+    const bool _convert, Errors &_errors, bool _enable_new_warnings)
 {
   TiXmlDocument xmlDoc;
   xmlDoc.Parse(_xmlString.c_str());
@@ -475,9 +488,9 @@ bool readStringInternal(const std::string &_xmlString, SDFPtr _sdf,
   else
   {
     SDF_SUPPRESS_DEPRECATED_BEGIN
-    URDF2SDF u2g;
+    URDF2SDF u2g(_enable_new_warnings);
     SDF_SUPPRESS_DEPRECATED_END
-    TiXmlDocument doc = u2g.InitModelString(_xmlString);
+    TiXmlDocument doc = u2g.InitModelString(_xmlString, true);
     if (sdf::readDoc(&doc, _sdf, "urdf string", _convert, _errors))
     {
       sdfdbg << "Parsing from urdf.\n";

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2626,8 +2626,9 @@ void CreateSDF(TiXmlElement *_root,
     if (_link->inertial && ignition::math::equal(_link->inertial->mass, 0.0))
     {
       _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
-             + "] has mass equal to 0.0, ["
-             + "] children links ignored.\n", _enable_new_warnings);
+             + "] has a mass considered zero ["
+             + std::to_string(_link->inertial->mass) +
+             + "].It is ignored.\n", _enable_new_warnings);
       return;
     }
 

--- a/src/parser_urdf_TEST.cc
+++ b/src/parser_urdf_TEST.cc
@@ -388,7 +388,7 @@ TEST(URDFParser, EnableNewWarnings)
                    << "      </geometry>"
                    << "    </visual>"
                    << "    <inertial>"
-                   << "      <mass value=\"0.0000001\" />"
+                   << "      <mass value=\"0.000001\" />"
                    << "      <origin xyz=\"0 0 0\" />"
                    << "      <inertia ixx=\"0.001\" ixy=\"0.0\" ixz=\"0.0\""
                    << "               iyy=\"0.001\" iyz=\"0.0\""
@@ -400,7 +400,7 @@ TEST(URDFParser, EnableNewWarnings)
   ASSERT_NO_THROW(parser_.InitModelDoc(&doc));
   // Check warning message
   EXPECT_NE(
-    std::string::npos, buffer.str().find("] has mass equal to 0.0"))
+    std::string::npos, buffer.str().find("] has a mass considered zero ["))
     << buffer.str();
   }
 }

--- a/src/parser_urdf_TEST.cc
+++ b/src/parser_urdf_TEST.cc
@@ -22,6 +22,8 @@
 #include "sdf/sdf.hh"
 #include "sdf/parser_urdf.hh"
 
+#include "test_utils.hh"
+
 /////////////////////////////////////////////////
 std::string getMinimalUrdfTxt()
 {
@@ -335,46 +337,72 @@ TEST(URDFParser, ParseGazeboLinkFactors)
 /////////////////////////////////////////////////
 TEST(URDFParser, EnableNewWarnings)
 {
-  std::ostringstream stream_no_inertial;
-  // Testing no inertia and inertia 0.0
-  stream_no_inertial << "<robot name=\"test\">"
-                     << "  <link name=\"link_no_inertia\">"
-                     << "    <visual>"
-                     << "      <geometry>"
-                     << "         <sphere radius=\"1.0\"/>"
-                     << "      </geometry>"
-                     << "    </visual>"
-                     << "  </link>"
-                     << "</robot>";
-  std::ostringstream stream_no_mass;
-  // Testing mass zero
-  stream_no_mass << "<robot name=\"test\">"
-                 << "  <link name=\"link_no_mass\">"
-                 << "    <visual>"
-                 << "      <geometry>"
-                 << "         <sphere radius=\"1.0\"/>"
-                 << "      </geometry>"
-                 << "    </visual>"
-                 << "    <inertial>"
-                 << "      <mass value=\"0.000001\" />"
-                 << "      <origin xyz=\"0 0 0\" />"
-                 << "      <inertia ixx=\"0.001\" ixy=\"0.0\" ixz=\"0.0\""
-                 << "               iyy=\"0.001\" iyz=\"0.0\""
-                 << "               izz=\"0.001\" />"
-                 << "    </inertial>"
-                 << "  </link>"
-                 << "</robot>";
-
+    // Redirect sdfwarn output (copied from model_dom.cc)
+    std::stringstream buffer;
+    sdf::testing::RedirectConsoleStream redir(
+        sdf::Console::Instance()->GetMsgStream(), &buffer);
+#ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+        []
+        {
+          sdf::Console::Instance()->SetQuiet(true);
+        });
+#endif
   SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser_(true);
   SDF_SUPPRESS_DEPRECATED_END
-  TiXmlDocument doc;
 
-  doc.Parse(stream_no_inertial.str().c_str());
-  ASSERT_NO_THROW(parser_.InitModelDoc(&doc));
+  {
+    TiXmlDocument doc;
+    buffer.str("");
+    std::ostringstream stream_no_inertial;
+    // Testing no inertia and inertia 0.0
+    stream_no_inertial << "<robot name=\"test\">"
+                       << "  <link name=\"link_no_inertia\">"
+                       << "    <visual>"
+                       << "      <geometry>"
+                       << "         <sphere radius=\"1.0\"/>"
+                       << "      </geometry>"
+                       << "    </visual>"
+                       << "  </link>"
+                       << "</robot>";
+    doc.Parse(stream_no_inertial.str().c_str());
+    ASSERT_NO_THROW(parser_.InitModelDoc(&doc));
+    // Check warning message
+    EXPECT_NE(
+      std::string::npos, buffer.str().find("] has no inertia"))
+      << buffer.str();
+  }
 
+  {
+    TiXmlDocument doc;
+    buffer.str("");
+    std::ostringstream stream_no_mass;
+    // Testing mass zero
+    stream_no_mass << "<robot name=\"test\">"
+                   << "  <link name=\"link_no_mass\">"
+                   << "    <visual>"
+                   << "      <geometry>"
+                   << "         <sphere radius=\"1.0\"/>"
+                   << "      </geometry>"
+                   << "    </visual>"
+                   << "    <inertial>"
+                   << "      <mass value=\"0.0000001\" />"
+                   << "      <origin xyz=\"0 0 0\" />"
+                   << "      <inertia ixx=\"0.001\" ixy=\"0.0\" ixz=\"0.0\""
+                   << "               iyy=\"0.001\" iyz=\"0.0\""
+                   << "               izz=\"0.001\" />"
+                   << "    </inertial>"
+                   << "  </link>"
+                   << "</robot>";
   doc.Parse(stream_no_mass.str().c_str());
   ASSERT_NO_THROW(parser_.InitModelDoc(&doc));
+  // Check warning message
+  EXPECT_NE(
+    std::string::npos, buffer.str().find("] has mass equal to 0.0"))
+    << buffer.str();
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/parser_urdf_TEST.cc
+++ b/src/parser_urdf_TEST.cc
@@ -333,6 +333,51 @@ TEST(URDFParser, ParseGazeboLinkFactors)
 }
 
 /////////////////////////////////////////////////
+TEST(URDFParser, EnableNewWarnings)
+{
+  std::ostringstream stream_no_inertial;
+  // Testing no inertia and inertia 0.0
+  stream_no_inertial << "<robot name=\"test\">"
+                     << "  <link name=\"link_no_inertia\">"
+                     << "    <visual>"
+                     << "      <geometry>"
+                     << "         <sphere radius=\"1.0\"/>"
+                     << "      </geometry>"
+                     << "    </visual>"
+                     << "  </link>"
+                     << "</robot>";
+  std::ostringstream stream_no_mass;
+  // Testing mass zero
+  stream_no_mass << "<robot name=\"test\">"
+                 << "  <link name=\"link_no_mass\">"
+                 << "    <visual>"
+                 << "      <geometry>"
+                 << "         <sphere radius=\"1.0\"/>"
+                 << "      </geometry>"
+                 << "    </visual>"
+                 << "    <inertial>"
+                 << "      <mass value=\"0.000001\" />"
+                 << "      <origin xyz=\"0 0 0\" />"
+                 << "      <inertia ixx=\"0.001\" ixy=\"0.0\" ixz=\"0.0\""
+                 << "               iyy=\"0.001\" iyz=\"0.0\""
+                 << "               izz=\"0.001\" />"
+                 << "    </inertial>"
+                 << "  </link>"
+                 << "</robot>";
+
+  SDF_SUPPRESS_DEPRECATED_BEGIN
+  sdf::URDF2SDF parser_(true);
+  SDF_SUPPRESS_DEPRECATED_END
+  TiXmlDocument doc;
+
+  doc.Parse(stream_no_inertial.str().c_str());
+  ASSERT_NO_THROW(parser_.InitModelDoc(&doc));
+
+  doc.Parse(stream_no_mass.str().c_str());
+  ASSERT_NO_THROW(parser_.InitModelDoc(&doc));
+}
+
+/////////////////////////////////////////////////
 TEST(URDFParser, ParseGazeboInvalidDampingFactor)
 {
   std::ostringstream stream;


### PR DESCRIPTION
# 🎉 New feature

Should help providing an API option to have explicit warnings for https://github.com/gazebosim/sdformat/issues/199 and https://github.com/gazebosim/sdformat/issues/1007.

## Summary
The PR tries to address the lack of the explicit information on decisions made that end up ignoring some link definitions in the user input which can lead to many problems see https://github.com/gazebosim/sdformat/issues/199 and https://github.com/gazebosim/sdformat/issues/1007.

For keeping backwards compatibility, no new warning is raised unless the consumer of sdformat readFile 

The PR implements a new API function:
```c++
bool readFile(const std::string &_filename, SDFPtr _sdf, bool _enable_new_warnings);
```
that allows users of sdf to enable new extra warnings.

If the parameter is enabled, the problems with links being ignored silently (not really, but the issues were stored in the logs) are promoted to warnings using `gzwarn` in the `CreateSDF` function.

## Test it
Should be fairly trivial to change Gazebo or other consumer of the `readFile` API to use the new parameter. Examples of code that triggers problems can be found in https://github.com/gazebosim/sdformat/issues/199 and https://github.com/gazebosim/sdformat/issues/1007. Simple patch for gazebo9:
```diff
diff --git a/tools/gz.cc b/tools/gz.cc
index 7a8f3d6b16..116c94541f 100644
--- a/tools/gz.cc
+++ b/tools/gz.cc
@@ -1070,6 +1070,10 @@ bool SDFCommand::RunImpl()
     }
   }
 
+  bool new_warnings = true;
+  if (common::getEnv("GAZEBO11_BACKWARDS_COMPAT_WARNINGS_ERRORS"))
+    new_warnings = false;
+
   if (!sdf::init(sdf))
   {
     std::cerr << "ERROR: SDF parsing the xml failed" << std::endl;
@@ -1124,7 +1128,7 @@ bool SDFCommand::RunImpl()
     if (!boost::filesystem::exists(path))
       std::cerr << "Error: File doesn't exist[" << path.string() << "]\n";
 
-    if (!sdf::readFile(path.string(), sdf))
+    if (!sdf::readFile(path.string(), sdf, new_warnings))
     {
       std::cerr << "Error: SDF parsing the xml failed\n";
       return false;
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.