### PR TITLE
Prepare for 13.0.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.0.0)
+project (sdformat13 VERSION 13.0.1)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ## libsdformat 13.X
 
-### libsdformat 13.0.0 (202X-XX-XX)
+### libsdformat 13.0.1 (2022-09-27)
+
+1. Fix arm tests
+    * [Pull request #1173](https://github.com/gazebosim/sdformat/pull/1173)
+
+### libsdformat 13.0.0 (2022-09-23)
 
 1. Add camera `optical_frame_id` element
     * [Pull request #1109](https://github.com/gazebosim/sdformat/pull/1109)


### PR DESCRIPTION
# 🎈 Release

Preparation for 13.0.1 release.

Comparison to 13.0.0: https://github.com/gazebosim/sdformat/compare/sdformat13_13.0.0...sdf13


## Checklist
- [X] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
