### PR TITLE
13.3.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if (BUILD_SDF)
   gz_configure_project(
     NO_PROJECT_PREFIX
     REPLACE_INCLUDE_PATH sdf
-    VERSION_SUFFIX pre1)
+    VERSION_SUFFIX)
 
   #################################################
   # Find tinyxml2.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,12 @@
 ## libsdformat 13.X
 
-### libsdformat 13.3.0 (2022-02-07)
+### libsdformat 13.3.0 (2023-02-07)
 
 1. Use `File.exist?` for Ruby 3.2 compatibility
     * [Pull request #1216](https://github.com/gazebosim/sdformat/pull/1216)
 
 1. Make ThrowOrPrintError a free internal function
     * [Pull request #1221](https://github.com/gazebosim/sdformat/pull/1221)
-
-1. Make throwOrPrintErrors a member of sdf::Error
     * [Pull request #1220](https://github.com/gazebosim/sdformat/pull/1220)
 
 1. macos workflow: don't upgrade existing packages

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,27 @@
 ## libsdformat 13.X
 
-### libsdformat 13.3.0 (2022-12-12)
+### libsdformat 13.3.0 (2022-02-07)
+
+1. Use `File.exist?` for Ruby 3.2 compatibility
+    * [Pull request #1216](https://github.com/gazebosim/sdformat/pull/1216)
+
+1. Make ThrowOrPrintError a free internal function
+    * [Pull request #1221](https://github.com/gazebosim/sdformat/pull/1221)
+
+1. Make throwOrPrintErrors a member of sdf::Error
+    * [Pull request #1220](https://github.com/gazebosim/sdformat/pull/1220)
+
+1. macos workflow: don't upgrade existing packages
+    * [Pull request #1217](https://github.com/gazebosim/sdformat/pull/1217)
+
+1. update Param calls to use error vectors parameters
+    * [Pull request #1140](https://github.com/gazebosim/sdformat/pull/1140)
+
+1. ign -> gz Migrate Ignition Headers : sdformat
+    * [Pull request #1118](https://github.com/gazebosim/sdformat/pull/1118)
+
+1. Don't assume CMAKE_INSTALL_*DIR variables are relative
+    * [Pull request #1190](https://github.com/gazebosim/sdformat/pull/1190)
 
 1. Sensor: add sdf::Errors output to API methods
     * [Pull request #1138](https://github.com/gazebosim/sdformat/pull/1138)
@@ -27,7 +48,7 @@
     * [Pull request #1198](https://github.com/gazebosim/sdformat/pull/1198)
     * [Pull request #1200](https://github.com/gazebosim/sdformat/pull/1200)
 
-1. Fix static URDF models with fixed joints 
+1. Fix static URDF models with fixed joints
     * [Pull request #1193](https://github.com/gazebosim/sdformat/pull/1193)
 
 ### libsdformat 13.2.0 (2022-10-20)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### libsdformat 13.3.0 (2023-02-07)
 
+1. Add airspeed sensor
+    * [Pull request #1215](https://github.com/gazebosim/sdformat/pull/1215)
+
 1. Use `File.exist?` for Ruby 3.2 compatibility
     * [Pull request #1216](https://github.com/gazebosim/sdformat/pull/1216)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,9 +21,6 @@
 1. ign -> gz Migrate Ignition Headers : sdformat
     * [Pull request #1118](https://github.com/gazebosim/sdformat/pull/1118)
 
-1. Don't assume CMAKE_INSTALL_*DIR variables are relative
-    * [Pull request #1190](https://github.com/gazebosim/sdformat/pull/1190)
-
 1. Sensor: add sdf::Errors output to API methods
     * [Pull request #1138](https://github.com/gazebosim/sdformat/pull/1138)
 


### PR DESCRIPTION

<!-- For maintainers only -->

# 🎈 Release

Preparation for 13.3.0 release.

Comparison to 13.2.0: https://github.com/gazebosim/sdformat/compare/sdformat13_13.2.0...prep_13.3.0

<!-- Add links to PRs that require this release (if needed) -->
* https://github.com/gazebosim/gz-sensors/pull/289
* https://github.com/gazebosim/gz-sim/issues/1865

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
