### PR TITLE
Add missing values in Surace ToElement method

### DIFF
--- a/src/Surface.cc
+++ b/src/Surface.cc
@@ -399,5 +399,13 @@ sdf::ElementPtr Surface::ToElement() const
   contactElem->GetElement("collide_bitmask")->Set(
       this->dataPtr->contact.CollideBitmask());
 
+  sdf::ElementPtr frictionElem = elem->GetElement("friction");
+  sdf::ElementPtr ode = frictionElem->GetElement("ode");
+  ode->GetElement("mu")->Set(this->dataPtr->friction.ODE()->Mu());
+  ode->GetElement("mu2")->Set(this->dataPtr->friction.ODE()->Mu2());
+  ode->GetElement("slip1")->Set(this->dataPtr->friction.ODE()->Slip1());
+  ode->GetElement("slip2")->Set(this->dataPtr->friction.ODE()->Slip2());
+  ode->GetElement("fdir1")->Set(this->dataPtr->friction.ODE()->Fdir1());
+
   return elem;
 }

--- a/src/Surface_TEST.cc
+++ b/src/Surface_TEST.cc
@@ -429,3 +429,36 @@ TEST(DOMode, Set)
   EXPECT_EQ(ode1.Fdir1(),
             gz::math::Vector3d(1, 2, 3));
 }
+
+/////////////////////////////////////////////////
+TEST(DOMsurface, ToElement)
+{
+  sdf::Surface surface1;
+  sdf::Contact contact;
+  sdf::ODE ode;
+  ode.SetMu(0.1);
+  ode.SetMu2(0.2);
+  ode.SetSlip1(3);
+  ode.SetSlip2(4);
+  ode.SetFdir1(gz::math::Vector3d(1, 2, 3));
+  sdf::Friction friction;
+  friction.SetODE(ode);
+  contact.SetCollideBitmask(0x12);
+  surface1.SetContact(contact);
+  surface1.SetFriction(friction);
+
+  sdf::ElementPtr elem = surface1.ToElement();
+  ASSERT_NE(nullptr, elem);
+
+  sdf::Surface surface2;
+  surface2.Load(elem);
+
+  EXPECT_EQ(surface2.Contact()->CollideBitmask(), 0x12);
+  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Mu(), 0.1);
+  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Mu2(), 0.2);
+  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Slip1(), 3);
+  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Slip2(), 4);
+  EXPECT_EQ(surface2.Friction()->ODE()->Fdir1(),
+            gz::math::Vector3d(1, 2, 3));
+
+}

--- a/src/Surface_TEST.cc
+++ b/src/Surface_TEST.cc
@@ -137,6 +137,39 @@ TEST(DOMsurface, CopyAssignmentAfterMove)
 }
 
 /////////////////////////////////////////////////
+TEST(DOMsurface, ToElement)
+{
+  sdf::Contact contact;
+  sdf::Friction friction;
+  sdf::Surface surface1;
+  sdf::ODE ode;
+  ode.SetMu(0.1);
+  ode.SetMu2(0.2);
+  ode.SetSlip1(3);
+  ode.SetSlip2(4);
+  ode.SetFdir1(gz::math::Vector3d(1, 2, 3));
+  friction.SetODE(ode);
+  contact.SetCollideBitmask(0x12);
+  surface1.SetContact(contact);
+  surface1.SetFriction(friction);
+
+  sdf::ElementPtr elem = surface1.ToElement();
+  ASSERT_NE(nullptr, elem);
+
+  sdf::Surface surface2;
+  surface2.Load(elem);
+
+  EXPECT_EQ(surface2.Contact()->CollideBitmask(), 0x12);
+  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Mu(), 0.1);
+  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Mu2(), 0.2);
+  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Slip1(), 3);
+  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Slip2(), 4);
+  EXPECT_EQ(surface2.Friction()->ODE()->Fdir1(),
+            gz::math::Vector3d(1, 2, 3));
+
+}
+
+/////////////////////////////////////////////////
 TEST(DOMcontact, DefaultConstruction)
 {
   sdf::Contact contact;
@@ -428,37 +461,4 @@ TEST(DOMode, Set)
   EXPECT_DOUBLE_EQ(ode1.Slip2(), 4);
   EXPECT_EQ(ode1.Fdir1(),
             gz::math::Vector3d(1, 2, 3));
-}
-
-/////////////////////////////////////////////////
-TEST(DOMsurface, ToElement)
-{
-  sdf::Surface surface1;
-  sdf::Contact contact;
-  sdf::ODE ode;
-  ode.SetMu(0.1);
-  ode.SetMu2(0.2);
-  ode.SetSlip1(3);
-  ode.SetSlip2(4);
-  ode.SetFdir1(gz::math::Vector3d(1, 2, 3));
-  sdf::Friction friction;
-  friction.SetODE(ode);
-  contact.SetCollideBitmask(0x12);
-  surface1.SetContact(contact);
-  surface1.SetFriction(friction);
-
-  sdf::ElementPtr elem = surface1.ToElement();
-  ASSERT_NE(nullptr, elem);
-
-  sdf::Surface surface2;
-  surface2.Load(elem);
-
-  EXPECT_EQ(surface2.Contact()->CollideBitmask(), 0x12);
-  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Mu(), 0.1);
-  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Mu2(), 0.2);
-  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Slip1(), 3);
-  EXPECT_DOUBLE_EQ(surface2.Friction()->ODE()->Slip2(), 4);
-  EXPECT_EQ(surface2.Friction()->ODE()->Fdir1(),
-            gz::math::Vector3d(1, 2, 3));
-
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This PR adds the transfer of missing attributes in the `ToElement()` method of the `Surface` class. It also adds a test for it. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.