### PR TITLE
Check JointAxis expressed-in values during Load

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -168,6 +168,10 @@ namespace sdf
 
     /// \brief Generic warning saved as error due to WarningsPolicy config
     WARNING,
+
+    /// \brief The joint axis expressed-in value does not match the name of an
+    /// existing frame in the current scope.
+    JOINT_AXIS_EXPRESSED_IN_INVALID,
   };
 
   class SDFORMAT_VISIBLE Error

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -416,6 +416,15 @@ namespace sdf
   SDFORMAT_VISIBLE
   void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors);
 
+  /// \brief Check that all joint axes in contained joints specify xyz
+  /// expressed-in names that match the names of valid frames.
+  /// This checks recursively and should check the files exhaustively
+  /// rather than terminating early when the first error is found.
+  /// \param[in] _root SDF Root object to check recursively.
+  /// \param[out] _errors Detected errors will be appended to this variable.
+  SDFORMAT_VISIBLE
+  void checkJointAxisExpressedInValues(const sdf::Root *_root, Errors &_errors);
+
   /// \brief For the world and each model, check that the attached_to graphs
   /// build without errors and have no cycles.
   /// Confirm that following directed edges from each vertex in the graph

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -386,6 +386,9 @@ Errors Root::Load(SDFPtr _sdf, const ParserConfig &_config)
   // different frames.
   checkJointParentChildNames(this, errors);
 
+  // Check that //axis*/xyz/@expressed_in values specify valid frames.
+  checkJointAxisExpressedInValues(this, errors);
+
   return errors;
 }
 

--- a/test/integration/joint_axis_dom.cc
+++ b/test/integration/joint_axis_dom.cc
@@ -219,6 +219,25 @@ TEST(DOMJointAxis, XyzExpressedIn)
   EXPECT_EQ(nullptr, model->FrameByIndex(0));
 }
 
+/////////////////////////////////////////////////
+TEST(DOMJointAxis, InvalidExpressedIn)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "joint_axis_invalid_expressed_in.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  for (auto e : errors)
+    std::cout << e << std::endl;
+  ASSERT_EQ(2u, errors.size());
+  EXPECT_NE(std::string::npos,
+    errors[0].Message().find(
+      "axis xyz expressed-in frame with name[invalid] specified by joint with"
+      " name[joint] not found in model with"
+      " name[joint_axis_invalid_expressed_in]"));
+}
+
 //////////////////////////////////////////////////
 TEST(DOMJointAxis, InfiniteLimits)
 {

--- a/test/integration/joint_axis_dom.cc
+++ b/test/integration/joint_axis_dom.cc
@@ -231,6 +231,7 @@ TEST(DOMJointAxis, InvalidExpressedIn)
   for (auto e : errors)
     std::cout << e << std::endl;
   ASSERT_EQ(2u, errors.size());
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::JOINT_AXIS_EXPRESSED_IN_INVALID);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(
       "axis xyz expressed-in frame with name[invalid] specified by joint with"

--- a/test/sdf/joint_axis_invalid_expressed_in.sdf
+++ b/test/sdf/joint_axis_invalid_expressed_in.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.6">
+<sdf version="1.7">
   <model name="joint_axis_invalid_expressed_in">
     <link name="link">
       <pose>0 0 1 0 0 0</pose>

--- a/test/sdf/joint_axis_invalid_expressed_in.sdf
+++ b/test/sdf/joint_axis_invalid_expressed_in.sdf
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="joint_axis_invalid_expressed_in">
+    <link name="link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <joint name="joint" type="revolute">
+      <pose>0 0 3 0 0 0</pose>
+      <parent>world</parent>
+      <child>link</child>
+      <axis>
+        <xyz expressed_in="invalid">0 0 1</xyz>
+      </axis>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Related to #1166 

## Summary

In `axis` and `axis2` elements, if the `//xyz/@expressed_in` attribute is not empty, then it must contain the name of a frame in the current scope. The parser does not currently check the validity of `//xyz/@expressed_in` values, as evidenced by the test failure added in https://github.com/gazebosim/sdformat/commit/078b042f6960875d226e1b18b45c51cb8ecfa952. A checking function `checkJointAxisExpressedInValues` is added to the parser in https://github.com/gazebosim/sdformat/commit/6ee6413c3bc9c6753a7239dee323d079be7aa168, along with a new error type `JOINT_AXIS_EXPRESSED_IN_INVALID`.

## Test it

Run the `INTEGRATION_joint_axis_dom` test with each commit from this branch.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
