### PR TITLE
Add missing sdf files from xsd generation

### DIFF
--- a/sdf/1.10/CMakeLists.txt
+++ b/sdf/1.10/CMakeLists.txt
@@ -36,6 +36,7 @@ set (sdfs
   mesh_shape.sdf
   model.sdf
   model_state.sdf
+  navsat.sdf
   noise.sdf
   particle_emitter.sdf
   physics.sdf

--- a/sdf/1.5/CMakeLists.txt
+++ b/sdf/1.5/CMakeLists.txt
@@ -7,6 +7,7 @@ set (sdfs
   box_shape.sdf
   camera.sdf
   collision.sdf
+  collision_engine.sdf
   contact.sdf
   cylinder_shape.sdf
   frame.sdf
@@ -51,6 +52,7 @@ set (sdfs
   state.sdf
   surface.sdf
   transceiver.sdf
+  urdf.sdf
   visual.sdf
   world.sdf
 )

--- a/sdf/1.6/CMakeLists.txt
+++ b/sdf/1.6/CMakeLists.txt
@@ -9,6 +9,7 @@ set (sdfs
   box_shape.sdf
   camera.sdf
   collision.sdf
+  collision_engine.sdf
   contact.sdf
   cylinder_shape.sdf
   frame.sdf
@@ -55,6 +56,7 @@ set (sdfs
   state.sdf
   surface.sdf
   transceiver.sdf
+  urdf.sdf
   visual.sdf
   world.sdf
 )

--- a/sdf/1.7/CMakeLists.txt
+++ b/sdf/1.7/CMakeLists.txt
@@ -9,6 +9,7 @@ set (sdfs
   box_shape.sdf
   camera.sdf
   collision.sdf
+  collision_engine.sdf
   contact.sdf
   cylinder_shape.sdf
   frame.sdf
@@ -33,6 +34,7 @@ set (sdfs
   mesh_shape.sdf
   model.sdf
   model_state.sdf
+  navsat.sdf
   noise.sdf
   particle_emitter.sdf
   physics.sdf
@@ -55,6 +57,7 @@ set (sdfs
   state.sdf
   surface.sdf
   transceiver.sdf
+  urdf.sdf
   visual.sdf
   world.sdf
 )

--- a/sdf/1.8/CMakeLists.txt
+++ b/sdf/1.8/CMakeLists.txt
@@ -10,6 +10,7 @@ set (sdfs
   camera.sdf
   capsule_shape.sdf
   collision.sdf
+  collision_engine.sdf
   contact.sdf
   cylinder_shape.sdf
   ellipsoid_shape.sdf
@@ -35,6 +36,7 @@ set (sdfs
   mesh_shape.sdf
   model.sdf
   model_state.sdf
+  navsat.sdf
   noise.sdf
   particle_emitter.sdf
   physics.sdf
@@ -57,6 +59,7 @@ set (sdfs
   state.sdf
   surface.sdf
   transceiver.sdf
+  urdf.sdf
   visual.sdf
   world.sdf
 )

--- a/sdf/1.9/CMakeLists.txt
+++ b/sdf/1.9/CMakeLists.txt
@@ -10,6 +10,7 @@ set (sdfs
   camera.sdf
   capsule_shape.sdf
   collision.sdf
+  collision_engine.sdf
   contact.sdf
   cylinder_shape.sdf
   ellipsoid_shape.sdf
@@ -35,6 +36,7 @@ set (sdfs
   mesh_shape.sdf
   model.sdf
   model_state.sdf
+  navsat.sdf
   noise.sdf
   particle_emitter.sdf
   physics.sdf
@@ -57,6 +59,7 @@ set (sdfs
   state.sdf
   surface.sdf
   transceiver.sdf
+  urdf.sdf
   visual.sdf
   world.sdf
 )


### PR DESCRIPTION
These `.sdf` files were not being used as part of the schema generation process.  I have re-added them here.