### PR TITLE
Fix Element Set method return value

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -653,8 +653,7 @@ namespace sdf
   {
     if (this->dataPtr->value)
     {
-      this->dataPtr->value->Set(_value);
-      return true;
+      return this->dataPtr->value->Set(_value);
     }
     return false;
   }

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -727,6 +727,9 @@ TEST(Element, Set)
   elem.AddValue("string", "val", false, "val description");
 
   ASSERT_TRUE(elem.Set<std::string>("hello"));
+
+  elem.AddValue("int", "0", true, "value");
+  ASSERT_FALSE(elem.Set<std::string>(""));
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Discovered [here](https://github.com/gazebosim/sdformat/pull/1141#discussion_r1140648979), the Element Set method would `return true` ignoring the result coming from the `this->dataPtr->value->Set(_value);`. This could cause the Set method to sometimes error but still return `true`.

 This PR fixes it and it makes the method return the result of `this->dataPtr->value->Set(_value);` instead of the hardcoded `true`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages. 