### PR TITLE
Use sdf::testing::contains instead of local contains functions

### DIFF
--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -28,6 +28,7 @@
 #include "sdf/SDFImpl.hh"
 #include "sdf/sdf_config.h"
 #include "test_config.h"
+#include "test_utils.hh"
 
 #ifdef _WIN32
   #define popen  _popen
@@ -950,12 +951,6 @@ TEST(print, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   }
 }
 
-//////////////////////////////////////////////////
-static bool contains(const std::string &_a, const std::string &_b)
-{
-  return _a.find(_b) != std::string::npos;
-}
-
 /////////////////////////////////////////////////
 TEST(print_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 {
@@ -966,14 +961,14 @@ TEST(print_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true'>1 2 3   30.009 44.991 -60.009</pose>");
 
   // Printing with in_degrees
   output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -982,7 +977,7 @@ TEST(print_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -991,7 +986,7 @@ TEST(print_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 2 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 44.991 -60</pose>");
 
@@ -1000,7 +995,7 @@ TEST(print_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 20 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60</pose>");
 
@@ -1009,7 +1004,7 @@ TEST(print_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.008 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1018,7 +1013,7 @@ TEST(print_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.01 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1033,14 +1028,14 @@ TEST(print_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose>1 2 3 0.523756 0.785241 -1.04735</pose>");
 
   // Printing with in_degrees
   output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.0087</pose>");
 
@@ -1049,7 +1044,7 @@ TEST(print_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1058,7 +1053,7 @@ TEST(print_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 2 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 44.991 -60</pose>");
 
@@ -1067,7 +1062,7 @@ TEST(print_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 20 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60</pose>");
 
@@ -1076,7 +1071,7 @@ TEST(print_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.008 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.0087</pose>");
 
@@ -1085,7 +1080,7 @@ TEST(print_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.01 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1100,7 +1095,7 @@ TEST(print_rotations_in_quaternions, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose rotation_format='quat_xyzw'>"
                "1 2 3   0.391948 0.200425 -0.532046 0.723279</pose>");
 
@@ -1108,7 +1103,7 @@ TEST(print_rotations_in_quaternions, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1117,7 +1112,7 @@ TEST(print_rotations_in_quaternions, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1126,7 +1121,7 @@ TEST(print_rotations_in_quaternions, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 2 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 44.991 -60</pose>");
 
@@ -1135,7 +1130,7 @@ TEST(print_rotations_in_quaternions, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 20 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60</pose>");
 
@@ -1144,7 +1139,7 @@ TEST(print_rotations_in_quaternions, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.008 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1153,7 +1148,7 @@ TEST(print_rotations_in_quaternions, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.01 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1171,14 +1166,14 @@ TEST(print_includes_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true'>1 2 3   30.009 44.991 -60.009</pose>");
 
   // Printing with in_degrees
   output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1187,7 +1182,7 @@ TEST(print_includes_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1196,7 +1191,7 @@ TEST(print_includes_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 2 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 44.991 -60</pose>");
 
@@ -1205,7 +1200,7 @@ TEST(print_includes_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 20 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60</pose>");
 
@@ -1214,7 +1209,7 @@ TEST(print_includes_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.008 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1223,7 +1218,7 @@ TEST(print_includes_rotations_in_degrees, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.01 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1241,14 +1236,14 @@ TEST(print_includes_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose>1 2 3 0.523756 0.785241 -1.04735</pose>");
 
   // Printing with in_degrees
   output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.0087</pose>");
 
@@ -1257,7 +1252,7 @@ TEST(print_includes_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1266,7 +1261,7 @@ TEST(print_includes_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 2 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 44.991 -60</pose>");
 
@@ -1275,7 +1270,7 @@ TEST(print_includes_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 20 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60</pose>");
 
@@ -1284,7 +1279,7 @@ TEST(print_includes_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.008 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.0087</pose>");
 
@@ -1293,7 +1288,7 @@ TEST(print_includes_rotations_in_radians, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.01 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1312,7 +1307,7 @@ TEST(print_includes_rotations_in_quaternions,
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose rotation_format='quat_xyzw'>"
                "1 2 3   0.391948 0.200425 -0.532046 0.723279</pose>");
 
@@ -1320,7 +1315,7 @@ TEST(print_includes_rotations_in_quaternions,
   output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1329,7 +1324,7 @@ TEST(print_includes_rotations_in_quaternions,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1338,7 +1333,7 @@ TEST(print_includes_rotations_in_quaternions,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 2 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 44.991 -60</pose>");
 
@@ -1347,7 +1342,7 @@ TEST(print_includes_rotations_in_quaternions,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 20 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60</pose>");
 
@@ -1356,7 +1351,7 @@ TEST(print_includes_rotations_in_quaternions,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.008 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1365,7 +1360,7 @@ TEST(print_includes_rotations_in_quaternions,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.01 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1384,14 +1379,14 @@ TEST(print_rotations_in_unnormalized_degrees,
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true'>1 2 3   30.009 44.991 -60.009</pose>");
 
   // Printing with in_degrees
   output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1400,7 +1395,7 @@ TEST(print_rotations_in_unnormalized_degrees,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1409,7 +1404,7 @@ TEST(print_rotations_in_unnormalized_degrees,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 2 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 44.991 -60</pose>");
 
@@ -1418,7 +1413,7 @@ TEST(print_rotations_in_unnormalized_degrees,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 20 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60</pose>");
 
@@ -1427,7 +1422,7 @@ TEST(print_rotations_in_unnormalized_degrees,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.008 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.991 -60.009</pose>");
 
@@ -1436,7 +1431,7 @@ TEST(print_rotations_in_unnormalized_degrees,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.01 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1452,14 +1447,14 @@ TEST(print_rotations_in_unnormalized_radians,
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose>1 2 3 -5.75943 -11.78112 5.23583</pose>");
 
   // Printing with in_degrees
   output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.9915 -60.009</pose>");
 
@@ -1468,7 +1463,7 @@ TEST(print_rotations_in_unnormalized_radians,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1477,7 +1472,7 @@ TEST(print_rotations_in_unnormalized_radians,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 2 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 44.9915 -60</pose>");
 
@@ -1486,7 +1481,7 @@ TEST(print_rotations_in_unnormalized_radians,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 20 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.9915 -60</pose>");
 
@@ -1495,7 +1490,7 @@ TEST(print_rotations_in_unnormalized_radians,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.008 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.9915 -60.009</pose>");
 
@@ -1504,7 +1499,7 @@ TEST(print_rotations_in_unnormalized_radians,
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       "--snap-tolerance 0.01 " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1519,7 +1514,7 @@ TEST(shuffled_cmd_flags, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   std::string output = custom_exec_str(
       IgnCommand() + " sdf -p " + path + " --degrees " + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.9915 -60.009</pose>");
 
@@ -1527,7 +1522,7 @@ TEST(shuffled_cmd_flags, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   output = custom_exec_str(
       IgnCommand() + " sdf --degrees -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30.009 44.9915 -60.009</pose>");
 
@@ -1536,7 +1531,7 @@ TEST(shuffled_cmd_flags, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
       IgnCommand() + " sdf -p " + path + " --snap-to-degrees 5 " +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1544,7 +1539,7 @@ TEST(shuffled_cmd_flags, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   output = custom_exec_str(
       IgnCommand() + " sdf -p --snap-to-degrees 5 " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 
@@ -1552,7 +1547,7 @@ TEST(shuffled_cmd_flags, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   output = custom_exec_str(
       IgnCommand() + " sdf --snap-to-degrees 5 -p " + path + SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 45 -60</pose>");
 }
@@ -1570,7 +1565,7 @@ TEST(print_snap_to_degrees_tolerance_too_high,
       " --snap-to-degrees 5 " + " --snap-tolerance 4" +
       SdfVersion());
   ASSERT_FALSE(output.empty());
-  EXPECT_PRED2(contains, output,
+  EXPECT_PRED2(sdf::testing::contains, output,
                "<pose degrees='true' rotation_format='euler_rpy'>"
                "1 2 3   30 50 60</pose>");
 }

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -24,6 +24,7 @@
 #include "sdf/Console.hh"
 #include "sdf/Filesystem.hh"
 #include "test_config.h"
+#include "test_utils.hh"
 
 /////////////////////////////////////////////////
 TEST(Parser, initStringTrim)
@@ -278,13 +279,6 @@ TEST(Parser, NameUniqueness)
 }
 
 /////////////////////////////////////////////////
-/// Check that _a contains _b
-static bool contains(const std::string &_a, const std::string &_b)
-{
-  return _a.find(_b) != std::string::npos;
-}
-
-/////////////////////////////////////////////////
 TEST(Parser, SyntaxErrorInValues)
 {
   // Capture sdferr output
@@ -301,10 +295,11 @@ TEST(Parser, SyntaxErrorInValues)
     sdf::init(sdf);
 
     sdf::readFile(path, sdf);
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Unable to set value [bad 0 0 0 0 0] for key [pose]");
-    EXPECT_PRED2(contains, buffer.str(), "bad_syntax_pose.sdf:L5");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "bad_syntax_pose.sdf:L5");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/model[@name=\"robot1\"]/pose:");
   }
   {
@@ -315,10 +310,11 @@ TEST(Parser, SyntaxErrorInValues)
     sdf::init(sdf);
 
     sdf::readFile(path, sdf);
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Unable to set value [bad ] for key[linear]");
-    EXPECT_PRED2(contains, buffer.str(), "bad_syntax_double.sdf:L7");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "bad_syntax_double.sdf:L7");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/model[@name=\"robot1\"]/"
                  "link[@name=\"link\"]/velocity_decay/linear:");
   }
@@ -330,10 +326,11 @@ TEST(Parser, SyntaxErrorInValues)
     sdf::init(sdf);
 
     sdf::readFile(path, sdf);
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Unable to set value [0 1 bad ] for key[gravity]");
-    EXPECT_PRED2(contains, buffer.str(), "bad_syntax_vector.sdf:L4");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "bad_syntax_vector.sdf:L4");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/gravity:");
   }
 
@@ -363,15 +360,15 @@ TEST(Parser, MissingRequiredAttributesErrors)
     sdf::init(sdf);
 
     sdf::readFile(path, sdf);
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Error Code " +
                  std::to_string(
                     static_cast<int>(sdf::ErrorCode::ATTRIBUTE_MISSING)));
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Required attribute[name] in element[link] is not specified "
                  "in SDF.");
-    EXPECT_PRED2(contains, buffer.str(), "box_bad_test.world:L6");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(), "box_bad_test.world:L6");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/model[@name=\"box\"]/link:");
   }
 
@@ -401,14 +398,15 @@ TEST(Parser, IncludesErrors)
     sdf::init(sdf);
 
     sdf::readFile(path, sdf);
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Error Code " +
                  std::to_string(
                     static_cast<int>(sdf::ErrorCode::ATTRIBUTE_MISSING)));
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "<include> element missing 'uri' attribute");
-    EXPECT_PRED2(contains, buffer.str(), "includes_missing_uri.sdf:L5");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "includes_missing_uri.sdf:L5");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/include[0]:");
   }
   {
@@ -421,14 +419,15 @@ TEST(Parser, IncludesErrors)
     sdf::init(sdf);
 
     sdf::readFile(path, sdf);
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Error Code " +
                  std::to_string(
                     static_cast<int>(sdf::ErrorCode::URI_LOOKUP)));
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Unable to find uri[missing_model]");
-    EXPECT_PRED2(contains, buffer.str(), "includes_missing_model.sdf:L6");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "includes_missing_model.sdf:L6");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
   {
@@ -446,15 +445,16 @@ TEST(Parser, IncludesErrors)
     sdf::init(sdf);
 
     sdf::readFile(path, sdf);
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Error Code " +
                  std::to_string(static_cast<int>(sdf::ErrorCode::URI_LOOKUP)));
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Unable to resolve uri[box_missing_config]");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "since it does not contain a model.config");
-    EXPECT_PRED2(contains, buffer.str(), "includes_model_without_sdf.sdf:L6");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "includes_model_without_sdf.sdf:L6");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
   {
@@ -472,15 +472,16 @@ TEST(Parser, IncludesErrors)
     sdf::init(sdf);
 
     sdf::readFile(path, sdf);
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Error Code " +
                  std::to_string(
                     static_cast<int>(sdf::ErrorCode::ELEMENT_MISSING)));
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "Failed to find top level <model> / <actor> / <light> for "
                  "<include>\n");
-    EXPECT_PRED2(contains, buffer.str(), "includes_without_top_level.sdf:L6");
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "includes_without_top_level.sdf:L6");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
                  "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
 

--- a/test/integration/deprecated_specs.cc
+++ b/test/integration/deprecated_specs.cc
@@ -61,11 +61,6 @@ TEST(DeprecatedElements, CanEmitErrors)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_DEPRECATED, errors[0].Code());
 }
 
-bool contains(const std::string &_a, const std::string &_b)
-{
-  return _a.find(_b) != std::string::npos;
-}
-
 ////////////////////////////////////////////////////
 TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
 {
@@ -98,7 +93,8 @@ TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
     EXPECT_TRUE(sdf::readString(
           "<sdf version='1.8'><testElem/></sdf>", config, sdf, errors));
     EXPECT_TRUE(errors.empty());
-    EXPECT_PRED2(contains, buffer.str(), "SDF Element[testElem] is deprecated");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "SDF Element[testElem] is deprecated");
   }
   // Flip the order of calling SetDeprecatedElementsPolicy and
   // SetWarningsPolicy.
@@ -112,7 +108,8 @@ TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
     EXPECT_TRUE(sdf::readString(
           "<sdf version='1.8'><testElem/></sdf>", config, sdf, errors));
     EXPECT_TRUE(errors.empty());
-    EXPECT_PRED2(contains, buffer.str(), "SDF Element[testElem] is deprecated");
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
+                 "SDF Element[testElem] is deprecated");
   }
   // Test ResetDeprecatedElementsPolicy
   {

--- a/test/integration/pose_1_9_sdf.cc
+++ b/test/integration/pose_1_9_sdf.cc
@@ -207,12 +207,6 @@ TEST(Pose1_9, PoseStringOutput)
 }
 
 //////////////////////////////////////////////////
-static bool contains(const std::string &_a, const std::string &_b)
-{
-  return _a.find(_b) != std::string::npos;
-}
-
-//////////////////////////////////////////////////
 TEST(Pose1_9, BadModelPoses)
 {
   // Redirect sdferr output
@@ -246,7 +240,7 @@ TEST(Pose1_9, BadModelPoses)
     EXPECT_FALSE(sdf::readString(stream.str(), sdfParsed, errors));
     EXPECT_FALSE(errors.empty());
 
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
         "Undefined attribute //pose[@rotation_format='bad_rotation_format']");
   }
 
@@ -269,7 +263,7 @@ TEST(Pose1_9, BadModelPoses)
     EXPECT_FALSE(sdf::readString(stream.str(), sdfParsed, errors));
     EXPECT_FALSE(errors.empty());
 
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
         "//pose[@rotation_format='euler_rpy'] must have 6 values, "
         "but 3 were found");
   }
@@ -293,7 +287,7 @@ TEST(Pose1_9, BadModelPoses)
     EXPECT_FALSE(sdf::readString(stream.str(), sdfParsed, errors));
     EXPECT_FALSE(errors.empty());
 
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
         "//pose[@rotation_format='quat_xyzw'] must have 7 values, "
         "but 4 were found");
   }
@@ -317,7 +311,7 @@ TEST(Pose1_9, BadModelPoses)
     EXPECT_FALSE(sdf::readString(stream.str(), sdfParsed, errors));
     EXPECT_FALSE(errors.empty());
 
-    EXPECT_PRED2(contains, buffer.str(),
+    EXPECT_PRED2(sdf::testing::contains, buffer.str(),
         "//pose[@degrees='true'] does not apply when parsing quaternions");
   }
 }
@@ -352,7 +346,7 @@ TEST(Pose1_9, PoseSet8ValuesFail)
   ASSERT_NE(nullptr, poseValueParam);
   EXPECT_FALSE(poseValueParam->SetFromString(
       "1 2 3   0.7071068 0.7071068 0 0   0"));
-  EXPECT_PRED2(contains, buffer.str(),
+  EXPECT_PRED2(sdf::testing::contains, buffer.str(),
       "The value for //pose[@rotation_format='quat_xyzw'] must have 7 values, "
       "but more than that were found in '1 2 3   0.7071068 0.7071068 0 0   0'");
 }
@@ -765,7 +759,7 @@ TEST(Pose1_9, ToStringWithoutAttrib)
   EXPECT_TRUE(poseValueParam->SetFromString("1 2 3  0.4 0.5 0.6"));
 
   std::string elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.4 0.5 0.6");
 }
 
 //////////////////////////////////////////////////
@@ -787,8 +781,8 @@ TEST(Pose1_9, ToStringWithDegreesFalse)
   EXPECT_TRUE(poseValueParam->SetFromString("1 2 3  0.4 0.5 0.6"));
 
   std::string elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "degrees='false'");
-  EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "degrees='false'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.4 0.5 0.6");
 }
 
 //////////////////////////////////////////////////
@@ -810,8 +804,8 @@ TEST(Pose1_9, ToStringWithDegreesTrue)
   EXPECT_TRUE(poseValueParam->SetFromString("1 2 3  0.4 0.5 0.6"));
 
   std::string elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "degrees='true'");
-  EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "degrees='true'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.4 0.5 0.6");
 }
 
 //////////////////////////////////////////////////
@@ -834,8 +828,8 @@ TEST(Pose1_9, ToStringWithEulerRPY)
   EXPECT_TRUE(poseValueParam->SetFromString("1 2 3  0.4 0.5 0.6"));
 
   std::string elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "rotation_format='euler_rpy'");
-  EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "rotation_format='euler_rpy'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.4 0.5 0.6");
 }
 
 //////////////////////////////////////////////////
@@ -862,9 +856,9 @@ TEST(Pose1_9, ToStringWithEulerRPYDegreesTrue)
   EXPECT_TRUE(poseValueParam->SetFromString("1 2 3  0.4 0.5 0.6"));
 
   std::string elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "degrees='true'");
-  EXPECT_PRED2(contains, elemStr, "rotation_format='euler_rpy'");
-  EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "degrees='true'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "rotation_format='euler_rpy'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.4 0.5 0.6");
 }
 
 //////////////////////////////////////////////////
@@ -889,8 +883,8 @@ TEST(Pose1_9, ToStringWithQuatXYZ)
   // The string output has changed as it was parsed from the value, instead of
   // the original string.
   std::string elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "rotation_format='quat_xyzw'");
-  EXPECT_PRED2(contains, elemStr, "0.707107 0 0 0.707107");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "rotation_format='quat_xyzw'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.707107 0 0 0.707107");
 }
 
 //////////////////////////////////////////////////
@@ -919,9 +913,9 @@ TEST(Pose1_9, ToStringWithQuatXYZWDegreesFalse)
   // The string output has changed as it was parsed from the value, instead of
   // the original string.
   std::string elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "degrees='false'");
-  EXPECT_PRED2(contains, elemStr, "rotation_format='quat_xyzw'");
-  EXPECT_PRED2(contains, elemStr, "0.707107 0 0 0.707107");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "degrees='false'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "rotation_format='quat_xyzw'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.707107 0 0 0.707107");
 }
 
 //////////////////////////////////////////////////
@@ -940,7 +934,7 @@ TEST(Pose1_9, ToStringAfterChangingDegreeAttribute)
   ASSERT_TRUE(valParam->SetFromString("1 2 3 0.4 0.5 0.6"));
 
   std::string elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.4 0.5 0.6");
 
   // Changing to attribute to degrees, however this does not modify the
   // value of the underlying Param. Reparse needs to be called, which uses
@@ -951,14 +945,14 @@ TEST(Pose1_9, ToStringAfterChangingDegreeAttribute)
   EXPECT_TRUE(valParam->Reparse());
 
   elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "degrees='true'");
-  EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "degrees='true'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.4 0.5 0.6");
 
   // Changing back to radians
   ASSERT_TRUE(degreesAttrib->Set<bool>(false));
   elemStr = poseElem->ToString("");
-  EXPECT_PRED2(contains, elemStr, "degrees='false'");
-  EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "degrees='false'");
+  EXPECT_PRED2(sdf::testing::contains, elemStr, "0.4 0.5 0.6");
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/gazebosim/sdformat/pull/1238 where `sdf::testing::contains` and `sdf::testing::notContains` was added to `test_utils.hh`.

## Summary

* Replace all local declarations and use of `bool contains(...)` in tests with `sdf::testing::contains`

## Test it

```bash
colcon build --merge-install --packages-up-to sdformat12
colcon test --merge-install --packages-select sdformat12
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers