### PR TITLE
Prepare for 13.2.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.1.0)
+project (sdformat13 VERSION 13.2.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,29 @@
 ## libsdformat 13.X
 
+### libsdformat 13.2.0 (2022-10-20)
+
+1. sdf/1.10/joint.sdf: add `screw_thread_pitch`
+    * [Pull request #1168](https://github.com/gazebosim/sdformat/pull/1168)
+
+1. sdf/1.10: support //world/joint specification
+    * [Pull request #1117](https://github.com/gazebosim/sdformat/pull/1117)
+    * [Pull request #1189](https://github.com/gazebosim/sdformat/pull/1189)
+
+1. Model: add sdf::Errors output to API methods
+    * [Pull request #1122](https://github.com/gazebosim/sdformat/pull/1122)
+
+1. Added Root::WorldByName
+    * [Pull request #1121](https://github.com/gazebosim/sdformat/pull/1121)
+
+1. Python: add OpticalFrameID APIs to pyCamera
+    * [Pull request #1184](https://github.com/gazebosim/sdformat/pull/1184)
+
+1. Fix `GZ_PYTHON_INSTALL_PATH` value
+    * [Pull request #1183](https://github.com/gazebosim/sdformat/pull/1183)
+
+1. Rename python bindings import library for Windows
+    * [Pull request #1165](https://github.com/gazebosim/sdformat/pull/1165)
+
 ### libsdformat 13.1.0 (2022-10-12)
 
 1. Add test helper python package for encapsulating versioned python packages


### PR DESCRIPTION
# 🎈 Release

Preparation for 13.2.0 release.

Comparison to 13.1.0: https://github.com/osrf/sdformat/compare/sdformat13_13.1.0...sdf13

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sim/pull/1669, https://github.com/RobotLocomotion/drake/pull/18127

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.