### PR TITLE
Added new error codes in Python

### DIFF
--- a/python/src/sdf/pyError.cc
+++ b/python/src/sdf/pyError.cc
@@ -141,7 +141,14 @@ void defineError(pybind11::object module)
            sdf::ErrorCode::MODEL_PLACEMENT_FRAME_INVALID)
     .value("VERSION_DEPRECATED", sdf::ErrorCode::VERSION_DEPRECATED)
     .value("MERGE_INCLUDE_UNSUPPORTED",
-           sdf::ErrorCode::MERGE_INCLUDE_UNSUPPORTED);
+           sdf::ErrorCode::MERGE_INCLUDE_UNSUPPORTED)
+    .value("PARAMETER_ERROR", sdf::ErrorCode::PARAMETER_ERROR)
+    .value("UNKNOWN_PARAMETER_TYPE", sdf::ErrorCode::UNKNOWN_PARAMETER_TYPE)
+    .value("FATAL_ERROR", sdf::ErrorCode::FATAL_ERROR)
+    .value("WARNING", sdf::ErrorCode::WARNING)
+    .value("JOINT_AXIS_EXPRESSED_IN_INVALID", sdf::ErrorCode::JOINT_AXIS_EXPRESSED_IN_INVALID)
+    .value("CONVERSION_ERROR", sdf::ErrorCode::CONVERSION_ERROR)
+    .value("PARSING_ERROR", sdf::ErrorCode::PARSING_ERROR);
 }
 }  // namespace python
 }  // namespace SDF_VERSION_NAMESPACE


### PR DESCRIPTION
# 🎉 New feature

## Summary
New Errors included in Python. Introduced in these PRs:
 - https://github.com/gazebosim/sdformat/pull/1123
 - https://github.com/gazebosim/sdformat/pull/1195
 - https://github.com/gazebosim/sdformat/pull/1095
 - https://github.com/gazebosim/sdformat/pull/939


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
