### PR TITLE
Prepare for 13.3.0~pre1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.2.0)
+project (sdformat13 VERSION 13.3.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software
@@ -43,7 +43,7 @@ if (BUILD_SDF)
   gz_configure_project(
     NO_PROJECT_PREFIX
     REPLACE_INCLUDE_PATH sdf
-    VERSION_SUFFIX)
+    VERSION_SUFFIX pre1)
 
   #################################################
   # Find tinyxml2.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,35 @@
 ## libsdformat 13.X
 
+### libsdformat 13.3.0 (2022-12-12)
+
+1. Sensor: add sdf::Errors output to API methods
+    * [Pull request #1138](https://github.com/gazebosim/sdformat/pull/1138)
+
+1. Warn child joint that resolves to world
+    * [Pull request #1211](https://github.com/gazebosim/sdformat/pull/1211)
+
+1. Converter: add sdf::Errors output to API methods
+    * [Pull request #1123](https://github.com/gazebosim/sdformat/pull/1123)
+
+1. ParamPassing: sdfwarns to sdf::Errors when warnings policy set to sdf::EnforcementPolicy::ERR
+    * [Pull request #1135](https://github.com/gazebosim/sdformat/pull/1135)
+
+1. Camera: added HasLensProjection
+    * [Pull request #1203](https://github.com/gazebosim/sdformat/pull/1203)
+
+1. Change default `camera_info_topic` value to `__default__`
+    * [Pull request #1201](https://github.com/gazebosim/sdformat/pull/1201)
+
+1. Check JointAxis expressed-in values during Load
+    * [Pull request #1195](https://github.com/gazebosim/sdformat/pull/1195)
+
+1. Added camera info topic to Camera
+    * [Pull request #1198](https://github.com/gazebosim/sdformat/pull/1198)
+    * [Pull request #1200](https://github.com/gazebosim/sdformat/pull/1200)
+
+1. Fix static URDF models with fixed joints 
+    * [Pull request #1193](https://github.com/gazebosim/sdformat/pull/1193)
+
 ### libsdformat 13.2.0 (2022-10-20)
 
 1. sdf/1.10/joint.sdf: add `screw_thread_pitch`


### PR DESCRIPTION
# 🎈 Release

Preparation for 13.3.0~pre1 release.

Comparison to 13.2.0: https://github.com/osrf/sdformat/compare/sdformat13_13.2.0...sdf13

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sensors/pull/289

## Checklist
- [ ] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.