### PR TITLE
Prepare for 12.7.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat12 VERSION 12.7.0)
+project (sdformat12 VERSION 12.7.1)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## libsdformat 12.X
 
+### libsdformat 12.7.1 (2023-02-28)
+
+1. Fix camera info topic default value
+    * [Pull request #1241](https://github.com/gazebosim/sdformat/pull/1241)
+
 ### libsdformat 12.7.0 (2023-02-03)
 
 1. Forward port libsdformat9.10.0. This includes the ign to gz headers.
@@ -10,7 +15,7 @@
 1. Infrastructure
   1. CI workflow: use checkout v3.
       * [Pull request #1225](https://github.com/gazebosim/sdformat/pull/1225)
-  
+
   1. macos workflow: don't upgrade existing packages.
       * [Pull request #1217](https://github.com/gazebosim/sdformat/pull/1217)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 12.7.1 release.

Comparison to 12.7.0: https://github.com/gazebosim/sdformat/compare/sdformat12_12.7.0...prep_12.7.1

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sensors/pull/327

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
