### PR TITLE
JointAxis: improve code coverage in Load()

### DIFF
--- a/src/JointAxis.cc
+++ b/src/JointAxis.cc
@@ -99,8 +99,8 @@ Errors JointAxis::Load(ElementPtr _sdf)
 
   this->dataPtr->sdf = _sdf;
 
-  // Read the xyz values.
-  if (_sdf->HasElement("xyz"))
+  // Read the xyz values. The xyz element is required, so it will always be
+  // present, populated from default values if necessary.
   {
     using gz::math::Vector3d;
     auto errs = this->SetXyz(_sdf->Get<Vector3d>("xyz",
@@ -112,11 +112,6 @@ Errors JointAxis::Load(ElementPtr _sdf)
       this->dataPtr->xyzExpressedIn = e->Get<std::string>(
           errors, "expressed_in");
     }
-  }
-  else
-  {
-    errors.push_back({ErrorCode::ELEMENT_MISSING,
-        "The xyz element in joint axis is required"});
   }
 
   // Load dynamic values, if present
@@ -134,8 +129,8 @@ Errors JointAxis::Load(ElementPtr _sdf)
         "spring_stiffness", this->dataPtr->springStiffness).first;
   }
 
-  // Load limit values
-  if (_sdf->HasElement("limit"))
+  // Load limit values. The limit element is required, so it will always be
+  // present, populated from default values if necessary.
   {
     sdf::ElementPtr limitElement = _sdf->GetElement("limit", errors);
 
@@ -151,11 +146,6 @@ Errors JointAxis::Load(ElementPtr _sdf)
         this->dataPtr->stiffness).first;
     this->dataPtr->dissipation = limitElement->Get<double>(errors,
         "dissipation", this->dataPtr->dissipation).first;
-  }
-  else
-  {
-    errors.push_back({ErrorCode::ELEMENT_MISSING,
-        "A limit element is a required child of a joint axis"});
   }
 
   return errors;


### PR DESCRIPTION
# 🦟 Bug fix

Improve code coverage in JointAxis.cc

## Summary

The `//axis*/xyz` and `//axis*/limit` elements are marked as required in the SDFormat spec, so they will always be present. This pull request improves code coverage by removing unreachable error checking that checks if those elements are missing.

I noticed part of this change in #1166 and pulled it out to a separate PR.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
