### PR TITLE
sdf error backport

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -83,9 +83,19 @@ namespace sdf
     /// \return A copy of this Element.
     public: ElementPtr Clone() const;
 
+    /// \brief Create a copy of this Element.
+    /// \param[out] _errors Vector of errors.
+    /// \return A copy of this Element, NULL if there was an error.
+    public: ElementPtr Clone(sdf::Errors &_errors) const;
+
     /// \brief Copy values from an Element.
     /// \param[in] _elem Element to copy value from.
     public: void Copy(const ElementPtr _elem);
+
+    /// \brief Copy values from an Element.
+    /// \param[in] _elem Element to copy value from.
+    /// \param[out] _errors Vector of errors.
+    public: void Copy(const ElementPtr _elem, sdf::Errors &_errors);
 
     /// \brief Get a pointer to this Element's parent.
     /// \return Pointer to this Element's parent, NULL if there is no
@@ -220,6 +230,21 @@ namespace sdf
                               bool _required,
                               const std::string &_description = "");
 
+    /// \brief Add an attribute value.
+    /// \param[in] _key Key value.
+    /// \param[in] _type Type of data the attribute will hold.
+    /// \param[in] _defaultValue Default value for the attribute.
+    /// \param[in] _required Requirement string. \as Element::SetRequired.
+    /// \param[out] _errors Vector of errors.
+    /// \param[in] _description A text description of the attribute.
+    /// \throws sdf::AssertionInternalError if an invalid type is given.
+    public: void AddAttribute(const std::string &_key,
+                              const std::string &_type,
+                              const std::string &_defaultvalue,
+                              bool _required,
+                              sdf::Errors &_errors,
+                              const std::string &_description = "");
+
     /// \brief Add a value to this Element.
     /// \param[in] _type Type of data the parameter will hold.
     /// \param[in] _defaultValue Default value for the parameter.
@@ -228,6 +253,18 @@ namespace sdf
     /// \throws sdf::AssertionInternalError if an invalid type is given.
     public: void AddValue(const std::string &_type,
                           const std::string &_defaultValue, bool _required,
+                          const std::string &_description = "");
+
+    /// \brief Add a value to this Element.
+    /// \param[in] _type Type of data the parameter will hold.
+    /// \param[in] _defaultValue Default value for the parameter.
+    /// \param[in] _required Requirement string. \as Element::SetRequired.
+    /// \param[out] _errors Vector of errors.
+    /// \param[in] _description A text description of the parameter.
+    /// \throws sdf::AssertionInternalError if an invalid type is given.
+    public: void AddValue(const std::string &_type,
+                          const std::string &_defaultValue, bool _required,
+                          sdf::Errors &_errors,
                           const std::string &_description = "");
 
     /// \brief Add a value to this Element. This override allows passing min and
@@ -243,6 +280,23 @@ namespace sdf
                           const std::string &_defaultValue, bool _required,
                           const std::string &_minValue,
                           const std::string &_maxValue,
+                          const std::string &_description = "");
+
+    /// \brief Add a value to this Element. This override allows passing min and
+    /// max values of the parameter.
+    /// \param[in] _type Type of data the parameter will hold.
+    /// \param[in] _defaultValue Default value for the parameter.
+    /// \param[in] _required Requirement string. \as Element::SetRequired.
+    /// \param[in] _minValue Minimum allowed value for the parameter.
+    /// \param[in] _maxValue Maximum allowed value for the parameter.
+    /// \param[out] _errors Vector of errors.
+    /// \param[in] _description A text description of the parameter.
+    /// \throws sdf::AssertionInternalError if an invalid type is given.
+    public: void AddValue(const std::string &_type,
+                          const std::string &_defaultValue, bool _required,
+                          const std::string &_minValue,
+                          const std::string &_maxValue,
+                          sdf::Errors &_errors,
                           const std::string &_description = "");
 
     /// \brief Get the param of an attribute.
