### PR TITLE
Fix camera_info_topic default value

### DIFF
--- a/sdf/1.8/camera.sdf
+++ b/sdf/1.8/camera.sdf
@@ -5,7 +5,7 @@
     <description>An optional name for the camera.</description>
   </attribute>
 
-  <element name="camera_info_topic" type="string" default="camera_info" required="0">
+  <element name="camera_info_topic" type="string" default="__default__" required="0">
     <description>Name of the camera info</description>
   </element> <!-- End camera Info topic -->
 

--- a/sdf/1.9/camera.sdf
+++ b/sdf/1.9/camera.sdf
@@ -5,7 +5,7 @@
     <description>An optional name for the camera.</description>
   </attribute>
 
-  <element name="camera_info_topic" type="string" default="camera_info" required="0">
+  <element name="camera_info_topic" type="string" default="__default__" required="0">
     <description>Name of the camera info</description>
   </element> <!-- End camera Info topic -->
 


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

The `<camera_info_topic>` default value was set to [`__default__`](https://github.com/gazebosim/sdformat/blob/sdf12/sdf/1.7/camera.sdf#L8) in sdf 1.7 in https://github.com/gazebosim/sdformat/pull/1201. However, these changes were not forward ported to sdf 1.8, 1.9. Ran into this bug as it caused a test failure in gz-sensors6 when I tried to forward port gz-sensors3 to 6 in https://github.com/gazebosim/gz-sensors/pull/327.

I believe `__default__` should be the correct value since the code specifically looks for this string: https://github.com/gazebosim/sdformat/blob/sdf12/src/Camera.cc#L263



## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
