### PR TITLE
xmlschema.rb: use File.exist?

### DIFF
--- a/tools/xmlschema.rb
+++ b/tools/xmlschema.rb
@@ -265,7 +265,7 @@ opt_parser.parse!
 if infile.nil?
   puts "Missing option -i."
   exit
-elsif !File.exists?(infile)
+elsif !File.exist?(infile)
   puts "Input file[#{infile}] does not exist\n"
   exit
 end
@@ -273,7 +273,7 @@ end
 if $path.nil?
   puts "Missing option -s."
   exit
-elsif !Dir.exists?($path)
+elsif !Dir.exist?($path)
   puts "SDF source dir[#{$path}] does not exist\n"
   exit
 end
@@ -281,7 +281,7 @@ end
 if outdir.nil?
   puts "Missing output directory, option -o."
   exit
-elsif !Dir.exists?(outdir)
+elsif !Dir.exist?(outdir)
   Dir.mkdir(outdir)
 end
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation with ruby 3

## Summary

The File.exists? method is [deprecated](https://ruby-doc.org/core-2.6.3/File.html#method-c-exists-3F) and has been [removed from ruby 3](https://ruby-doc.org/3.0.4/File.html#method-c-exist-3F).

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
