### PR TITLE
CI workflow: use checkout v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Ubuntu Bionic CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@bionic
@@ -19,7 +19,7 @@ jobs:
     name: Ubuntu Focal CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ jobs:
       PACKAGE: sdformat9
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Homebrew
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
# 🦟 Bug fix

Part of gazebo-tooling/release-tools#862.

## Summary

Version v2 of the actions/checkout workflow is deprecated, so switch to v3.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
