### PR TITLE
Allowing relative paths in URDF

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -415,7 +415,7 @@ bool readFileInternal(const std::string &_filename, SDFPtr _sdf,
   {
     URDF2SDF u2g;
     TiXmlDocument doc = u2g.InitModelFile(filename);
-    if (sdf::readDoc(&doc, _sdf, "urdf file", _convert, _errors))
+    if (sdf::readDoc(&doc, _sdf, filename, _convert, _errors))
     {
       sdfdbg << "parse from urdf file [" << _filename << "].\n";
       return true;


### PR DESCRIPTION
# 🦟 Bug fix
## Summary
When parsing a URDF file, the `_source` parameter is set to "urdf file" which breaks relative path resolution later on. This commit changes the call to `sdf::readDoc` to use `filename` as the `_source` parameter instead.

## Additional Information
I came across this issue while testing out a physics plugin I am developing for PhysX 4.1 integration. Searching all repos pulled by colcon reveals no other uses of the phrase "urdf file" as a special case. Testing has revealed no new issues.