### PR TITLE
Cherry-pick #1216: Use `File.exist?` for Ruby 3.2 compatibility

### DIFF
--- a/tools/xmlschema.rb
+++ b/tools/xmlschema.rb
@@ -265,7 +265,7 @@ opt_parser.parse!
 if infile.nil?
   puts "Missing option -i."
   exit
-elsif !File.exists?(infile)
+elsif !File.exist?(infile)
   puts "Input file[#{infile}] does not exist\n"
   exit
 end
@@ -273,7 +273,7 @@ end
 if $path.nil?
   puts "Missing option -s."
   exit
-elsif !Dir.exists?($path)
+elsif !Dir.exist?($path)
   puts "SDF source dir[#{$path}] does not exist\n"
   exit
 end
@@ -281,7 +281,7 @@ end
 if outdir.nil?
   puts "Missing output directory, option -o."
   exit
-elsif !Dir.exists?(outdir)
+elsif !Dir.exist?(outdir)
   Dir.mkdir(outdir)
 end
 


### PR DESCRIPTION
# 🦟 Bug fix

Cherry-pick of #1216 to sdf9

## Summary

Prepare for ruby 3

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-Merge**.
