### PR TITLE
Prepare for 13.4.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.3.0)
+project (sdformat13 VERSION 13.4.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,28 @@
 ## libsdformat 13.X
 
+### libsdformat 13.4.0 (2023-03-03)
+
+1. Fix camera info topic default value
+    * [Pull request #1241](https://github.com/gazebosim/sdformat/pull/1241)
+
+1. Add support for merge-includes in worlds
+    * [Pull request #1233](https://github.com/gazebosim/sdformat/pull/1233)
+
+1. Backport the python3 embedSdf script variant
+    * [Pull request #1240](https://github.com/gazebosim/sdformat/pull/1240)
+
+1. Go back to SDF_ASSERT instead of FATAL_ERROR
+    * [Pull request #1235](https://github.com/gazebosim/sdformat/pull/1235)
+
+1. Add missing sdf files from xsd generation
+    * [Pull request #1231](https://github.com/gazebosim/sdformat/pull/1231)
+
+1. CI workflow: use checkout v3
+    * [Pull request #1225](https://github.com/gazebosim/sdformat/pull/1225)
+
+1. Use `File.exist?` for Ruby 3.2 compatibility
+    * [Pull request #1216](https://github.com/gazebosim/sdformat/pull/1216)
+
 ### libsdformat 13.3.0 (2023-02-07)
 
 1. Add airspeed sensor


### PR DESCRIPTION
<!--

<!-- For maintainers only -->

# 🎈 Release

Preparation for 13.4.0 release.

Comparison to 13.3.0: https://github.com/gazebosim/sdformat/compare/sdformat13_13.3.0...prep_13.4.0

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sensors/pull/331

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

