### PR TITLE
Check World joints in checkJointParentChildNames

### DIFF
--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -487,6 +487,18 @@ namespace sdf
     public: sdf::ElementPtr ToElement(
         const OutputConfig &_config = OutputConfig::GlobalConfig()) const;
 
+    /// \brief Check if a given name exists in the FrameAttachedTo graph at the
+    /// scope of the world.
+    /// \param[in] _name Name of the implicit or explicit frame to check.
+    /// To check for a frame in a nested model, prefix the frame name with
+    /// the sequence of nested models containing this frame, delimited by "::".
+    /// \return True if the frame name is found in the FrameAttachedTo graph.
+    /// False otherwise, or if the frame graph is invalid.
+    /// \note This function assumes the world has a valid FrameAttachedTo graph.
+    /// It will return false if the graph is invalid.
+    public: bool NameExistsInFrameAttachedToGraph(
+                const std::string &_name) const;
+
     /// \brief Get the plugins attached to this object.
     /// \return A vector of Plugin, which will be empty if there are no
     /// plugins.

--- a/python/src/sdf/pyModel.cc
+++ b/python/src/sdf/pyModel.cc
@@ -175,7 +175,7 @@ void defineModel(pybind11::object module)
      .def("name_exists_in_frame_attached_to_graph",
           &sdf::Model::NameExistsInFrameAttachedToGraph,
           "Check if a given name exists in the FrameAttachedTo graph at the "
-          "scope of the model..")
+          "scope of the model.")
      .def("add_link", &sdf::Model::AddLink,
           "Add a link to the model.")
      .def("add_joint", &sdf::Model::AddJoint,

--- a/python/src/sdf/pyWorld.cc
+++ b/python/src/sdf/pyWorld.cc
@@ -107,6 +107,10 @@ void defineWorld(pybind11::object module)
           "index.")
      .def("model_name_exists", &sdf::World::ModelNameExists,
           "Get whether a model name exists.")
+     .def("name_exists_in_frame_attached_to_graph",
+          &sdf::World::NameExistsInFrameAttachedToGraph,
+          "Check if a given name exists in the FrameAttachedTo graph at the "
+          "scope of the world.")
      .def("add_model", &sdf::World::AddModel,
           "Add a model to the world.")
      // .def("add_actor", &sdf::World::AddActor,

--- a/src/World.cc
+++ b/src/World.cc
@@ -1092,6 +1092,16 @@ void World::ClearFrames()
 }
 
 /////////////////////////////////////////////////
+bool World::NameExistsInFrameAttachedToGraph(const std::string &_name) const
+{
+  if (!this->dataPtr->frameAttachedToGraph)
+    return false;
+
+  return this->dataPtr->frameAttachedToGraph.VertexIdByName(_name)
+      !=  gz::math::graph::kNullId;
+}
+
+/////////////////////////////////////////////////
 bool World::AddModel(const Model &_model)
 {
   if (this->ModelNameExists(_model.Name()))

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -2502,87 +2502,92 @@ bool checkJointParentChildNames(const sdf::Root *_root)
 }
 
 //////////////////////////////////////////////////