@@ -308,6 +362,14 @@ namespace sdf
     /// the element. Defaults to empty.
     /// \return The element as a std::any.
     public: std::any GetAny(const std::string &_key = "") const;
+
+    /// \brief Get the element value/attribute as a std::any.
+    /// \param[in] _key The key of the attribute. If empty, get the value of
+    /// the element. Defaults to empty.
+    /// \param[out] _errors Vector of errors.
+    /// \return The element as a std::any.
+    public: std::any GetAny(sdf::Errors &_errors,
+                            const std::string &_key = "") const;
 
     /// \brief Get the value of a key. This function assumes the _key
     /// exists.
@@ -433,6 +495,20 @@ namespace sdf
 
     /// \brief Return a pointer to the child element with the provided name.
     ///
+    /// A new child element, with the provided name, is added to this element
+    /// if there is no existing child element. If this is not desired see \ref
+    /// FindElement
+    /// \remarks If there are multiple elements with the given tag, it returns
+    ///          the first one.
+    /// \param[in] _name Name of the child element to retreive.
+    /// \param[out] _errors Vector of errors.
+    /// \return Pointer to the existing child element, or a new child
+    /// element if an existing child element did not exist.
+    public: ElementPtr GetElement(const std::string &_name,
+                sdf::Errors &_errors);
+
+    /// \brief Return a pointer to the child element with the provided name.
+    ///
     /// Unlike \ref GetElement, this does not create a new child element if it
     /// fails to find an existing element.
     /// \remarks If there are multiple elements with the given tag, it returns
@@ -458,6 +534,13 @@ namespace sdf
     /// \return A pointer to the newly created Element object.
     public: ElementPtr AddElement(const std::string &_name);
 
+    /// \brief Add a named element.
+    /// \param[in] _name the name of the element to add.
+    /// \param[out] _errors Vector of errors.
+    /// \return A pointer to the newly created Element object.
+    public: ElementPtr AddElement(const std::string &_name,
+                sdf::Errors &_errors);
+
     /// \brief Add an element object.
     /// \param[in] _elem the element object to add.
     public: void InsertElement(ElementPtr _elem);
@@ -475,6 +558,11 @@ namespace sdf
     /// \brief Remove a child element.
     /// \param[in] _child Pointer to the child to remove.
     public: void RemoveChild(ElementPtr _child);
+
+    /// \brief Remove a child element.
+    /// \param[in] _child Pointer to the child to remove.
+    /// \param[out] _errors Vector of errors.
+    public: void RemoveChild(ElementPtr _child, sdf::Errors &_errors);
 
     /// \brief Remove all child elements.
     public: void ClearElements();
@@ -602,14 +690,15 @@ namespace sdf
     /// int,...).
     /// \param[in] _defaultValue Default value.
     /// \param[in] _required True if the parameter is required to be set.
+    /// \param[out] _errors Vector of errors.
     /// \param[in] _description Description of the parameter.
     /// \return A pointer to the new Param object.
     private: ParamPtr CreateParam(const std::string &_key,
                                   const std::string &_type,
                                   const std::string &_defaultValue,
                                   bool _required,
+                                  sdf::Errors &_errors,
                                   const std::string &_description = "");
-
 
     /// \brief Private data pointer
     private: std::unique_ptr<ElementPrivate> dataPtr;

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -165,6 +165,9 @@ namespace sdf
     /// \brief Generic error to be thrown with SDF_ASSERT by the caller.
     /// This has been created to help preserve behavior.
     FATAL_ERROR,
+
+    /// \brief Generic warning saved as error due to WarningsPolicy config
+    WARNING,
   };
 
   class SDFORMAT_VISIBLE Error

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -161,6 +161,10 @@ namespace sdf
     /// \brief The specified parameter (values of SDFormat elements
     /// or attributes) type is unknown.
     UNKNOWN_PARAMETER_TYPE,
