### PR TITLE
Make dataPtr private in Plugin class

### DIFF
--- a/include/sdf/Plugin.hh
+++ b/include/sdf/Plugin.hh
@@ -189,7 +189,7 @@ namespace sdf
     }
 
     /// \brief Private data pointer.
-    std::unique_ptr<sdf::PluginPrivate> dataPtr;
+    private: std::unique_ptr<sdf::PluginPrivate> dataPtr;
   };
 
   /// \brief A vector of Plugin.


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The `dataPtr` attribute on the Plugin Class is currently public. This PR makes it private. This is a quick fix as eventually classes should use `GZ_UTILS_IMPL_PTR`.

I also opened an [issue here](https://github.com/gazebosim/sdformat/issues/1269) for future reference on the need of porting all remaining `dataPtr`s to use `GZ_UTILS_IMPL_PTR`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.