### PR TITLE
URDF->SDF handle links with no inertia or small mass

### DIFF
--- a/include/sdf/ParserConfig.hh
+++ b/include/sdf/ParserConfig.hh
@@ -174,6 +174,13 @@ class SDFORMAT_VISIBLE ParserConfig
   /// \brief Get the preserveFixedJoint flag value.
   public: bool URDFPreserveFixedJoint() const;
 
+  /// @brief Set the convertLinkWithNoMassToFrame flag value.
+  public: void URDFSetConvertLinkWithNoMassToFrame(
+      bool _convertLinkWithNoMassToFrame);
+
+  /// @brief Get the convertLinkWithNoMassToFrame flag value.
+  public: bool URDFConvertLinkWithNoMassToFrame() const;
+
   /// \brief Private data pointer.
   IGN_UTILS_IMPL_PTR(dataPtr)
 };

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -50,6 +50,10 @@ class sdf::ParserConfig::Implementation
   /// reading the SDF/URDF file.
   public: bool preserveFixedJoint = false;
 
+  /// @brief Flag to convert of links with small (equal to or less than 1e-6) or
+  /// no mass in URDF to frames in SDF.
+  public: bool convertLinkWithNoMassToFrame = false;
+
   /// \brief Flag to use <include> tags within ToElement methods instead of
   /// the fully included model.
   public: bool toElementUseIncludeTag = true;
