### PR TITLE
Suggestions for #1166

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -172,6 +172,10 @@ namespace sdf
     /// \brief The joint axis expressed-in value does not match the name of an
     /// existing frame in the current scope.
     JOINT_AXIS_EXPRESSED_IN_INVALID,
+
+    /// \brief The joint axis mimic does not refer to a valid joint in the
+    /// current scope.
+    JOINT_AXIS_MIMIC_INVALID,
   };
 
   class SDFORMAT_VISIBLE Error

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -425,6 +425,15 @@ namespace sdf
   SDFORMAT_VISIBLE
   void checkJointAxisExpressedInValues(const sdf::Root *_root, Errors &_errors);
 
+  /// \brief Check that all joint axes in contained joints that specify mimic
+  /// constraints use valid joint names.
+  /// This checks recursively and should check the files exhaustively
+  /// rather than terminating early when the first error is found.
+  /// \param[in] _root SDF Root object to check recursively.
+  /// \param[out] _errors Detected errors will be appended to this variable.
+  SDFORMAT_VISIBLE
+  void checkJointAxisMimicValues(const sdf::Root *_root, Errors &_errors);
+
   /// \brief For the world and each model, check that the attached_to graphs
   /// build without errors and have no cycles.
   /// Confirm that following directed edges from each vertex in the graph

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -176,7 +176,7 @@ Errors Joint::Load(ElementPtr _sdf)
     {
       if (this->dataPtr->axis[0]->MimicJoint()->joint == this->Name())
       {
-        errors.push_back({ErrorCode::ATTRIBUTE_INVALID,
+        errors.push_back({ErrorCode::JOINT_AXIS_MIMIC_INVALID,
           "Joint with name [" + this->dataPtr->name +
           "] cannot mimic itself."});
       }
@@ -193,7 +193,7 @@ Errors Joint::Load(ElementPtr _sdf)
     {
       if (this->dataPtr->axis[1]->MimicJoint()->joint == this->Name())
       {
-        errors.push_back({ErrorCode::ATTRIBUTE_INVALID,
+        errors.push_back({ErrorCode::JOINT_AXIS_MIMIC_INVALID,
           "Joint with name [" + this->dataPtr->name +
           "] cannot mimic itself."});
       }

--- a/src/JointAxis_TEST.cc
+++ b/src/JointAxis_TEST.cc
@@ -168,6 +168,7 @@ TEST(DOMJointAxis, ZeroNormVectorReturnsError)
   EXPECT_EQ(errors[0].Message(), "The norm of the xyz vector cannot be zero");
 }
 
+/////////////////////////////////////////////////
 TEST(DOMJointAxis, ParseMimic)
 {
   std::string sdf =
@@ -215,7 +216,8 @@ TEST(DOMJointAxis, ParseMimic)
   EXPECT_EQ(mimicElement->Get<double>("reference"), 3);
 }
 
-TEST(DOMJointAxis, ParseMimicInvalidJointName)
+/////////////////////////////////////////////////
+TEST(DOMJointAxis, ParseInvalidSelfMimic)
 {
   std::string sdf =
     "<?xml version='1.0' ?>"
@@ -223,28 +225,39 @@ TEST(DOMJointAxis, ParseMimicInvalidJointName)
     "  <model name='test'>"
     "    <link name='link1'/>"
     "    <link name='link2'/>"
-    "    <joint name='revolute_joint' type='revolute'>"
+    "    <joint name='self_mimic' type='universal'>"
     "      <pose>1 0 0 0 0 0</pose>"
     "      <child>link1</child>"
     "      <parent>link2</parent>"
     "      <axis>"
     "        <xyz>0 0 1</xyz>"
-    "        <mimic joint='revolute_joint'>"
+    "        <mimic joint='self_mimic'>"
     "          <multiplier>4</multiplier>"
     "          <offset>2</offset>"
     "          <reference>3</reference>"
     "        </mimic>"
     "      </axis>"
+    "      <axis2>"
+    "        <xyz>1 0 0</xyz>"
+    "        <mimic joint='self_mimic'>"
+    "          <multiplier>4</multiplier>"
+    "          <offset>2</offset>"
+    "          <reference>3</reference>"
+    "        </mimic>"
+    "      </axis2>"
     "    </joint>"
     "  </model>"
     "</sdf>";
 
   sdf::Root root;
   auto errors = root.LoadSdfString(sdf);
-  EXPECT_EQ(errors.size(), 1);
-  std::stringstream ss;
-  ss << errors[0];
-  std::string errorMsg = "Error Code 5: Msg: Joint with name "
-    "[revolute_joint] cannot mimic itself.";
-  EXPECT_EQ(ss.str(), errorMsg);
+  EXPECT_EQ(errors.size(), 2) << errors;
+  for (const auto &error : errors)
+  {
+    std::stringstream ss;
+    ss << error;
+    const std::string errorMsg = "Error Code 39: Msg: Joint with name "
+      "[self_mimic] cannot mimic itself.";
+    EXPECT_EQ(ss.str(), errorMsg);
+  }
 }

--- a/src/JointAxis_TEST.cc
+++ b/src/JointAxis_TEST.cc
@@ -251,13 +251,60 @@ TEST(DOMJointAxis, ParseInvalidSelfMimic)
 
   sdf::Root root;
   auto errors = root.LoadSdfString(sdf);
-  EXPECT_EQ(errors.size(), 2) << errors;
+  EXPECT_EQ(errors.size(), 4) << errors;
   for (const auto &error : errors)
   {
     std::stringstream ss;
     ss << error;
     const std::string errorMsg = "Error Code 39: Msg: Joint with name "
       "[self_mimic] cannot mimic itself.";
+    EXPECT_EQ(ss.str(), errorMsg);
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(DOMJointAxis, ParseMimicInvalidJointName)
+{
+  std::string sdf =
+    "<?xml version='1.0' ?>"
+    "<sdf version='1.10'>"
+    "  <model name='test'>"
+    "    <link name='link1'/>"
+    "    <link name='link2'/>"
+    "    <joint name='joint' type='universal'>"
+    "      <pose>1 0 0 0 0 0</pose>"
+    "      <child>link1</child>"
+    "      <parent>link2</parent>"
+    "      <axis>"
+    "        <xyz>0 0 1</xyz>"
+    "        <mimic joint='invalid'>"
+    "          <multiplier>4</multiplier>"
+    "          <offset>2</offset>"
+    "          <reference>3</reference>"
+    "        </mimic>"
+    "      </axis>"
+    "      <axis2>"
+    "        <xyz>1 0 0</xyz>"
+    "        <mimic joint='invalid'>"
+    "          <multiplier>4</multiplier>"
+    "          <offset>2</offset>"
+    "          <reference>3</reference>"
+    "        </mimic>"
+    "      </axis2>"
+    "    </joint>"
+    "  </model>"
+    "</sdf>";
+
+  sdf::Root root;
+  auto errors = root.LoadSdfString(sdf);
+  EXPECT_EQ(errors.size(), 2) << errors;
+  for (const auto &error : errors)
+  {
+    std::stringstream ss;
+    ss << error;
+    const std::string errorMsg = "Error Code 39: Msg: A joint with"
+      " name[invalid] specified by an axis mimic in joint with name[joint] not"
+      " found in model with name[test].";
     EXPECT_EQ(ss.str(), errorMsg);
   }
 }

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -389,6 +389,9 @@ Errors Root::Load(SDFPtr _sdf, const ParserConfig &_config)
   // Check that //axis*/xyz/@expressed_in values specify valid frames.
   checkJointAxisExpressedInValues(this, errors);
 
+  // Check that //axis*/mimic/@joint values specify valid joints.
+  checkJointAxisMimicValues(this, errors);
+
   return errors;
 }
 


### PR DESCRIPTION
These are some suggested changes for #1166.

* Adding a new error type for invalid mimic attributes
* Checking the `//mimic/@joint` attributes during `Root::Load`