+
+    /// \brief Generic error to be thrown with SDF_ASSERT by the caller.
+    /// This has been created to help preserve behavior.
+    FATAL_ERROR,
   };
 
   class SDFORMAT_VISIBLE Error

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -307,14 +307,14 @@ namespace sdf
 
     /// \brief Set the parent Element of this Param.
     /// \param[in] _parentElement Pointer to new parent Element. A nullptr can
-    /// provided to remove the current parent Element.
+    ///  be provided to remove the current parent Element.
     /// \return True if the parent Element was set and the value was reparsed
     /// successfully.
     public: bool SetParentElement(ElementPtr _parentElement);
 
     /// \brief Set the parent Element of this Param.
     /// \param[in] _parentElement Pointer to new parent Element. A nullptr can
-    /// provided to remove the current parent Element.
+    /// be provided to remove the current parent Element.
     /// \param[out] _errors Vector of errors.
     /// \return True if the parent Element was set and the value was reparsed
     /// successfully.

--- a/include/sdf/PrintConfig.hh
+++ b/include/sdf/PrintConfig.hh
@@ -22,6 +22,7 @@
 
 #include "sdf/sdf_config.h"
 #include "sdf/system_util.hh"
+#include "sdf/Types.hh"
 
 namespace sdf
 {
@@ -53,6 +54,19 @@ namespace sdf
     /// \return True, unless any of the provided values are not valid.
     public: bool SetRotationSnapToDegrees(unsigned int _interval,
                                           double _tolerance);
+
+    /// \brief Sets the option for printing pose rotation in degrees as well as
+    /// snapping the rotation to the desired interval, with the provided
+    /// tolerance.
+    /// \param[in] _interval Degrees interval to snap to, this value must be
+    /// larger than 0, and less than or equal to 360.
+    /// \param[in] _tolerance Tolerance which snapping occurs, this value must
+    /// be larger than 0, less than 360, and less than the provided interval.
+    /// \param[out] _errors Vector of Errors.
+    /// \return True, unless any of the provided values are not valid.
+    public: bool SetRotationSnapToDegrees(unsigned int _interval,
+                                          double _tolerance,
+                                          sdf::Errors &_errors);
 
     /// \brief Returns the current degree value that pose rotations will snap to
     /// when printed.

--- a/src/Param.cc
+++ b/src/Param.cc
@@ -987,7 +987,7 @@ bool ParamPrivate::ValueFromStringImpl(const std::string &_typeName,
   {
     _errors.push_back({ErrorCode::PARAMETER_ERROR,
         "Invalid argument. Unable to set value ["
-        + _valueStr + " ] for key["
+        + _valueStr + "] for key["
         + this->key + "]."});
     return false;
   }

--- a/src/PrintConfig.cc
+++ b/src/PrintConfig.cc
@@ -18,6 +18,7 @@
 
 #include "sdf/PrintConfig.hh"
 #include "sdf/Console.hh"
+#include "Utils.hh"
 
 using namespace sdf;
 
@@ -76,18 +77,35 @@ bool PrintConfig::PreserveIncludes() const
 bool PrintConfig::SetRotationSnapToDegrees(unsigned int _interval,
                                            double _tolerance)
 {
+  sdf::Errors errors;
+  bool result = this->SetRotationSnapToDegrees(_interval,
+                                               _tolerance,
+                                               errors);
+  throwOrPrintErrors(errors);
+  return result;
+}
+
+/////////////////////////////////////////////////
+bool PrintConfig::SetRotationSnapToDegrees(unsigned int _interval,
+                                           double _tolerance,
+                                           sdf::Errors &_errors)
+{
   if (_interval == 0 || _interval > 360)
   {
-    sdferr << "Interval value to snap to must be larger than 0, and less than "
-           << "or equal to 360.\n";
+    std::stringstream ss;
+    ss << "Interval value to snap to must be larger than 0, and less than "
+       << "or equal to 360.";
+    _errors.push_back({ErrorCode::ROTATION_SNAP_CONFIG_ERROR, ss.str()});
     return false;
   }
 
   if (_tolerance <= 0 || _tolerance > 360 ||
       _tolerance >= static_cast<double>(_interval))
   {
-    sdferr << "Tolerance must be larger than 0, less than or equal to "
-           << "360, and less than the provided interval.\n";
+    std::stringstream ss;
+    ss << "Tolerance must be larger than 0, less than or equal to "
+       << "360, and less than the provided interval.";
+    _errors.push_back({ErrorCode::ROTATION_SNAP_CONFIG_ERROR, ss.str()});
     return false;
   }
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -17,6 +17,7 @@
 #include <limits>
 #include <string>
 #include <utility>
+#include "sdf/Assert.hh"
 #include "sdf/SDFImpl.hh"
 #include "Utils.hh"
 
@@ -162,6 +163,22 @@ void enforceConfigurablePolicyCondition(
       break;
     default:
       throw std::runtime_error("Unhandled warning policy enum value");
+  }
+}
+
+/////////////////////////////////////////////////
+void throwOrPrintErrors(const sdf::Errors& _errors)
+{
+  for(auto& error : _errors)
+  {
+    if (error.Code() == sdf::ErrorCode::FATAL_ERROR)
+    {
+      SDF_ASSERT(false, error.Message());
+    }
+    else
+    {
+      sdferr << error.Message();
+    }
   }
 }
 

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -85,6 +85,11 @@ namespace sdf
     const sdf::Error &_error,
     sdf::Errors &_errors);
 
+  /// \brief It will print the errors to sdferr or throw them using
+  /// SDF_ASSERT depending on their ErrorCode.
+  /// \param[in] _errors  The vector of errors.
+  void throwOrPrintErrors(const sdf::Errors& _errors);
+
   /// \brief Load all objects of a specific sdf element type. No error
   /// is returned if an element is not present. This function assumes that
   /// an element has a "name" attribute that must be unique.

--- a/src/World.cc
+++ b/src/World.cc
@@ -206,20 +206,13 @@ Errors World::Load(sdf::ElementPtr _sdf, const ParserConfig &_config)
   {
     if (size > 1)
     {
-      sdfwarn << "Non-unique name[" << name << "] detected " << size
-              << " times in XML children of world with name[" << this->Name()
-              << "].\n";
-    }
-  }
-
-  for (const auto &[name, size] :
-       _sdf->CountNamedElements("", Element::NameUniquenessExceptions()))
-  {
-    if (size > 1)
-    {
-      sdfwarn << "Non-unique name[" << name << "] detected " << size
-              << " times in XML children of world with name[" << this->Name()
-              << "].\n";
+      std::stringstream ss;
+      ss << "Non-unique name[" << name << "] detected " << size
+         << " times in XML children of world with name[" << this->Name()
+         << "].";
+      Error err(ErrorCode::WARNING, ss.str());
+      enforceConfigurablePolicyCondition(
+          _config.WarningsPolicy(), err, errors);
     }
   }
 
@@ -288,10 +281,14 @@ Errors World::Load(sdf::ElementPtr _sdf, const ParserConfig &_config)
       {
         frameName = frame.Name() + "_frame" + std::to_string(i++);
       }
-      sdfwarn << "Frame with name [" << frame.Name() << "] "
-              << "in world with name [" << this->Name() << "] "
-              << "has a name collision, changing frame name to ["
-              << frameName << "].\n";
+      std::stringstream ss;
+      ss << "Frame with name [" << frame.Name() << "] "
+          << "in world with name [" << this->Name() << "] "
+          << "has a name collision, changing frame name to ["
+          << frameName << "].\n";
+      Error err(ErrorCode::WARNING, ss.str());
+      enforceConfigurablePolicyCondition(
+          _config.WarningsPolicy(), err, errors);
       frame.SetName(frameName);
     }
     frameNames.insert(frameName);

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -23,6 +23,7 @@
 
 #include <gz/utils/ExtraTestMacros.hh>
 