@@ -172,4 +176,17 @@ void ParserConfig::URDFSetPreserveFixedJoint(bool _preserveFixedJoint)
 bool ParserConfig::URDFPreserveFixedJoint() const
 {
   return this->dataPtr->preserveFixedJoint;
+}
+
+/////////////////////////////////////////////////
+void ParserConfig::URDFSetConvertLinkWithNoMassToFrame(
+  bool _convertLinkWithNoMassToFrame)
+{
+  this->dataPtr->convertLinkWithNoMassToFrame = _convertLinkWithNoMassToFrame;
+}
+
+/////////////////////////////////////////////////
+bool ParserConfig::URDFConvertLinkWithNoMassToFrame() const
+{
+  return this->dataPtr->convertLinkWithNoMassToFrame;
 }

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2675,47 +2675,48 @@ void CreateSDF(tinyxml2::XMLElement *_root,
   //  allow det(I) == zero, in the case of point mass geoms.
   // @todo:  keyword "world" should be a constant defined somewhere else
   if (_link->name != "world" &&
-      ((!_link->inertial) || gz::math::equal(_link->inertial->mass, 0.0)) &&
+      ((!_link->inertial) ||
+          gz::math::equal(_link->inertial->mass, 0.0, 1e-6)) &&
       !_parserConfig.URDFConvertLinkWithNoMassToFrame())
   {
     const std::string inertia_issue =
-        _link->inertial && gz::math::equal(_link->inertial->mass, 0.0) ?
+        _link->inertial && gz::math::equal(_link->inertial->mass, 0.0, 1e-6) ?
         "a mass value of less than or equal to 1e-6" :
         "no inertia defined";
 
     if (!_link->child_links.empty())
     {
       sdfwarn << "urdf2sdf: link[" << _link->name
-             << "] has "
-             << inertia_issue
-             << ", ["
-             << static_cast<int>(_link->child_links.size())
-             << "] children links ignored.\n";
+              << "] has "
+              << inertia_issue
+              << ", ["
+              << static_cast<int>(_link->child_links.size())
+              << "] children links ignored.\n";
     }
 
     if (!_link->child_joints.empty())
     {
       sdfwarn << "urdf2sdf: link[" << _link->name
-             << "] has "
-             << inertia_issue
-             << ", ["
-             << static_cast<int>(_link->child_links.size())
-             << "] children joints ignored.\n";
+              << "] has "
+              << inertia_issue
+              << ", ["
+              << static_cast<int>(_link->child_links.size())
+              << "] children joints ignored.\n";
     }
 
     if (_link->parent_joint)
     {
       sdfwarn << "urdf2sdf: link[" << _link->name
-             << "] has "
-             << inertia_issue
-             << ", parent joint [" << _link->parent_joint->name
-             << "] ignored.\n";
+              << "] has "
+              << inertia_issue
+              << ", parent joint [" << _link->parent_joint->name
+              << "] ignored.\n";
     }
 
     sdfwarn << "urdf2sdf: link[" << _link->name
-           << "] has "
-           << inertia_issue
-           << ", not modeled in sdf\n";
+            << "] has "
+            << inertia_issue
+            << ", not modeled in sdf\n";
     return;
   }
 
@@ -2725,9 +2726,19 @@ void CreateSDF(tinyxml2::XMLElement *_root,
       (!_link->parent_joint ||
        !FixedJointShouldBeReduced(_link->parent_joint)))
   {
-    if ((!_link->inertial) || gz::math::equal(_link->inertial->mass, 0.0) &&
+    if (((!_link->inertial) ||
+            gz::math::equal(_link->inertial->mass, 0.0, 1e-6)) &&
         _parserConfig.URDFConvertLinkWithNoMassToFrame())
     {
+      const std::string inertia_issue =
+          _link->inertial && gz::math::equal(_link->inertial->mass, 0.0, 1e-6) ?
+          "a mass value of less than or equal to 1e-6" :
+          "no inertia defined";
+      sdfwarn << "urdf2sdf: link[" << _link->name
+              << "] has "
+              << inertia_issue
+              << ", converting to a frame in sdf\n";
+
       CreateFrameFromLink(_root, _link, gz::math::Pose3d::Zero);
     }
     else

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2669,32 +2669,44 @@ void CreateSDF(tinyxml2::XMLElement *_root,
   if (_link->name != "world" &&
       ((!_link->inertial) || gz::math::equal(_link->inertial->mass, 0.0)))
   {
+    const std::string inertia_issue =
+        _link->inertial && gz::math::equal(_link->inertial->mass, 0.0) ?
+        "a mass value of less than or equal to 1e-6" :
+        "no inertia defined";
+
     if (!_link->child_links.empty())
     {
-      sdfdbg << "urdf2sdf: link[" << _link->name
-             << "] has no inertia, ["
+      sdfwarn << "urdf2sdf: link[" << _link->name
+             << "] has "
+             << inertia_issue
+             << ", ["
              << static_cast<int>(_link->child_links.size())
              << "] children links ignored.\n";
     }
 
     if (!_link->child_joints.empty())
     {
-      sdfdbg << "urdf2sdf: link[" << _link->name
-             << "] has no inertia, ["
+      sdfwarn << "urdf2sdf: link[" << _link->name
+             << "] has "
+             << inertia_issue
+             << ", ["
              << static_cast<int>(_link->child_links.size())
              << "] children joints ignored.\n";
     }
 
     if (_link->parent_joint)
     {
-      sdfdbg << "urdf2sdf: link[" << _link->name
-             << "] has no inertia, "
-             << "parent joint [" << _link->parent_joint->name
+      sdfwarn << "urdf2sdf: link[" << _link->name
+             << "] has "
+             << inertia_issue
+             << ", parent joint [" << _link->parent_joint->name
              << "] ignored.\n";
     }
 
-    sdfdbg << "urdf2sdf: link[" << _link->name
-           << "] has no inertia, not modeled in sdf\n";
+    sdfwarn << "urdf2sdf: link[" << _link->name
+           << "] has "
+           << inertia_issue
+           << ", not modeled in sdf\n";
     return;
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/gazebosim/sdformat/issues/199, and https://github.com/gazebosim/sdformat/issues/1007.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

* Adds a flag to `ParserConfig`, to convert URDF links with no inertia defined or with masses smaller than 1e-6, to frames
* Promotes `sdfdbg` to `sdfwarn` for when links with no inertia or small mass are ignored, and their child joints and links
* Added more tests

# Possible points of discussions
* Should we rename the converted frames to something more descriptive, for example `frame_from_LINKNAME`? This might make it less searchable though
* To ensure backward compatibility, is changing `sdfdbg` to `sdfwarn` a bad idea? I've not encountered regressions so far

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.