### PR TITLE
macos workflow: don't upgrade existing packages

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,6 +16,8 @@ jobs:
     - run: brew config
 
     - name: Install base dependencies
+      env:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
         brew tap osrf/simulation;
         brew install --only-dependencies ${PACKAGE};


### PR DESCRIPTION
# 🦟 Bug fix

Fixes macOS CI

## Summary

Set `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` environment variable to prevent upgrading preinstalled packages, since current CI builds are failing when upgrading one of the existing packages. I saw a hint for this in the console output of a failed build:

~~~
==> Upgrading 10 dependents of upgraded formulae:
Disable this behaviour by setting HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
colima 0.5.0 -> 0.5.2, composer 2.4.4 -> 2.5.1, curl 7.86.0 -> 7.87.0, imagemagick 7.1.0-54 -> 7.1.0-57, kotlin 1.7.21 -> 1.8.0, libheif 1.14.0 -> 1.14.1, libraw 0.20.2_4 -> 0.21.0, lima 0.14.1 -> 0.14.2, maven 3.8.6 -> 3.8.7, python@3.11 3.11.0 -> 3.11.1
~~~

https://github.com/gazebosim/sdformat/actions/runs/3681027316/jobs/6557385982

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