+#include "sdf/Error.hh"
 #include "sdf/Filesystem.hh"
 #include "sdf/parser.hh"
 #include "sdf/SDFImpl.hh"
@@ -1862,7 +1863,7 @@ TEST(inertial_stats, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";
 
-  auto expectedOutput =
+  std::string expectedOutput =
     "Inertial statistics for model: test_model\n"
     "---\n"
     "Total mass of the model: 24\n"
@@ -1900,7 +1901,10 @@ TEST(inertial_stats, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   }
 
   expectedOutput =
-          "Error Code 19: Msg: A link named link has invalid inertia.\n\n"
+          "Error Code " +
+          std::to_string(static_cast<int>(
+              sdf::ErrorCode::LINK_INERTIA_INVALID)) +
+          ": Msg: A link named link has invalid inertia.\n\n"
           "Inertial statistics for model: model\n"
           "---\n"
           "Total mass of the model: 0\n"

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -319,7 +319,7 @@ TEST(Parser, SyntaxErrorInValues)
 
     sdf::readFile(path, sdf);
     EXPECT_PRED2(contains, buffer.str(),
-                 "Unable to set value [bad ] for key[linear]");
+                 "Unable to set value [bad] for key[linear]");
     EXPECT_PRED2(contains, buffer.str(), "bad_syntax_double.sdf:L7");
     EXPECT_PRED2(contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/model[@name=\"robot1\"]/"

--- a/test/integration/error_output.cc
+++ b/test/integration/error_output.cc
@@ -32,16 +32,16 @@ TEST(ErrorOutput, ParamErrorOutput)
 {
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
-    sdf::Console::Instance()->GetMsgStream(), &buffer);
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
 
   sdf::Errors errors;
   ASSERT_NO_THROW(sdf::Param param1("key", "not_valid_type", "true", false,
-        errors, "description"));
+      errors, "description"));
   ASSERT_GE(2u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::UNKNOWN_PARAMETER_TYPE);
   EXPECT_NE(std::string::npos,
       errors[0].Message().find(
-        "Unknown parameter type[not_valid_type]"));
+      "Unknown parameter type[not_valid_type]"));
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos,
       errors[1].Message().find("Invalid parameter"));
