### PR TITLE
Change default camera_info_topic value to __default__

### DIFF
--- a/sdf/1.7/camera.sdf
+++ b/sdf/1.7/camera.sdf
@@ -5,7 +5,7 @@
     <description>An optional name for the camera.</description>
   </attribute>
 
-  <element name="camera_info_topic" type="string" default="camera_info" required="0">
+  <element name="camera_info_topic" type="string" default="__default__" required="0">
     <description>Name of the camera info</description>
   </element> <!-- End camera Info topic -->
 

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -258,6 +258,8 @@ Errors Camera::Load(ElementPtr _sdf)
 
   this->dataPtr->cameraInfoTopic = _sdf->Get<std::string>("camera_info_topic",
       this->dataPtr->cameraInfoTopic).first;
+  if (this->dataPtr->cameraInfoTopic == "__default__")
+    this->dataPtr->cameraInfoTopic = "";
 
   this->dataPtr->hfov = _sdf->Get<ignition::math::Angle>("horizontal_fov",
       this->dataPtr->hfov).first;


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

Related with this comment https://github.com/gazebosim/gz-sensors/pull/285#issuecomment-1316156578

## Summary

Changed default value of camera topic to `__default__`  like the other topic names and strings.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.