### PR TITLE
Disable pybind11 tests on windows

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -111,7 +111,7 @@ set_target_properties(${BINDINGS_MODULE_NAME} PROPERTIES
 
 configure_build_install_location(${BINDINGS_MODULE_NAME})
 
-if (BUILD_TESTING)
+if (BUILD_TESTING AND NOT WIN32)
   pybind11_add_module(sdformattest SHARED
     test/_gz_sdformattest_pybind11.cc
   )


### PR DESCRIPTION
# 🦟 Bug fix

Relates to #1276 

## Summary

Disables pybind11 tests until we find a solution for #1276.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.