### PR TITLE
Prepare for 13.4.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.4.0)
+project (sdformat13 VERSION 13.4.1)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## libsdformat 13.X
 
+### libsdformat 13.4.1 (2023-03-08)
+
+1. Fix camera_info_topic default value
+    * [Pull request #1247](https://github.com/gazebosim/sdformat/pull/1247)
+
+1. CI workflow: use checkout v3
+    * [Pull request #1245](https://github.com/gazebosim/sdformat/pull/1245)
+
 ### libsdformat 13.4.0 (2023-03-03)
 
 1. Fix camera info topic default value


### PR DESCRIPTION
<!-- For maintainers only -->

# 🎈 Release

Preparation for 13.4.1 release.

Comparison to 13.4.0: https://github.com/gazebosim/sdformat/compare/sdformat13_13.4.0...prep_13.4.1

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sensors/pull/331

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
