### PR TITLE
Switch lower and upper of limits

### DIFF
--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -3058,9 +3058,9 @@ void CreateJoint(tinyxml2::XMLElement *_root,
             *highstop = tmp;
           }
           AddKeyValue(jointAxisLimit, "lower",
-                      Values2str(1, &_link->parent_joint->limits->lower));
+                      Values2str(1, *lowstop));
           AddKeyValue(jointAxisLimit, "upper",
-                      Values2str(1, &_link->parent_joint->limits->upper));
+                      Values2str(1, *highstop));
         }
         AddKeyValue(jointAxisLimit, "effort",
                     Values2str(1, &_link->parent_joint->limits->effort));


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
In the urdf file, if the lowStop(lower) of a revolute joint is larger than the highStop(upper), they need to be swapped. While the `/src/parser_urdf.cc` file does swap the `*lowstop` and `*highstop` variables, the `AddKeyValue()` function below does not use the swapped values. This PR fixes this issue.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
