### PR TITLE
Use relative path in an urdf include to avoid confusion between internal and system headers

### DIFF
--- a/src/urdf/urdf_parser/check_urdf.cpp
+++ b/src/urdf/urdf_parser/check_urdf.cpp
@@ -35,7 +35,7 @@
 /* Author: Wim Meeussen */
 #pragma warning(push, 0)
 
-#include "urdf_parser/urdf_parser.h"
+#include "../urdf_parser/urdf_parser.h"
 #include <iostream>
 #include <fstream>
 

--- a/src/urdf/urdf_parser/joint.cpp
+++ b/src/urdf/urdf_parser/joint.cpp
@@ -41,7 +41,7 @@
 #include <urdf_model/joint.h>
 // #include <console_bridge/console.h>
 #include <tinyxml2.h>
-#include <urdf_parser/urdf_parser.h>
+#include "../urdf_parser/urdf_parser.h"
 
 namespace urdf{
 

--- a/src/urdf/urdf_parser/link.cpp
+++ b/src/urdf/urdf_parser/link.cpp
@@ -35,7 +35,7 @@
 /* Author: Wim Meeussen */
 #pragma warning(push, 0)
 
-#include <urdf_parser/urdf_parser.h>
+#include "../urdf_parser/urdf_parser.h"
 #include <urdf_model/link.h>
 #include <fstream>
 #include <sstream>

--- a/src/urdf/urdf_parser/model.cpp
+++ b/src/urdf/urdf_parser/model.cpp
@@ -36,6 +36,10 @@
 #pragma warning(push, 0)
 
 #include <vector>
+// Use relative path to avoid confusion with urdf system headers (if present).
+// The change to the relative path is only required to be present in this
+// file given how MSVC include headers. See:
+// https://github.com/gazebosim/sdformat/pull/1259/files#r1149821498
 #include "../urdf_parser/urdf_parser.h"
 // #include <console_bridge/console.h>
 #include <fstream>

--- a/src/urdf/urdf_parser/model.cpp
+++ b/src/urdf/urdf_parser/model.cpp
@@ -36,7 +36,7 @@
 #pragma warning(push, 0)
 
 #include <vector>
-#include "urdf_parser/urdf_parser.h"
+#include "../urdf_parser/urdf_parser.h"
 // #include <console_bridge/console.h>
 #include <fstream>
 

--- a/src/urdf/urdf_parser/pose.cpp
+++ b/src/urdf/urdf_parser/pose.cpp
@@ -41,7 +41,7 @@
 #include <algorithm>
 // #include <console_bridge/console.h>
 #include <tinyxml2.h>
-#include <urdf_parser/urdf_parser.h>
+#include "../urdf_parser/urdf_parser.h"
 
 namespace urdf_export_helpers {
 

--- a/src/urdf/urdf_parser/urdf_to_graphiz.cpp
+++ b/src/urdf/urdf_parser/urdf_to_graphiz.cpp
@@ -35,7 +35,7 @@
 /* Author: Wim Meeussen */
 #pragma warning(push, 0)
 
-#include "urdf_parser/urdf_parser.h"
+#include "../urdf_parser/urdf_parser.h"
 #include <iostream>
 #include <fstream>
 

--- a/src/urdf/urdf_parser/world.cpp
+++ b/src/urdf/urdf_parser/world.cpp
@@ -37,7 +37,7 @@
 
 #include <urdf_world/world.h>
 #include <urdf_model/model.h>
-#include <urdf_parser/urdf_parser.h>
+#include "../urdf_parser/urdf_parser.h"
 #include <fstream>
 #include <sstream>
 #include <algorithm>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

I found the following situation when doing some changes in the Windows CI:
 * urdfdom was installed via vcpkg
 * The compilation of sdformat is using **the internal copy of urdfdom** since the find module for URDFDom in gz-cmake can not find the Windows vcpkg installation.
 *  The colcon build invocation uses the vcpkg toolchain.cmake file which injects the vcpkg paths.

With this scenario the [following build problem appeared:](https://build.osrfoundation.org/job/_test_ign_gazebo-ign-6-win/6/consoleFull#console-section-34)
```bash
  model.cpp

C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\sdformat\src\urdf\urdf_parser\model.cpp(45,40): error C2653: 'tinyxml2': is not a class or namespace name [C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\build\sdformat12\src\sdformat12.vcxproj]

C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\sdformat\src\urdf\urdf_parser\model.cpp(45,50): error C2061: syntax error: identifier 'XMLElement' [C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\build\sdformat12\src\sdformat12.vcxproj]

C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\sdformat\src\urdf\urdf_parser\model.cpp(46,28): error C2653: 'tinyxml2': is not a class or namespace name [C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\build\sdformat12\src\sdformat12.vcxproj]
...

C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\sdformat\src\urdf\urdf_parser\model.cpp(230,1): error C2556: 'int *urdf::exportURDF(const urdf::ModelInterface &)': overloaded function differs only by return type from 'TiXmlDocument *urdf::exportURDF(const urdf::ModelInterface &)' [C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\build\sdformat12\src\sdformat12.vcxproj]

C:\vcpkg\installed\x64-windows\include\urdf_parser/urdf_parser.h(145): message : see declaration of 'urdf::exportURDF' [C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\build\sdformat12\src\sdformat12.vcxproj]

C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\sdformat\src\urdf\urdf_parser\model.cpp(229,25): error C2371: 'urdf::exportURDF': redefinition; different basic types [C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\build\sdformat12\src\sdformat12.vcxproj]

C:\vcpkg\installed\x64-windows\include\urdf_parser/urdf_parser.h(145): message : see declaration of 'urdf::exportURDF' [C:\J\workspace\_test_ign_gazebo-ign-6-win\ws\build\sdformat12\src\sdformat12.vcxproj]
```

The compilation is mixing the headers from the vcpkg installation of urdfdom (tinyxml) with the headers of the internal copy (tinyxml2). The buildsystem defines an include on the internal header directory but the somehow the build system was including the toolchain file configurations before.

The cleaner solution I found was to modify the first include to make MSVC lo look for the headers file in the right directory instead. Since sdformat is not installing this files, we should not be affecting the final user experience at all.


## Checklist
- [x] Signed all commits for DCO
