### PR TITLE
Warn when ignoring urdf links due to small masses or no inertia defined

### DIFF
--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2653,7 +2653,7 @@ void CreateSDF(TiXmlElement *_root,
   {
     if (!_link->child_links.empty())
     {
-      sdfdbg << "urdf2sdf: link[" << _link->name
+      sdfwarn << "urdf2sdf: link[" << _link->name
              << "] has no inertia, ["
              << static_cast<int>(_link->child_links.size())
              << "] children links ignored.\n";
@@ -2661,7 +2661,7 @@ void CreateSDF(TiXmlElement *_root,
 
     if (!_link->child_joints.empty())
     {
-      sdfdbg << "urdf2sdf: link[" << _link->name
+      sdfwarn << "urdf2sdf: link[" << _link->name
              << "] has no inertia, ["
              << static_cast<int>(_link->child_links.size())
              << "] children joints ignored.\n";
@@ -2669,13 +2669,13 @@ void CreateSDF(TiXmlElement *_root,
 
     if (_link->parent_joint)
     {
-      sdfdbg << "urdf2sdf: link[" << _link->name
+      sdfwarn << "urdf2sdf: link[" << _link->name
              << "] has no inertia, "
              << "parent joint [" << _link->parent_joint->name
              << "] ignored.\n";
     }
 
-    sdfdbg << "urdf2sdf: link[" << _link->name
+    sdfwarn << "urdf2sdf: link[" << _link->name
            << "] has no inertia, not modeled in sdf\n";
     return;
   }

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2651,10 +2651,17 @@ void CreateSDF(TiXmlElement *_root,
   if (_link->name != "world" &&
       ((!_link->inertial) || gz::math::equal(_link->inertial->mass, 0.0)))
   {
+    const std::string inertia_issue =
+        _link->inertial && gz::math::equal(_link->inertial->mass, 0.0) ?
+        "a mass value of less than 1e-6" :
+        "no inertia defined";
+
     if (!_link->child_links.empty())
     {
       sdfwarn << "urdf2sdf: link[" << _link->name
-             << "] has no inertia, ["
+             << "] has "
+             << inertia_issue
+             << ", ["
              << static_cast<int>(_link->child_links.size())
              << "] children links ignored.\n";
     }
@@ -2662,7 +2669,9 @@ void CreateSDF(TiXmlElement *_root,
     if (!_link->child_joints.empty())
     {
       sdfwarn << "urdf2sdf: link[" << _link->name
-             << "] has no inertia, ["
+             << "] has "
+             << inertia_issue
+             << ", ["
              << static_cast<int>(_link->child_links.size())
              << "] children joints ignored.\n";
     }
@@ -2670,13 +2679,16 @@ void CreateSDF(TiXmlElement *_root,
     if (_link->parent_joint)
     {
       sdfwarn << "urdf2sdf: link[" << _link->name
-             << "] has no inertia, "
-             << "parent joint [" << _link->parent_joint->name
+             << "] has "
+             << inertia_issue
+             << ", parent joint [" << _link->parent_joint->name
              << "] ignored.\n";
     }
 
     sdfwarn << "urdf2sdf: link[" << _link->name
-           << "] has no inertia, not modeled in sdf\n";
+           << "] has "
+           << inertia_issue
+           << ", not modeled in sdf\n";
     return;
   }
 

--- a/src/parser_urdf_TEST.cc
+++ b/src/parser_urdf_TEST.cc
@@ -927,7 +927,8 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithNoInertia)
           << "  <joint name='joint1_2' type='continuous'>"
           << "    <parent link='link1' />"
           << "    <child  link='link2' />"
-          << "    <origin xyz='0.0 0.0 0.0' rpy='0.0 0.0 " << IGN_PI*0.5 << "' />"
+          << "    <origin xyz='0.0 0.0 0.0' rpy='0.0 0.0 " << IGN_PI*0.5
+          << "' />"
           << "  </joint>"
           << "  <link name='link2'>"
           << "    <inertial>"
@@ -973,7 +974,8 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithNoInertia)
           << "  <joint name='joint1_2' type='continuous'>"
           << "    <parent link='link1' />"
           << "    <child  link='link2' />"
-          << "    <origin xyz='0.0 0.0 0.0' rpy='0.0 0.0 " << IGN_PI*0.5 << "' />"
+          << "    <origin xyz='0.0 0.0 0.0' rpy='0.0 0.0 " << IGN_PI*0.5
+          << "' />"
           << "  </joint>"
           << "  <link name='link2' />"
           << "</robot>";
@@ -1002,7 +1004,8 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithNoInertia)
           << "  <joint name='joint1_2' type='continuous'>"
           << "    <parent link='link1' />"
           << "    <child  link='link2' />"
-          << "    <origin xyz='0.0 0.0 0.0' rpy='0.0 0.0 " << IGN_PI*0.5 << "' />"
+          << "    <origin xyz='0.0 0.0 0.0' rpy='0.0 0.0 " << IGN_PI*0.5
+          << "' />"
           << "  </joint>"
           << "  <link name='link2' />"
           << "</robot>";

--- a/src/parser_urdf_TEST.cc
+++ b/src/parser_urdf_TEST.cc
@@ -893,7 +893,7 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithNoInertia)
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
     EXPECT_PRED2(not_contains, buffer.str(),
-        "urdf2sdf: link[link] has no inertia, not modeled in sdf");
+        "urdf2sdf: link[link] has no inertia defined, not modeled in sdf");
   }
 
   {
@@ -913,7 +913,7 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithNoInertia)
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link] has no inertia, not modeled in sdf");
+        "urdf2sdf: link[link] has no inertia defined, not modeled in sdf");
   }
 
   {
@@ -946,11 +946,13 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithNoInertia)
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link1] has no inertia, [1] children links ignored");
+        "urdf2sdf: link[link1] has no inertia defined, [1] children links "
+        "ignored");
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link1] has no inertia, [1] children joints ignored");
+        "urdf2sdf: link[link1] has no inertia defined, [1] children joints "
+        "ignored");
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link1] has no inertia, not modeled in sdf");
+        "urdf2sdf: link[link1] has no inertia defined, not modeled in sdf");
   }
 
   {
@@ -983,9 +985,10 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithNoInertia)
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link2] has no inertia, parent joint [joint1_2] ignored");
+        "urdf2sdf: link[link2] has no inertia defined, parent joint [joint1_2] "
+        "ignored");
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link2] has no inertia, not modeled in sdf");
+        "urdf2sdf: link[link2] has no inertia defined, not modeled in sdf");
   }
 
   {
@@ -1011,19 +1014,21 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithNoInertia)
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link1] has no inertia, [1] children links ignored");
+        "urdf2sdf: link[link1] has no inertia defined, [1] children links "
+        "ignored");
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link1] has no inertia, [1] children joints ignored");
+        "urdf2sdf: link[link1] has no inertia defined, [1] children joints "
+        "ignored");
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link1] has no inertia, not modeled in sdf");
+        "urdf2sdf: link[link1] has no inertia defined, not modeled in sdf");
 
     // It parses in sequence, therefore once ignored, no warnings for link2 will
     // be issued.
     EXPECT_PRED2(not_contains, buffer.str(),
-        "urdf2sdf: link[link2] has no inertia, parent joint [joint1_2] will be "
-        "ignored");
+        "urdf2sdf: link[link2] has no inertia defined, parent joint [joint1_2] "
+        "will be ignored");
     EXPECT_PRED2(not_contains, buffer.str(),
-        "urdf2sdf: link[link2] has no inertia, not modeled in sdf");
+        "urdf2sdf: link[link2] has no inertia defined, not modeled in sdf");
   }
 
   // Revert cerr rdbug so as to not interfere with other tests
@@ -1068,7 +1073,8 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithSmallInertia)
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
     EXPECT_PRED2(contains, buffer.str(),
-        "urdf2sdf: link[link] has no inertia, not modeled in sdf");
+        "urdf2sdf: link[link] has a mass value of less than 1e-6, not modeled "
+        "in sdf");
   }
 
   {
@@ -1095,7 +1101,8 @@ TEST(URDFParser, WarningWhenIgnoringLinksWithSmallInertia)
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
     EXPECT_PRED2(not_contains, buffer.str(),
-        "urdf2sdf: link[link] has no inertia, not modeled in sdf");
+        "urdf2sdf: link[link] has a mass value of less than 1e-6, not modeled "
+        "in sdf");
   }
 
   // Revert cerr rdbug so as to not interfere with other tests


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/gazebosim/sdformat/issues/199 and https://github.com/gazebosim/sdformat/issues/1007.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

* Promote `sdfdbg` calls when ignoring urdf links with small masses or no inertia, to `sdfwarn`
* Make warnings more verbose, whether inertia was not defined, or mass was too small
* Added tests

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.