### PR TITLE
Prepare for 13.5.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.4.1)
+project (sdformat13 VERSION 13.5.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,97 @@
 ## libsdformat 13.X
 
+### libsdformat 13.5.0 (2023-05-18)
+
+1. Added projector Python wrapper
+    * [Pull request #1279](https://github.com/gazebosim/sdformat/pull/1279)
+
+1. Added new error codes in Python
+    * [Pull request #1280](https://github.com/gazebosim/sdformat/pull/1280)
+
+1. Fixed 1.9/light.sdf
+    * [Pull request #1281](https://github.com/gazebosim/sdformat/pull/1281)
+
+1. Add Projector DOM
+    * [Pull request #1277](https://github.com/gazebosim/sdformat/pull/1277)
+
+1. Disable pybind11 tests on windows
+    * [Pull request #1278](https://github.com/gazebosim/sdformat/pull/1278)
+
+1. Geometry and others: update calls to use sdf::Errors parameters
+    * [Pull request #1153](https://github.com/gazebosim/sdformat/pull/1153)
+
+1. Fix GitHub Actions on macOS
+    * [Pull request #1271](https://github.com/gazebosim/sdformat/pull/1271)
+
+1. JointAxis: improve code coverage in Load()
+    * [Pull request #1267](https://github.com/gazebosim/sdformat/pull/1267)
+
+1. Scene: update calls to use sdf::Errors parameters
+    * [Pull request #1164](https://github.com/gazebosim/sdformat/pull/1164)
+
+1. ForceTorque: update calls to use sdf::Errors output
+    * [Pull request #1163](https://github.com/gazebosim/sdformat/pull/1163)
+
+1. Fix Element::Set method return value
+    * [Pull request #1256](https://github.com/gazebosim/sdformat/pull/1256)
+
+1. Sky: update calls to use sdf::Errors output
+    * [Pull request #1162](https://github.com/gazebosim/sdformat/pull/1162)
+
+1. Add missing values in Surace ToElement method
+    * [Pull request #1263](https://github.com/gazebosim/sdformat/pull/1263)
+
+1. Atmosphere: update calls to use sdf::Errors output
+    * [Pull request #1161](https://github.com/gazebosim/sdformat/pull/1161)
+
+1. Altimeter: update calls to use sdf::Errors output
+    * [Pull request #1160](https://github.com/gazebosim/sdformat/pull/1160)
+
+1. AirPressure: update calls to use sdf::Errors output
+    * [Pull request #1159](https://github.com/gazebosim/sdformat/pull/1159)
+
+1. ParticleEmitter: update calls to use sdf::Errors output
+    * [Pull request #1158](https://github.com/gazebosim/sdformat/pull/1158)
+
+1. Physics: update calls to use sdf::Errors output
+    * [Pull request #1157](https://github.com/gazebosim/sdformat/pull/1157)
+
+1. Frame: update calls to use sdf::Errors output
+    * [Pull request #1156](https://github.com/gazebosim/sdformat/pull/1156)
+
+1. Material: update calls to use sdf::Errors output
+    * [Pull request #1155](https://github.com/gazebosim/sdformat/pull/1155)
+
+1. Light: update calls to use sdf::Errors parameters
+    * [Pull request #1154](https://github.com/gazebosim/sdformat/pull/1154)
+
+1. Imu: update calls to use sdf::Errors output
+    * [Pull request #1152](https://github.com/gazebosim/sdformat/pull/1152)
+
+1. JointAxis: update calls to use sdf::Errors output
+    * [Pull request #1145](https://github.com/gazebosim/sdformat/pull/1145)
+
+1. Noise: update calls to use sdf::Errors parameters
+    * [Pull request #1151](https://github.com/gazebosim/sdformat/pull/1151)
+
+1. Plugin: update calls to use sdf::Errors output
+    * [Pull request #1144](https://github.com/gazebosim/sdformat/pull/1144)
+
+1. URDF->SDF handle links with no inertia or small mass
+    * [Pull request #1238](https://github.com/gazebosim/sdformat/pull/1238)
+
+1. Element: update calls to use sdf::Errors output
+    * [Pull request #1141](https://github.com/gazebosim/sdformat/pull/1141)
+
+1. Add: new error enums to Python
+    * [Pull request #1249](https://github.com/gazebosim/sdformat/pull/1249)
+
+1. Rename COPYING to LICENSE
+    * [Pull request #1252](https://github.com/gazebosim/sdformat/pull/1252)
+
+1. Allowing relative paths in URDF
+    * [Pull request #1213](https://github.com/gazebosim/sdformat/pull/1213)
+
 ### libsdformat 13.4.1 (2023-03-08)
 
 1. Fix camera_info_topic default value

--- a/Changelog.md
+++ b/Changelog.md
@@ -38,7 +38,7 @@
 1. Sky: update calls to use sdf::Errors output
     * [Pull request #1162](https://github.com/gazebosim/sdformat/pull/1162)
 
-1. Add missing values in Surace ToElement method
+1. Add missing values in Surface ToElement method
     * [Pull request #1263](https://github.com/gazebosim/sdformat/pull/1263)
 
 1. Atmosphere: update calls to use sdf::Errors output


### PR DESCRIPTION


# 🎈 Release

Preparation for 13.5.0 release.

Comparison to 13.4.1: https://github.com/gazebosim/sdformat/compare/sdformat13_13.4.1...prep_13.5.0


Needed by https://github.com/gazebosim/gz-sim/pull/1979

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