@@ -52,10 +52,10 @@ TEST(ErrorOutput, ParamErrorOutput)
   ASSERT_GE(2u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::UNKNOWN_PARAMETER_TYPE);
   EXPECT_NE(std::string::npos,
-   errors[0].Message().find("Unknown parameter type[not_valid_type]"));
+      errors[0].Message().find("Unknown parameter type[not_valid_type]"));
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos,
-   errors[1].Message().find("Invalid parameter"));
+      errors[1].Message().find("Invalid parameter"));
 
   errors.clear();
   sdf::Param param3("key", "bool", "true", false, errors, "description");
@@ -73,15 +73,15 @@ TEST(ErrorOutput, ParamErrorOutput)
   ASSERT_GE(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "The value for //pose[@rotation_format='euler_rpy'] must have 6 "
-    "values, but 1 were found instead in '1'."));
+      "The value for //pose[@rotation_format='euler_rpy'] must have 6 "
+      "values, but 1 were found instead in '1'."));
 
   errors.clear();
   param3.Update(errors);
   ASSERT_GE(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "[updateFunc] is not set."));
+      "[updateFunc] is not set."));
 
   errors.clear();
   sdf::Param requiredParam("key", "int", "1", true, "2", "4", errors,
@@ -92,14 +92,13 @@ TEST(ErrorOutput, ParamErrorOutput)
   ASSERT_GE(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Empty string used when setting a required parameter. Key[key]"));
+      "Empty string used when setting a required parameter. Key[key]"));
   EXPECT_FALSE(requiredParam.ValidateValue(errors));
   ASSERT_GE(errors.size(), 2u);
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[1].Message().find(
-    "The value [1] is less than the minimum allowed value of [2] for "
-    "key [key]"));
-
+      "The value [1] is less than the minimum allowed value of [2] for "
+      "key [key]"));
 
   errors.clear();
   // Adding a parent with @rotation_format to something invalid
