### PR TITLE
12.7.0~pre1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat12 VERSION 12.6.0)
+project (sdformat12 VERSION 12.7.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software
@@ -25,7 +25,7 @@ if (BUILD_SDF)
   ign_configure_project(
     NO_IGNITION_PREFIX
     REPLACE_IGNITION_INCLUDE_PATH sdf
-    VERSION_SUFFIX)
+    VERSION_SUFFIX pre1)
 
   #################################################
   # Find tinyxml2.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,18 @@
 ## libsdformat 12.X
 
+### libsdformat 12.7.0 (2023-09-07)
+
+1. Forward port libsdformat9.10.0. This includes the ign to gz headers.
+
+1. Use File.exist? for Ruby 3.2 compatibility.
+    * [Pull request #1216](https://github.com/gazebosim/sdformat/pull/1216)
+
+1. CI workflow: use checkout v3.
+    * [Pull request #1225](https://github.com/gazebosim/sdformat/pull/1225)
+
+1. macos workflow: don't upgrade existing packages.
+    * [Pull request #1217](https://github.com/gazebosim/sdformat/pull/1217)
+
 ### libsdformat 12.6.0 (2022-09-07)
 
 1. Reduce the number of include dirs for sdformat.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,17 +1,18 @@
 ## libsdformat 12.X
 
-### libsdformat 12.7.0 (2023-09-07)
+### libsdformat 12.7.0 (2023-02-03)
 
 1. Forward port libsdformat9.10.0. This includes the ign to gz headers.
 
 1. Use File.exist? for Ruby 3.2 compatibility.
     * [Pull request #1216](https://github.com/gazebosim/sdformat/pull/1216)
 
-1. CI workflow: use checkout v3.
-    * [Pull request #1225](https://github.com/gazebosim/sdformat/pull/1225)
-
-1. macos workflow: don't upgrade existing packages.
-    * [Pull request #1217](https://github.com/gazebosim/sdformat/pull/1217)
+1. Infrastructure
+  1. CI workflow: use checkout v3.
+      * [Pull request #1225](https://github.com/gazebosim/sdformat/pull/1225)
+  
+  1. macos workflow: don't upgrade existing packages.
+      * [Pull request #1217](https://github.com/gazebosim/sdformat/pull/1217)
 
 ### libsdformat 12.6.0 (2022-09-07)
 


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎈 Release

Preparation for 12.7.0~pre1 release.

Comparison to 12.6.0: https://github.com/gazebosim/sdformat/compare/sdformat12_12.6.0...sdf12

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
