### PR TITLE
Offer an API option to display new warnings on problems with URDF to SDF conversions (sdf12)

### DIFF
--- a/include/sdf/ParserConfig.hh
+++ b/include/sdf/ParserConfig.hh
@@ -174,11 +174,13 @@ class SDFORMAT_VISIBLE ParserConfig
   /// \brief Get the preserveFixedJoint flag value.
   public: bool URDFPreserveFixedJoint() const;
 
-  /// \brief set the enableNewWarnings flag to _enable value
-  public: void URDFSetNewWarnings(const bool _enable);
+  /// \brief Set the policy to display URDF issues. Default is LOG. Only WARN
+  /// and LOG values are allowed since ERR can possibly break existing code.
+  /// ERR will be consider as WARN.
+  public: void SetURDFEnforcementPolicy(const EnforcementPolicy _policy);
 
-  /// \brief get the enableNewWarnings flag value;
-  public: bool URDFEnableNewWarnings() const;
+  /// \brief get the curren  URDFPolicy to display issues
+  public: EnforcementPolicy URDFPolicy() const;
 
   /// \brief Private data pointer.
   IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/ParserConfig.hh
+++ b/include/sdf/ParserConfig.hh
@@ -174,6 +174,12 @@ class SDFORMAT_VISIBLE ParserConfig
   /// \brief Get the preserveFixedJoint flag value.
   public: bool URDFPreserveFixedJoint() const;
 
+  /// \brief set the enableNewWarnings flag to _enable value
+  public: void URDFSetNewWarnings(const bool _enable);
+
+  /// \brief get the enableNewWarnings flag value;
+  public: bool URDFEnableNewWarnings() const;
+
   /// \brief Private data pointer.
   IGN_UTILS_IMPL_PTR(dataPtr)
 };

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -53,6 +53,12 @@ class sdf::ParserConfig::Implementation
   /// \brief Flag to use <include> tags within ToElement methods instead of
   /// the fully included model.
   public: bool toElementUseIncludeTag = true;
+
+  /// \brief Flag to consider previous issues in debug log as
+  /// warnings. This allow to keep log level backwards compatible
+  /// while providing an option to increase the warnings with new
+  /// relevant issues.
+  public: bool enableNewWarnings = false;
 };
 
 
@@ -172,4 +178,13 @@ void ParserConfig::URDFSetPreserveFixedJoint(bool _preserveFixedJoint)
 bool ParserConfig::URDFPreserveFixedJoint() const
 {
   return this->dataPtr->preserveFixedJoint;
+}
+
+void ParserConfig::URDFSetNewWarnings(const bool _enable) {
+  this->dataPtr->enableNewWarnings = _enable;
+}
+
+/////////////////////////////////////////////////
+bool ParserConfig::URDFEnableNewWarnings() const {
+  return this->dataPtr->enableNewWarnings;
 }

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -58,7 +58,7 @@ class sdf::ParserConfig::Implementation
   /// warnings. This allow to keep log level backwards compatible
   /// while providing an option to increase the warnings with new
   /// relevant issues.
-  public: bool enableNewWarnings = false;
+  public: EnforcementPolicy URDFEnforcementPolicy = EnforcementPolicy::LOG;
 };
 
 
@@ -180,11 +180,20 @@ bool ParserConfig::URDFPreserveFixedJoint() const
   return this->dataPtr->preserveFixedJoint;
 }
 
-void ParserConfig::URDFSetNewWarnings(const bool _enable) {
-  this->dataPtr->enableNewWarnings = _enable;
+void ParserConfig::SetURDFEnforcementPolicy(const EnforcementPolicy _policy)
+{
+  this->dataPtr->URDFEnforcementPolicy = _policy;
+  if (_policy == EnforcementPolicy::ERR)
+  {
+    sdfwarn << "The policies allowed when using SetURDFEnforcementPolicy are "
+               "LOG or WARN. ERR was used but it is considered a WARN not "
+               "to break backwards compatibility. Please change the code to "
+               "use WARN or LOG.\n";
+    this->dataPtr->URDFEnforcementPolicy = EnforcementPolicy::WARN;
+  }
 }
 
 /////////////////////////////////////////////////
-bool ParserConfig::URDFEnableNewWarnings() const {
-  return this->dataPtr->enableNewWarnings;
+EnforcementPolicy ParserConfig::URDFPolicy() const {
+  return this->dataPtr->URDFEnforcementPolicy;
 }

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2659,8 +2659,9 @@ void URDF2SDF::ListSDFExtensions(const std::string &_reference)
 
 ////////////////////////////////////////////////////////////////////////////////
 void _DisplayDbgOrWarning(const std::string &_msg,
-                          const bool _enableNewWarnings) {
-  if (_enableNewWarnings)
+                          const EnforcementPolicy &_policy) {
+  SDF_ASSERT(_policy != EnforcementPolicy::ERR, "ERR Policy should not appear in ParserConfig");
+  if (_policy == EnforcementPolicy::WARN)
     sdfwarn << _msg;
   else
     sdfdbg << _msg;
@@ -2681,7 +2682,7 @@ void CreateSDF(tinyxml2::XMLElement *_root,
       _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
              + "] has a mass considered zero ["
              + std::to_string(_link->inertial->mass) +
-             + "].It is ignored.\n", _config.URDFEnableNewWarnings());
+             + "].It is ignored.\n", _config.URDFPolicy());
       return;
     }
 
@@ -2689,26 +2690,26 @@ void CreateSDF(tinyxml2::XMLElement *_root,
        _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
          + "] has no inertia, ["
          + std::to_string(_link->child_links.size())
-         + "] children links ignored.\n", _config.URDFEnableNewWarnings());
+         + "] children links ignored.\n", _config.URDFPolicy());
     }
 
     if (!_link->child_joints.empty()) {
       _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
          + "] has no inertia, ["
          + std::to_string(_link->child_links.size())
-         + "] children joints ignored.\n", _config.URDFEnableNewWarnings());
+         + "] children joints ignored.\n", _config.URDFPolicy());
     }
 
     if (_link->parent_joint) {
       _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
          + "] has no inertia, "
          + "parent joint [" + _link->parent_joint->name
-         + "] ignored.\n", _config.URDFEnableNewWarnings());
+         + "] ignored.\n", _config.URDFPolicy());
     }
 
     _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
        + "] has no inertia, not modeled in sdf\n",
