### PR TITLE
Make ThrowOrPrintError a free internal function

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -248,11 +248,6 @@ namespace sdf
     /// \sa Element::SetXmlPath
     public: void SetXmlPath(const std::string &_xmlPath);
 
-    /// \brief It will print the error to _out or throw it using
-    /// SDF_ASSERT depending on its ErrorCode.
-    /// \param[in] _out ostream to use for printing errors.
-    public: void ThrowOrPrintError(sdf::Console::ConsoleStream &_out) const;
-
     /// \brief Safe bool conversion.
     /// \return True if this Error's Code() != NONE. In otherwords, this is
     /// true when there is an error.
@@ -277,8 +272,20 @@ namespace sdf
     /// \brief Private data pointer.
     GZ_UTILS_IMPL_PTR(dataPtr)
   };
-  }
-}
+
+  /// \brief Internal namespace. Functions and classes defined in this namespace
+  /// are for internal use only and maybe removed without a deprecation cycle.
+  namespace internal
+  {
+  /// \brief Prints the error to _out or throw using SDF_ASSERT depending on the
+  /// ErrorCode in _error.
+  /// \param[out] _out ostream to use for printing errors.
+  /// \param[in] _error _error The error object to be printed
+  void SDFORMAT_VISIBLE throwOrPrintError(sdf::Console::ConsoleStream &_out,
+                                          const sdf::Error &_error);
+  }  // namespace internal
+  }  // namespace SDF_VERSION_NAMESPACE
+}  // namespace sdf
 #ifdef _WIN32
 #pragma warning(pop)
 #endif

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -120,19 +120,6 @@ void Error::SetXmlPath(const std::string &_xmlPath)
 }
 
 /////////////////////////////////////////////////
-void Error::ThrowOrPrintError(sdf::Console::ConsoleStream &_out) const
-{
-  if (this->dataPtr->code == sdf::ErrorCode::FATAL_ERROR)
-  {
-    SDF_ASSERT(false, this->dataPtr->message);
-  }
-  else
-  {
-    _out << this->dataPtr->message;
-  }
-}
-
-/////////////////////////////////////////////////
 Error::operator bool() const
 {
   return this->dataPtr->code != ErrorCode::NONE;
@@ -174,5 +161,22 @@ std::ostream &operator<<(std::ostream &_out, const sdf::Error &_err)
       << "Msg: " << _err.Message();
   return _out;
 }
+
+namespace internal
+{
+
+void throwOrPrintError(sdf::Console::ConsoleStream &_out,
+                       const sdf::Error &_error)
+{
+  if (_error.Code() == sdf::ErrorCode::FATAL_ERROR)
+  {
+    SDF_ASSERT(false, _error.Message());
+  }
+  else
+  {
+    _out << _error.Message();
+  }
 }
-}
+}  // namespace internal
+}  // namespace SDF_VERSION_NAMESPACE
+}  // namespace sdf

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -139,6 +139,14 @@ TEST(Error, ValueConstructionWithXmlPath)
 /////////////////////////////////////////////////
 TEST(Error, ThrowOrPrint)
 {
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
   {
     sdf::Error error(sdf::ErrorCode::DUPLICATE_NAME, "Duplicate found");
     std::stringstream buffer;

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -18,7 +18,9 @@
 #include <gtest/gtest.h>
 #include <optional>
 #include "sdf/sdf_config.h"
+#include "sdf/Exception.hh"
 #include "sdf/Error.hh"
+#include "test_utils.hh"
 
 /////////////////////////////////////////////////
 TEST(Error, DefaultConstruction)
@@ -134,3 +136,26 @@ TEST(Error, ValueConstructionWithXmlPath)
     FAIL();
 }
 
+/////////////////////////////////////////////////
+TEST(Error, ThrowOrPrint)
+{
+  {
+    sdf::Error error(sdf::ErrorCode::DUPLICATE_NAME, "Duplicate found");
+    std::stringstream buffer;
+    sdf::testing::RedirectConsoleStream redir(
+        sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+    sdf::internal::throwOrPrintError(sdferr, error);
+    EXPECT_NE(std::string::npos, buffer.str().find("Duplicate found"))
+        << buffer.str();
+  }
+
+  {
+    std::stringstream buffer;
+    sdf::testing::RedirectConsoleStream redir(
+        sdf::Console::Instance()->GetMsgStream(), &buffer);
+    sdf::Error error(sdf::ErrorCode::FATAL_ERROR, "Fatal Error");
+    EXPECT_THROW(sdf::internal::throwOrPrintError(sdferr, error),
+                 sdf::AssertionInternalError);
+  }
+}

--- a/src/Exception.cc
+++ b/src/Exception.cc
@@ -48,6 +48,7 @@ Exception::Exception(const char *_file, std::int64_t _line, std::string _msg)
   this->dataPtr->file = _file;
   this->dataPtr->line = _line;
   this->dataPtr->str = _msg;
+  // TODO(azeey) Remove Print for libsdformat 14.0
   this->Print();
 }
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -171,7 +171,7 @@ void throwOrPrintErrors(const sdf::Errors& _errors)
 {
   for(auto& error : _errors)
   {
-    error.ThrowOrPrintError(sdferr);
+    internal::throwOrPrintError(sdferr, error);
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
#1220 added `sdf::Error::ThrowOrPrintError`, but after further thought, I think it would be better if we made it a free function inside the `internal` namespace as this allows us to remove the function without a deprecation cycle. Since the future goal of libsdformat is to remove exceptions, it is likely that we'd want to remove `ThrowOrPrintError` in the not too distance future.



## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
