### PR TITLE
Python: Added OpticalFrameID and SetOpticalFrameID to pyCamera

### DIFF
--- a/python/src/sdf/pyCamera.cc
+++ b/python/src/sdf/pyCamera.cc
@@ -171,6 +171,16 @@ void defineCamera(pybind11::object module)
          "Set the name of the coordinate frame relative to which this "
          "object's pose is expressed. An empty value indicates that the frame "
          "is relative to the parent link.")
+    .def("optical_frame_id", &sdf::Camera::OpticalFrameId,
+         "Get the name of the coordinate frame relative to which this "
+         "object's camera_info message header is expressed. "
+         "Note: while Gazebo interprets the camera frame to be looking towards "
+         "+X, other tools, such as ROS interprets this frame as looking "
+         "towards +Z.  The Camera sensor assumes that the color and depth "
+         "images are captured at the same frame_id.")
+    .def("set_optical_frame_id", &sdf::Camera::SetOpticalFrameId,
+         "Set the name of the coordinate frame relative to which this "
+         "object's camera_info is expressed.")
     .def("lens_type", &sdf::Camera::LensType,
          "Get the lens type. This is the type of the lens mapping. "
          "Supported values are gnomonical, stereographic, equidistant, "

--- a/python/test/pyCamera_TEST.py
+++ b/python/test/pyCamera_TEST.py
@@ -131,6 +131,10 @@ class CameraTEST(unittest.TestCase):
       cam.set_pose_relative_to("/frame")
       self.assertEqual("/frame", cam.pose_relative_to())
 
+      self.assertFalse(cam.optical_frame_id());
+      cam.set_optical_frame_id("/optical_frame");
+      self.assertEqual("/optical_frame", cam.optical_frame_id());
+
       self.assertEqual("stereographic", cam.lens_type())
       cam.set_lens_type("custom")
       self.assertEqual("custom", cam.lens_type())


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

Closes https://github.com/gazebosim/sdformat/issues/1128

## Summary

Python: Added OpticalFrameID and SetOpticalFrameID to pyCamera

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