+template <typename TPtr>
+void checkScopedJointParentChildNames(
+    const TPtr _scope, const std::string &_scopeType, Errors &errors)
+{
+  for (uint64_t j = 0; j < _scope->JointCount(); ++j)
+  {
+    auto joint = _scope->JointByIndex(j);
+
+    const std::string &parentName = joint->ParentName();
+    const std::string parentLocalName = sdf::SplitName(parentName).second;
+
+    if (parentName != "world" && parentLocalName != "__model__" &&
+        !_scope->NameExistsInFrameAttachedToGraph(parentName))
+    {
+      errors.push_back({ErrorCode::JOINT_PARENT_LINK_INVALID,
+        "parent frame with name[" + parentName +
+        "] specified by joint with name[" + joint->Name() +
+        "] not found in " + _scopeType + " with name[" +
+        _scope->Name() + "]."});
+    }
+
+    const std::string &childName = joint->ChildName();
+    const std::string childLocalName = sdf::SplitName(childName).second;
+    if (childName == "world")
+    {
+      errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
+        "invalid child name[world] specified by joint with name[" +
+        joint->Name() + "] in " + _scopeType + " with name[" +
+        _scope->Name() + "]."});
+    }
+
+    if (childLocalName != "__model__" &&
+        !_scope->NameExistsInFrameAttachedToGraph(childName))
+    {
+      errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
+        "child frame with name[" + childName +
+        "] specified by joint with name[" + joint->Name() +
+        "] not found in " + _scopeType + " with name[" +
+        _scope->Name() + "]."});
+    }
+
+    if (childName == joint->Name())
+    {
+      errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
+        "joint with name[" + joint->Name() +
+        "] in " + _scopeType + " with name[" + _scope->Name() +
+        "] must not specify its own name as the child frame."});
+    }
+
+    if (parentName == joint->Name())
+    {
+      errors.push_back({ErrorCode::JOINT_PARENT_LINK_INVALID,
+        "joint with name[" + joint->Name() +
+        "] in " + _scopeType + " with name[" + _scope->Name() +
+        "] must not specify its own name as the parent frame."});
+    }
+
+    // Check that parent and child frames resolve to different links
+    std::string resolvedChildName;
+    std::string resolvedParentName;
+
+    auto resolveErrors = joint->ResolveChildLink(resolvedChildName);
+    errors.insert(errors.end(), resolveErrors.begin(), resolveErrors.end());
+
+    resolveErrors = joint->ResolveParentLink(resolvedParentName);
+    errors.insert(errors.end(), resolveErrors.begin(), resolveErrors.end());
+
+    if (resolvedChildName == resolvedParentName)
+    {
+      errors.push_back({ErrorCode::JOINT_PARENT_SAME_AS_CHILD,
+        "joint with name[" + joint->Name() +
+        "] in " + _scopeType + " with name[" + _scope->Name() +
+        "] specified parent frame [" + parentName +
+        "] and child frame [" + childName +
+        "] that both resolve to [" + resolvedChildName +
+        "], but they should resolve to different values."});
+    }
+  }
+}
+
+//////////////////////////////////////////////////
 void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
 {
-  auto checkModelJointParentChildNames = [](
-      const sdf::Model *_model, Errors &errors) -> void
-  {
-    for (uint64_t j = 0; j < _model->JointCount(); ++j)
-    {
-      auto joint = _model->JointByIndex(j);
-
-      const std::string &parentName = joint->ParentName();
-      const std::string parentLocalName = sdf::SplitName(parentName).second;
-
-      if (parentName != "world" && parentLocalName != "__model__" &&
-          !_model->NameExistsInFrameAttachedToGraph(parentName))
-      {
-        errors.push_back({ErrorCode::JOINT_PARENT_LINK_INVALID,
-          "parent frame with name[" + parentName +
-          "] specified by joint with name[" + joint->Name() +
-          "] not found in model with name[" + _model->Name() + "]."});
-      }
-
-      const std::string &childName = joint->ChildName();
-      const std::string childLocalName = sdf::SplitName(childName).second;
-      if (childName == "world")
-      {
-        errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
-          "invalid child name[world] specified by joint with name[" +
-          joint->Name() + "] in model with name[" + _model->Name() + "]."});
-      }
-
-      if (childLocalName != "__model__" &&
-          !_model->NameExistsInFrameAttachedToGraph(childName))
-      {
-        errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
-          "child frame with name[" + childName +
-          "] specified by joint with name[" + joint->Name() +
-          "] not found in model with name[" + _model->Name() + "]."});
-      }
-
-      if (childName == joint->Name())
-      {
-        errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
-          "joint with name[" + joint->Name() +
-          "] in model with name[" + _model->Name() +
-          "] must not specify its own name as the child frame."});
-      }
-
-      if (parentName == joint->Name())
-      {
-        errors.push_back({ErrorCode::JOINT_PARENT_LINK_INVALID,
-          "joint with name[" + joint->Name() +
-          "] in model with name[" + _model->Name() +
-          "] must not specify its own name as the parent frame."});
-      }
-
-      // Check that parent and child frames resolve to different links
-      std::string resolvedChildName;
-      std::string resolvedParentName;
-
-      auto resolveErrors = joint->ResolveChildLink(resolvedChildName);
-      errors.insert(errors.end(), resolveErrors.begin(), resolveErrors.end());
-
-      resolveErrors = joint->ResolveParentLink(resolvedParentName);
-      errors.insert(errors.end(), resolveErrors.begin(), resolveErrors.end());
-
-      if (resolvedChildName == resolvedParentName)
-      {
-        errors.push_back({ErrorCode::JOINT_PARENT_SAME_AS_CHILD,
-          "joint with name[" + joint->Name() +
-          "] in model with name[" + _model->Name() +
-          "] specified parent frame [" + parentName +
-          "] and child frame [" + childName +
-          "] that both resolve to [" + resolvedChildName +
-          "], but they should resolve to different values."});
-      }
-    }
-  };
-
   if (_root->Model())
   {
-    checkModelJointParentChildNames(_root->Model(), _errors);
+    checkScopedJointParentChildNames(_root->Model(), "model", _errors);
   }
 
   for (uint64_t w = 0; w < _root->WorldCount(); ++w)
