### PR TITLE
Fix GitHub Actions on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,13 +15,21 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
     - run: brew config
 
-    # Use --overwrite as a workaround for https://github.com/actions/setup-python/issues/577
+    # Workaround for https://github.com/actions/setup-python/issues/577
+    - name: Clean up python binaries
+      run: |
+        rm /usr/local/bin/2to3;
+        rm /usr/local/bin/2to3-*;
+        rm /usr/local/bin/idle3;
+        rm /usr/local/bin/pydoc3;
+        rm /usr/local/bin/python3;
+        rm /usr/local/bin/python3-config;
     - name: Install base dependencies
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
         brew tap osrf/simulation;
-        brew install --only-dependencies --overwrite ${PACKAGE};
+        brew install --only-dependencies ${PACKAGE};
 
     - run: mkdir build
     - name: cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,11 +18,11 @@ jobs:
     # Workaround for https://github.com/actions/setup-python/issues/577
     - name: Clean up python binaries
       run: |
-        rm /usr/local/bin/2to3*;
-        rm /usr/local/bin/idle3*;
-        rm /usr/local/bin/pydoc3*;
-        rm /usr/local/bin/python3*;
-        rm /usr/local/bin/python3*-config;
+        rm -f /usr/local/bin/2to3*;
+        rm -f /usr/local/bin/idle3*;
+        rm -f /usr/local/bin/pydoc3*;
+        rm -f /usr/local/bin/python3*;
+        rm -f /usr/local/bin/python3*-config;
     - name: Install base dependencies
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,12 +18,11 @@ jobs:
     # Workaround for https://github.com/actions/setup-python/issues/577
     - name: Clean up python binaries
       run: |
-        rm /usr/local/bin/2to3;
-        rm /usr/local/bin/2to3-*;
-        rm /usr/local/bin/idle3;
-        rm /usr/local/bin/pydoc3;
-        rm /usr/local/bin/python3;
-        rm /usr/local/bin/python3-config;
+        rm /usr/local/bin/2to3*;
+        rm /usr/local/bin/idle3*;
+        rm /usr/local/bin/pydoc3*;
+        rm /usr/local/bin/python3*;
+        rm /usr/local/bin/python3*-config;
     - name: Install base dependencies
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,20 +15,13 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
     - run: brew config
 
-    # Workaround for https://github.com/actions/setup-python/issues/577
-    - name: Clean up python binaries
-      run: |
-        rm /usr/local/bin/2to3;
-        rm /usr/local/bin/idle3;
-        rm /usr/local/bin/pydoc3;
-        rm /usr/local/bin/python3;
-        rm /usr/local/bin/python3-config;
+    # Use --overwrite as a workaround for https://github.com/actions/setup-python/issues/577
     - name: Install base dependencies
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
         brew tap osrf/simulation;
-        brew install --only-dependencies ${PACKAGE};
+        brew install --only-dependencies --overwrite ${PACKAGE};
 
     - run: mkdir build
     - name: cmake


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
Github Actions is failing for macOS on PRs #1268 and #1270 with the following error

```
==> Pouring python@3.11--3.11.3.monterey.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.11
Target /usr/local/bin/2to3-3.11
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.11'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.11

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.11
```

~Since we seem to keep running into this, I'm trying the `brew install --overwrite` approach to see if it's a more permanent fix for this issue.~ That didn't work, so removing all `2to3-*`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