@@ -111,8 +110,8 @@ TEST(ErrorOutput, ParamErrorOutput)
   ASSERT_EQ(errors.size(), 2u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Undefined attribute //pose[@rotation_format='invalid_format'], "
-    "only 'euler_rpy' and 'quat_xyzw' is supported."));
+      "Undefined attribute //pose[@rotation_format='invalid_format'], "
+      "only 'euler_rpy' and 'quat_xyzw' is supported."));
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::PARAMETER_ERROR);
 #if !defined __ARM_ARCH
   EXPECT_NE(std::string::npos, errors[1].Message().find(
@@ -128,22 +127,22 @@ TEST(ErrorOutput, ParamErrorOutput)
   ASSERT_EQ(errors.size(), 6u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Invalid boolean value"));
+      "Invalid boolean value"));
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[1].Message().find(
-    "Invalid parameter"));
+      "Invalid parameter"));
   EXPECT_EQ(errors[2].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[2].Message().find(
-    "Invalid boolean value"));
+      "Invalid boolean value"));
   EXPECT_EQ(errors[3].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[3].Message().find(
-    "Invalid [min] parameter in SDFormat description of [key]"));
+      "Invalid [min] parameter in SDFormat description of [key]"));
   EXPECT_EQ(errors[4].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[4].Message().find(
-    "Invalid boolean value"));
+      "Invalid boolean value"));
   EXPECT_EQ(errors[5].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[5].Message().find(
-    "Invalid [max] parameter in SDFormat description of [key]"));
+      "Invalid [max] parameter in SDFormat description of [key]"));
 
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
@@ -155,7 +154,7 @@ TEST(ErrorOutput, ElementErrorOutput)
 {
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
-    sdf::Console::Instance()->GetMsgStream(), &buffer);
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
 
   sdf::Errors errors;
   sdf::ElementPtr elem = std::make_shared<sdf::Element>();
@@ -165,59 +164,84 @@ TEST(ErrorOutput, ElementErrorOutput)
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ELEMENT_ERROR);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Unable to find value for key [test]"));
+      "Unable to find value for key [test]"));
 
   errors.clear();
   elem->GetElement("missingElement", errors);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Missing element description for [missingElement]"));
+      "Missing element description for [missingElement]"));
 
   errors.clear();
   elem->AddAttribute(
-    "invalidAttribute", "int", "invalidFormat", false, errors);
+      "invalidAttribute", "int", "invalidFormat", false, errors);
   ASSERT_EQ(errors.size(), 2u);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Invalid argument. Unable to set value [invalidFormat]"
-    " for key[invalidAttribute]"));
+      "Invalid argument. Unable to set value [invalidFormat]"
+      " for key[invalidAttribute]"));
   EXPECT_NE(std::string::npos, errors[1].Message().find(
-    "Invalid parameter"));
+      "Invalid parameter"));
 
   errors.clear();
   elem->AddValue("type", "value", true, "a", "b", errors);
   ASSERT_EQ(errors.size(), 9u);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Unknown parameter type[type]"));