@@ -2591,8 +2596,9 @@ void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
     for (uint64_t m = 0; m < world->ModelCount(); ++m)
     {
       auto model = world->ModelByIndex(m);
-      checkModelJointParentChildNames(model, _errors);
+      checkScopedJointParentChildNames(model, "model", _errors);
     }
+    checkScopedJointParentChildNames(world, "world", _errors);
   }
 }
 

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -487,7 +487,8 @@ TEST(DOMJoint, LoadWorldJointChildFrame)
 
   // Load the SDF file
   sdf::Root root;
-  EXPECT_TRUE(root.Load(testFile).empty());
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty()) << errors;
 
   using Pose = gz::math::Pose3d;
 
@@ -602,7 +603,7 @@ TEST(DOMJoint, WorldJointInvalidChildWorld)
   auto errors = root.Load(testFile);
   for (auto e : errors)
     std::cout << e << std::endl;
-  ASSERT_EQ(2u, errors.size());
+  ASSERT_EQ(3u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::JOINT_CHILD_LINK_INVALID);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -610,6 +610,27 @@ TEST(DOMJoint, WorldJointInvalidChildWorld)
 }
 
 /////////////////////////////////////////////////
+TEST(DOMJoint, WorldJointInvalidResolvedParentSameAsChild)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf",
+      "world_joint_invalid_resolved_parent_same_as_child.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  std::cerr << errors << std::endl;
+  ASSERT_EQ(1u, errors.size());
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::JOINT_PARENT_SAME_AS_CHILD);
+  EXPECT_NE(std::string::npos,
+    errors[0].Message().find(
+      "joint with name[J] in world with name["
+      "joint_invalid_resolved_parent_same_as_child.sdf] specified parent "
+      "frame [child_model] and child frame [child_frame] that both resolve "
+      "to [child_model::L]"));
+}
+
+/////////////////////////////////////////////////
 TEST(DOMJoint, LoadJointPoseRelativeTo)
 {
   const std::string testFile =

--- a/test/sdf/world_joint_invalid_resolved_parent_same_as_child.sdf
+++ b/test/sdf/world_joint_invalid_resolved_parent_same_as_child.sdf
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<sdf version="1.10">
+  <world name="joint_invalid_resolved_parent_same_as_child.sdf">
+    <!--
+      For ease of unittesting unique values,
+      each model's pose is displaced along the z-axis,
+      frames are displaced along the y-axis,
+      and joints are displaced along the x-axis.
+    -->
+    <model name="parent_model">
+      <pose>0 0 1 0 0 0</pose>
+      <link name="L"/>
+    </model>
+    <model name="child_model">
+      <pose>0 0 10 0 0 0</pose>
+      <link name="L"/>
+    </model>
+    <frame name="child_frame" attached_to="child_model">
+      <pose>0 1 0 0 0 0</pose>
+    </frame>
+    <joint name="J" type="ball">
+      <pose>10 0 0 0 0 0</pose>
+      <parent>child_model</parent>
+      <child>child_frame</child>
+    </joint>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Follow-up to #1117

## Summary

Joints were added in the world scope in #1117, but the `checkJointParentChildNames` method in `parser.hh` was not updated to check these joints. A failing test is added in https://github.com/gazebosim/sdformat/commit/4e86c3edccd28dde7fdaf9613a31f703239ba46e, and then the `checkModelJointParentChildNames` lambda function into a template function that works for both `sdf::Model` and `sdf::World` objects, after adding the `World::NameExistsInFrameAttachedToGraph` API.

## Test it

Run `INTEGRATION_joint_dom` or `gz sdf --check test/sdf/world_joint_invalid_resolved_parent_same_as_child.sdf`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
