### PR TITLE
Use `File.exist?` for Ruby 3.2 compatibility

### DIFF
--- a/tools/xmlschema.rb
+++ b/tools/xmlschema.rb
@@ -265,7 +265,7 @@ opt_parser.parse!
 if infile.nil?
   puts "Missing option -i."
   exit
-elsif !File.exists?(infile)
+elsif !File.exist?(infile)
   puts "Input file[#{infile}] does not exist\n"
   exit
 end
@@ -273,7 +273,7 @@ end
 if $path.nil?
   puts "Missing option -s."
   exit
-elsif !Dir.exists?($path)
+elsif !Dir.exist?($path)
   puts "SDF source dir[#{$path}] does not exist\n"
   exit
 end
@@ -281,7 +281,7 @@ end
 if outdir.nil?
   puts "Missing output directory, option -o."
   exit
-elsif !Dir.exists?(outdir)
+elsif !Dir.exist?(outdir)
   Dir.mkdir(outdir)
 end
 


### PR DESCRIPTION
Preparing Ruby 3.2 for Fedora, I have noticed that sdformat package build fails:

~~~
... snip ...

[  4%] Running xml schema compiler on actor.sdf
cd /builddir/build/BUILD/sdformat-6.0.0/redhat-linux-build/sdf/1.6 && /usr/bin/ruby /builddir/build/BUILD/sdformat-6.0.0/tools/xmlschema.rb -s /builddir/build/BUILD/sdformat-6.0.0/sdf/1.6 -i /builddir/build/BUILD/sdformat-6.0.0/sdf/1.6/actor.sdf -o /builddir/build/BUILD/sdformat-6.0.0/redhat-linux-build/sdf/1.6 [  5%] Building CXX object src/CMakeFiles/sdformat.dir/Exception.cc.o
cd /builddir/build/BUILD/sdformat-6.0.0/redhat-linux-build/src && /usr/bin/g++ -Dsdformat_EXPORTS -DBUILDING_DLL -I/builddir/build/BUILD/sdformat-6.0.0/test/gtest/include -I/builddir/build/BUILD/sdformat-6.0.0/include -I/builddir/build/BUILD/sdformat-6.0.0/redhat-linux-build -I/builddir/build/BUILD/sdformat-6.0.0/redhat-linux-build/include -isystem /usr/include/ignition/math4 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1   -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Waddress -Warray-bounds -Wcomment -Wformat -Wnonnull -Wparentheses -Wreorder -Wreturn-type -Wsequence-point -Wsign-compare -Wstrict-aliasing -Wstrict-overflow=1 -Wswitch -Wtrigraphs -Wuninitialized -Wunused-function -Wunused-label -Wunused-value -Wunused-variable -Wvolatile-register-var -Wextra -Wno-long-long -Wno-unused-value -Wno-unused-value -Wno-unused-value -Wno-unused-value -Wfloat-equal -Wshadow -Winit-self -Wswitch-default -Wmissing-include-dirs -pedantic -Wno-pragmas -Wc++11-compat -DNDEBUG -fPIC   -fPIC -MD -MT src/CMakeFiles/sdformat.dir/Exception.cc.o -MF CMakeFiles/sdformat.dir/Exception.cc.o.d -o CMakeFiles/sdformat.dir/Exception.cc.o -c /builddir/build/BUILD/sdformat-6.0.0/src/Exception.cc
/builddir/build/BUILD/sdformat-6.0.0/tools/xmlschema.rb:268:in `<main>': undefined method `exists?' for File:Class (NoMethodError)

elsif !File.exists?(infile)
           ^^^^^^^^
Did you mean?  exist?
gmake[2]: *** [sdf/1.6/CMakeFiles/schema1_6.dir/build.make:130: sdf/1.6/actor.xsd] Error 1 gmake[2]: Leaving directory '/builddir/build/BUILD/sdformat-6.0.0/redhat-linux-build' gmake[1]: *** [CMakeFiles/Makefile2:1675: sdf/1.6/CMakeFiles/schema1_6.dir/all] Error 2 gmake[1]: *** Waiting for unfinished jobs....
[  5%] Building CXX object src/CMakeFiles/sdformat.dir/Filesystem.cc.o

... snip ...
~~~

This is due to this change in Ruby:

https://github.com/ruby/ruby/blob/a528908271c678360d2d8ca232c178e7cdd340b4/NEWS.md?plain=1#L589

Please note that I have not tested this patch in any way. Just thought that it will be better to sent PR instead of opening ticket :)