-       _config.URDFEnableNewWarnings());
+       _config.URDFPolicy());
     return;
   }
 

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2694,20 +2694,21 @@ void CreateSDF(tinyxml2::XMLElement *_root,
 
     if (!_link->child_joints.empty()) {
       _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
-             + "] has no inertia, ["
-             + std::to_string(_link->child_links.size())
-             + "] children joints ignored.\n", _config.URDFEnableNewWarnings());
+         + "] has no inertia, ["
+         + std::to_string(_link->child_links.size())
+         + "] children joints ignored.\n", _config.URDFEnableNewWarnings());
     }
 
     if (_link->parent_joint) {
       _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
-             + "] has no inertia, "
-             + "parent joint [" + _link->parent_joint->name
-             + "] ignored.\n", _config.URDFEnableNewWarnings());
+         + "] has no inertia, "
+         + "parent joint [" + _link->parent_joint->name
+         + "] ignored.\n", _config.URDFEnableNewWarnings());
     }
 
     _DisplayDbgOrWarning(std::string("urdf2sdf: link[" + _link->name)
-           + "] has no inertia, not modeled in sdf\n", _config.URDFEnableNewWarnings());
+       + "] has no inertia, not modeled in sdf\n",
+       _config.URDFEnableNewWarnings());
     return;
   }
 

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2660,7 +2660,8 @@ void URDF2SDF::ListSDFExtensions(const std::string &_reference)
 ////////////////////////////////////////////////////////////////////////////////
 void _DisplayDbgOrWarning(const std::string &_msg,
                           const EnforcementPolicy &_policy) {
-  SDF_ASSERT(_policy != EnforcementPolicy::ERR, "ERR Policy should not appear in ParserConfig");
+  SDF_ASSERT(_policy != EnforcementPolicy::ERR,
+             "ERR Policy should not appear in ParserConfig");
   if (_policy == EnforcementPolicy::WARN)
     sdfwarn << _msg;
   else

--- a/src/parser_urdf_TEST.cc
+++ b/src/parser_urdf_TEST.cc
@@ -1011,9 +1011,6 @@ TEST(URDFParser, EnableNewWarnings)
         });
 #endif
 
-  // SDF_SUPPRESS_DEPRECATED_BEGIN
-  // sdf::URDF2SDF parser_(true);
-  // SDF_SUPPRESS_DEPRECATED_END
   sdf::URDF2SDF parser;
   sdf::ParserConfig config_;
   config_.URDFSetNewWarnings(true);

--- a/src/parser_urdf_TEST.cc
+++ b/src/parser_urdf_TEST.cc
@@ -19,6 +19,7 @@
 
 #include <list>
 
+#include "sdf/ParserConfig.hh"
 #include "sdf/sdf.hh"
 #include "parser_urdf.hh"
 #include "test_utils.hh"
@@ -1012,8 +1013,9 @@ TEST(URDFParser, EnableNewWarnings)
 #endif
 
   sdf::URDF2SDF parser;
+  sdf::EnforcementPolicy warn_policy = sdf::EnforcementPolicy::WARN;
   sdf::ParserConfig config_;
-  config_.URDFSetNewWarnings(true);
+  config_.SetURDFEnforcementPolicy(warn_policy);
   tinyxml2::XMLDocument sdfResult;
 
   {


### PR DESCRIPTION
# 🎉 New feature

See #1171 . It was requested to implement first the feature in sdf12.

## Summary

Instead of using the overloading approach in #1171, in this branch the API is nicer using ParserConfig options:
```c++
  /// \brief set the enableNewWarnings flag to _enable value
  public: void URDFSetNewWarnings(const bool _enable);

  /// \brief get the enableNewWarnings flag value;
  public: bool URDFEnableNewWarnings() const;
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