+      "Unknown parameter type[type]"));
   EXPECT_NE(std::string::npos, errors[1].Message().find(
-    "Invalid parameter"));
+      "Invalid parameter"));
   EXPECT_NE(std::string::npos, errors[2].Message().find(
-    "Unknown parameter type[type]"));
+      "Unknown parameter type[type]"));
   EXPECT_NE(std::string::npos, errors[3].Message().find(
-    "Invalid [min] parameter in SDFormat description of [testElement]"));
+      "Invalid [min] parameter in SDFormat description of [testElement]"));
   EXPECT_NE(std::string::npos, errors[4].Message().find(
-    "Unknown parameter type[type]"));
+      "Unknown parameter type[type]"));
   EXPECT_NE(std::string::npos, errors[5].Message().find(
-    "Invalid [max] parameter in SDFormat description of [testElement]"));
+      "Invalid [max] parameter in SDFormat description of [testElement]"));
   EXPECT_NE(std::string::npos, errors[6].Message().find(
-    "Unknown parameter type[type]"));
+      "Unknown parameter type[type]"));
   EXPECT_NE(std::string::npos, errors[7].Message().find(
-    "Failed to set value '0' to key [testElement] for new parent element"
-    " of name 'testElement', reverting to previous value '0'."));
+      "Failed to set value '0' to key [testElement] for new parent element"
+      " of name 'testElement', reverting to previous value '0'."));
   EXPECT_NE(std::string::npos, errors[8].Message().find(
-    "Cannot set parent Element of value to itself."));
+      "Cannot set parent Element of value to itself."));
   errors.clear();
 
   elem->GetElement("nonExistentElement", errors);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Missing element description for [nonExistentElement]"));
+      "Missing element description for [nonExistentElement]"));
   errors.clear();
 
   elem->RemoveChild(sdf::ElementPtr(), errors);
   ASSERT_EQ(errors.size(), 1u);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
-    "Cannot remove a nullptr child pointer"));
+      "Cannot remove a nullptr child pointer"));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
+}
 
+////////////////////////////////////////
+// Test PrintConfig class for sdf::Errors outputs
+TEST(ErrorOutput, PrintConfigErrorOutput)
+{
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::Errors errors;
+  sdf::PrintConfig printConfig;
+  ASSERT_FALSE(printConfig.SetRotationSnapToDegrees(361, 300, errors));
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+      "Interval value to snap to must be larger than 0,"
+      " and less than or equal to 360."));
+  errors.clear();
+
+  ASSERT_FALSE(printConfig.SetRotationSnapToDegrees(300, 300, errors));
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+      "Tolerance must be larger than 0, less than or equal to 360, "
+      "and less than the provided interval."));
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 }

--- a/test/integration/error_output.cc
+++ b/test/integration/error_output.cc
@@ -28,7 +28,7 @@
 
 ////////////////////////////////////////
 // Test Param class for sdf::Errors outputs
