### PR TITLE
Fix camera_info_topic default value in sdf 1.10

### DIFF
--- a/sdf/1.10/camera.sdf
+++ b/sdf/1.10/camera.sdf
@@ -9,7 +9,7 @@
     <description>If the camera will be triggered by a topic</description>
   </element> <!-- End Triggered -->
 
-  <element name="camera_info_topic" type="string" default="camera_info" required="0">
+  <element name="camera_info_topic" type="string" default="__default__" required="0">
     <description>Name of the camera info</description>
   </element> <!-- End Trigger_Topic -->
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix


## Summary

Applies the same fix done in https://github.com/gazebosim/sdformat/pull/1241 to sdf 1.10

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
