### PR TITLE
[backport sdf9] Added HasLensProjection (#1203)

### DIFF
--- a/include/sdf/Camera.hh
+++ b/include/sdf/Camera.hh
@@ -553,6 +553,10 @@ namespace sdf
     /// \param[in] _mask visibility mask
     public: void SetVisibilityMask(uint32_t _mask);
 
+    /// \brief Get whether or not the camera has projection values set
+    /// \return True if the camera has projection values set, false otherwise
+    public: bool HasLensProjection() const;
+
     /// \brief Private data pointer.
     private: CameraPrivate *dataPtr = nullptr;
   };

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -186,6 +186,9 @@ class sdf::CameraPrivate
   /// \brief lens instrinsics s.
   public: double lensIntrinsicsS{1.0};
 
+  /// \brief True if this camera has custom projection values
+  public: bool hasProjection = false;
+
   /// \brief Visibility mask of a camera. Defaults to 0xFFFFFFFF
   public: uint32_t visibilityMask{4294967295u};
 };
@@ -426,7 +429,7 @@ Errors Camera::Load(ElementPtr _sdf)
           this->dataPtr->lensProjectionTx).first;
       this->dataPtr->lensProjectionTy = projection->Get<double>("ty",
           this->dataPtr->lensProjectionTy).first;
-
+      this->dataPtr->hasProjection = true;
     }
   }
 
@@ -972,6 +975,7 @@ double Camera::LensProjectionFx() const
 void Camera::SetLensProjectionFx(double _fx_p)
 {
   this->dataPtr->lensProjectionFx = _fx_p;
+  this->dataPtr->hasProjection = true;
 }
 
 /////////////////////////////////////////////////
@@ -984,6 +988,7 @@ double Camera::LensProjectionFy() const
 void Camera::SetLensProjectionFy(double _fy_p)
 {
   this->dataPtr->lensProjectionFy = _fy_p;
+  this->dataPtr->hasProjection = true;
 }
 
 /////////////////////////////////////////////////
@@ -996,6 +1001,7 @@ double Camera::LensProjectionCx() const
 void Camera::SetLensProjectionCx(double _cx_p)
 {
   this->dataPtr->lensProjectionCx = _cx_p;
+  this->dataPtr->hasProjection = true;
 }
 
 /////////////////////////////////////////////////
@@ -1008,6 +1014,7 @@ double Camera::LensProjectionCy() const
 void Camera::SetLensProjectionCy(double _cy_p)
 {
   this->dataPtr->lensProjectionCy = _cy_p;
+  this->dataPtr->hasProjection = true;
 }
 
 /////////////////////////////////////////////////
@@ -1020,6 +1027,7 @@ double Camera::LensProjectionTx() const
 void Camera::SetLensProjectionTx(double _tx)
 {
   this->dataPtr->lensProjectionTx = _tx;
+  this->dataPtr->hasProjection = true;
 }
 
 /////////////////////////////////////////////////
@@ -1032,6 +1040,7 @@ double Camera::LensProjectionTy() const
 void Camera::SetLensProjectionTy(double _ty)
 {
   this->dataPtr->lensProjectionTy = _ty;
+  this->dataPtr->hasProjection = true;
 }
 
 /////////////////////////////////////////////////
@@ -1098,4 +1107,10 @@ uint32_t Camera::VisibilityMask() const
 void Camera::SetVisibilityMask(uint32_t _mask)
 {
   this->dataPtr->visibilityMask = _mask;
+}
+
+/////////////////////////////////////////////////
+bool Camera::HasLensProjection() const
+{
+  return this->dataPtr->hasProjection;
 }

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -191,6 +191,7 @@ TEST(DOMCamera, Construction)
   EXPECT_DOUBLE_EQ(2.3, cam.LensIntrinsicsSkew());
 
   EXPECT_EQ(4294967295u, cam.VisibilityMask());
+  EXPECT_TRUE(cam.HasLensProjection());
   cam.SetVisibilityMask(123u);
   EXPECT_EQ(123u, cam.VisibilityMask());
 


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>


# 🎉 New feature

Related with: https://github.com/gazebosim/sdformat/pull/1203

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