-TEST(Error, ErrorOutput)
+TEST(ErrorOutput, ParamErrorOutput)
 {
   std::stringstream buffer;
   sdf::testing::RedirectConsoleStream redir(
@@ -144,6 +144,79 @@ TEST(Error, ErrorOutput)
   EXPECT_EQ(errors[5].Code(), sdf::ErrorCode::PARAMETER_ERROR);
   EXPECT_NE(std::string::npos, errors[5].Message().find(
     "Invalid [max] parameter in SDFormat description of [key]"));
+
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
+}
+
+////////////////////////////////////////
+// Test Element class for sdf::Errors outputs
+TEST(ErrorOutput, ElementErrorOutput)
+{
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+    sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::Errors errors;
+  sdf::ElementPtr elem = std::make_shared<sdf::Element>();
+  elem->SetName("testElement");
+
+  elem->GetAny(errors, "test");
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ELEMENT_ERROR);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Unable to find value for key [test]"));
+
+  errors.clear();
+  elem->GetElement("missingElement", errors);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Missing element description for [missingElement]"));
+
+  errors.clear();
+  elem->AddAttribute(
+    "invalidAttribute", "int", "invalidFormat", false, errors);
+  ASSERT_EQ(errors.size(), 2u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Invalid argument. Unable to set value [invalidFormat]"
+    " for key[invalidAttribute]"));
+  EXPECT_NE(std::string::npos, errors[1].Message().find(
+    "Invalid parameter"));
+
+  errors.clear();
+  elem->AddValue("type", "value", true, "a", "b", errors);
+  ASSERT_EQ(errors.size(), 9u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Unknown parameter type[type]"));
+  EXPECT_NE(std::string::npos, errors[1].Message().find(
+    "Invalid parameter"));
+  EXPECT_NE(std::string::npos, errors[2].Message().find(
+    "Unknown parameter type[type]"));
+  EXPECT_NE(std::string::npos, errors[3].Message().find(
+    "Invalid [min] parameter in SDFormat description of [testElement]"));
+  EXPECT_NE(std::string::npos, errors[4].Message().find(
+    "Unknown parameter type[type]"));
+  EXPECT_NE(std::string::npos, errors[5].Message().find(
+    "Invalid [max] parameter in SDFormat description of [testElement]"));
+  EXPECT_NE(std::string::npos, errors[6].Message().find(
+    "Unknown parameter type[type]"));
+  EXPECT_NE(std::string::npos, errors[7].Message().find(
+    "Failed to set value '0' to key [testElement] for new parent element"
+    " of name 'testElement', reverting to previous value '0'."));
+  EXPECT_NE(std::string::npos, errors[8].Message().find(
+    "Cannot set parent Element of value to itself."));
+  errors.clear();
+
+  elem->GetElement("nonExistentElement", errors);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Missing element description for [nonExistentElement]"));
+  errors.clear();
+
+  elem->RemoveChild(sdf::ElementPtr(), errors);
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Cannot remove a nullptr child pointer"));
 
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();

--- a/test/integration/error_output.cc
+++ b/test/integration/error_output.cc
@@ -24,7 +24,9 @@
 #include "sdf/Error.hh"
 #include "sdf/Param.hh"
 #include "sdf/Types.hh"
+#include "sdf/World.hh"
 #include "test_utils.hh"
+#include "test_config.hh"
 
 ////////////////////////////////////////
 // Test Param class for sdf::Errors outputs
@@ -242,6 +244,55 @@ TEST(ErrorOutput, PrintConfigErrorOutput)
   EXPECT_NE(std::string::npos, errors[0].Message().find(
       "Tolerance must be larger than 0, less than or equal to 360, "
       "and less than the provided interval."));
+  // Check nothing has been printed
+  EXPECT_TRUE(buffer.str().empty()) << buffer.str();
+}
+
+////////////////////////////////////////
+// Test World class for sdf::Errors outputs
+TEST(ErrorOutput, WorldErrorOutput)
+{
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+    sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  sdf::Errors errors;
+
+  std::ostringstream stream;
+  stream << "<?xml version=\"1.0\"?>"
+         << "<sdf version='1.8'>"
+         << "  <world name='test_world'>"
+         << "    <model name='common_name'>"
+         << "      <link name='a'>"
+         << "      </link>"
+         << "    </model>"
+         << "    <model name='common_name'>"
+         << "      <link name='a'>"
+         << "      </link>"
+         << "    </model>"
+         << "    <frame name='common_name'/>"
+         << "  </world>"
+         << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+
+  sdf::ParserConfig parserConfig;
+  parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::readString(stream.str(), parserConfig, sdfParsed, errors);
+  EXPECT_TRUE(errors.empty());
+
+  sdf::World world;
+  errors = world.Load(sdfParsed->Root()->GetElement("world"), parserConfig);
+  ASSERT_EQ(errors.size(), 3u);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+    "Non-unique name[common_name] detected 3 times in XML children of world"
+    " with name[test_world]."));
+  EXPECT_NE(std::string::npos, errors[1].Message().find(
+    "model with name[common_name] already exists."));
+  EXPECT_NE(std::string::npos, errors[2].Message().find(
+    "Frame with name [common_name] in world with name [test_world] has a name"
+    " collision, changing frame name to [common_name_frame]."));
   // Check nothing has been printed
   EXPECT_TRUE(buffer.str().empty()) << buffer.str();
 }


### PR DESCRIPTION
# 🎉 New feature

Work towards https://github.com/gazebosim/sdformat/issues/820.

## Summary

This backports the changes merged into `main` related to the use of `sdf::Errors` as parameters.

## Test it

Errors and warnings should be reported through the `sdf::Errors` parameter when using the modified functions of the relevant classes. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.