### PR TITLE
Make throwOrPrintErrors a member of sdf::Error

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -251,7 +251,7 @@ namespace sdf
     /// \brief It will print the error to _out or throw it using
     /// SDF_ASSERT depending on its ErrorCode.
     /// \param[in] _out ostream to use for printing errors.
-    public: void throwOrPrintError(sdf::Console::ConsoleStream &_out) const;
+    public: void ThrowOrPrintError(sdf::Console::ConsoleStream &_out) const;
 
     /// \brief Safe bool conversion.
     /// \return True if this Error's Code() != NONE. In otherwords, this is

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -247,6 +247,10 @@ namespace sdf
     /// \sa Element::SetXmlPath
     public: void SetXmlPath(const std::string &_xmlPath);
 
+    /// \brief It will print the error to sdferr or throw it using
+    /// SDF_ASSERT depending on its ErrorCode.
+    public: void throwOrPrintError();
+
     /// \brief Safe bool conversion.
     /// \return True if this Error's Code() != NONE. In otherwords, this is
     /// true when there is an error.

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -22,6 +22,7 @@
 #include <optional>
 #include <gz/utils/ImplPtr.hh>
 #include <sdf/sdf_config.h>
+#include "sdf/Console.hh"
 #include "sdf/system_util.hh"
 
 #ifdef _WIN32
@@ -247,9 +248,10 @@ namespace sdf
     /// \sa Element::SetXmlPath
     public: void SetXmlPath(const std::string &_xmlPath);
 
-    /// \brief It will print the error to sdferr or throw it using
+    /// \brief It will print the error to _out or throw it using
     /// SDF_ASSERT depending on its ErrorCode.
-    public: void throwOrPrintError();
+    /// \param[in] _out ostream to use for printing errors.
+    public: void throwOrPrintError(sdf::Console::ConsoleStream &_out) const;
 
     /// \brief Safe bool conversion.
     /// \return True if this Error's Code() != NONE. In otherwords, this is

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -16,7 +16,6 @@
 */
 
 #include "sdf/Assert.hh"
-#include "sdf/Console.hh"
 #include "sdf/Error.hh"
 
 using namespace sdf;
@@ -121,7 +120,7 @@ void Error::SetXmlPath(const std::string &_xmlPath)
 }
 
 /////////////////////////////////////////////////
-void Error::throwOrPrintError()
+void Error::throwOrPrintError(sdf::Console::ConsoleStream &_out) const
 {
   if (this->dataPtr->code == sdf::ErrorCode::FATAL_ERROR)
   {
@@ -129,7 +128,7 @@ void Error::throwOrPrintError()
   }
   else
   {
-    sdferr << this->dataPtr->message;
+    _out << this->dataPtr->message;
   }
 }
 

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include "sdf/Assert.hh"
+#include "sdf/Console.hh"
 #include "sdf/Error.hh"
 
 using namespace sdf;
@@ -116,6 +118,19 @@ std::optional<std::string> Error::XmlPath() const
 void Error::SetXmlPath(const std::string &_xmlPath)
 {
   this->dataPtr->xmlPath = _xmlPath;
+}
+
+/////////////////////////////////////////////////
+void Error::throwOrPrintError()
+{
+  if (this->dataPtr->code == sdf::ErrorCode::FATAL_ERROR)
+  {
+    SDF_ASSERT(false, this->dataPtr->message);
+  }
+  else
+  {
+    sdferr << this->dataPtr->message;
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -120,7 +120,7 @@ void Error::SetXmlPath(const std::string &_xmlPath)
 }
 
 /////////////////////////////////////////////////
-void Error::throwOrPrintError(sdf::Console::ConsoleStream &_out) const
+void Error::ThrowOrPrintError(sdf::Console::ConsoleStream &_out) const
 {
   if (this->dataPtr->code == sdf::ErrorCode::FATAL_ERROR)
   {

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -167,18 +167,11 @@ void enforceConfigurablePolicyCondition(
 }
 
 /////////////////////////////////////////////////
-void throwOrPrintErrors(const sdf::Errors& _errors)
+void throwOrPrintErrors(sdf::Errors& _errors)
 {
   for(auto& error : _errors)
   {
-    if (error.Code() == sdf::ErrorCode::FATAL_ERROR)
-    {
-      SDF_ASSERT(false, error.Message());
-    }
-    else
-    {
-      sdferr << error.Message();
-    }
+    error.throwOrPrintError();
   }
 }
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -171,7 +171,7 @@ void throwOrPrintErrors(const sdf::Errors& _errors)
 {
   for(auto& error : _errors)
   {
-    error.throwOrPrintError(sdferr);
+    error.ThrowOrPrintError(sdferr);
   }
 }
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -167,11 +167,11 @@ void enforceConfigurablePolicyCondition(
 }
 
 /////////////////////////////////////////////////
-void throwOrPrintErrors(sdf::Errors& _errors)
+void throwOrPrintErrors(const sdf::Errors& _errors)
 {
   for(auto& error : _errors)
   {
-    error.throwOrPrintError();
+    error.throwOrPrintError(sdferr);
   }
 }
 

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -88,7 +88,7 @@ namespace sdf
   /// \brief It will print the errors to sdferr or throw them using
   /// SDF_ASSERT depending on their ErrorCode.
   /// \param[in] _errors  The vector of errors.
-  void throwOrPrintErrors(const sdf::Errors& _errors);
+  void throwOrPrintErrors(sdf::Errors& _errors);
 
   /// \brief Load all objects of a specific sdf element type. No error
   /// is returned if an element is not present. This function assumes that

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -88,7 +88,7 @@ namespace sdf
   /// \brief It will print the errors to sdferr or throw them using
   /// SDF_ASSERT depending on their ErrorCode.
   /// \param[in] _errors  The vector of errors.
-  void throwOrPrintErrors(sdf::Errors& _errors);
+  void throwOrPrintErrors(const sdf::Errors& _errors);
 
   /// \brief Load all objects of a specific sdf element type. No error
   /// is returned if an element is not present. This function assumes that


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🎉 New feature

Related to https://github.com/gazebosim/sdformat/pull/1141.

## Summary

Because of the request [here](https://github.com/gazebosim/sdformat/pull/1141#discussion_r1043663060) and as per IM, moving `throwOrPrintErrors` into `Error.cc` so now an Error has a method to be thrown or printed and this can be used in current SDFormat header files.

## Test it
Throw any `Error` object using the new method.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

