### PR TITLE
Remove robot not found error when parsing fails

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -768,15 +768,16 @@ bool readFileInternal(const std::string &_filename, const bool _convert,
     return false;
   }
 
-  // Suppress deprecation for sdf::URDF2SDF
-  if (readDoc(&xmlDoc, _sdf, filename, _convert, _config, _errors))
+  tinyxml2::XMLElement *sdfXml = xmlDoc.FirstChildElement("sdf");
+  if (sdfXml)
   {
-    return true;
+    // Suppress deprecation for sdf::URDF2SDF
+    return readDoc(&xmlDoc, _sdf, filename, _convert, _config, _errors);
   }
   else
   {
     tinyxml2::XMLElement *robotXml = xmlDoc.FirstChildElement("robot");
-    if (robotXml && URDF2SDF::IsURDF(filename))
+    if (robotXml)
     {
       URDF2SDF u2g;
       auto doc = makeSdfDoc();
@@ -794,7 +795,7 @@ bool readFileInternal(const std::string &_filename, const bool _convert,
     }
     else
     {
-      sdferr << "XML does not seem to be an SDF or an URDF file.\n";
+      sdferr << "XML does not seem to be an SDFormat or an URDF file.\n";
     }
   }
 
@@ -853,10 +854,11 @@ bool readStringInternal(const std::string &_xmlString, const bool _convert,
     sdferr << "Error parsing XML from string: " << xmlDoc.ErrorStr() << '\n';
     return false;
   }
-  if (readDoc(&xmlDoc, _sdf, std::string(kSdfStringSource), _convert, _config,
-              _errors))
+  tinyxml2::XMLElement *sdfXml = xmlDoc.FirstChildElement("sdf");
+  if (sdfXml)
   {
-    return true;
+    return readDoc(&xmlDoc, _sdf, std::string(kSdfStringSource), _convert,
+                   _config, _errors);
   }
   else
   {
@@ -881,10 +883,10 @@ bool readStringInternal(const std::string &_xmlString, const bool _convert,
     }
     else
     {
-      sdferr << "XML does not seem to be an SDF or an URDF string.\n";
+      sdferr << "XML does not seem to be an SDFormat or an URDF string.\n";
+      return false;
     }
   }
-
   return false;
 }
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -784,12 +784,14 @@ bool readFileInternal(const std::string &_filename, const bool _convert,
       u2g.InitModelFile(filename, _config, &doc);
       if (sdf::readDoc(&doc, _sdf, filename, _convert, _config, _errors))
       {
-        sdfdbg << "parse from urdf file [" << _filename << "].\n";
+        sdfdbg << "Converting URDF file [" << _filename << "] to SDFormat"
+               << " and parsing it.\n";
         return true;
       }
       else
       {
-        sdferr << "parse as old deprecated model file failed.\n";
+        sdferr << "Failed to parse the URDF file after converting to"
+               << " SDFormat.\n";
         return false;
       }
     }
@@ -872,12 +874,13 @@ bool readStringInternal(const std::string &_xmlString, const bool _convert,
       if (sdf::readDoc(&doc, _sdf, std::string(kUrdfStringSource), _convert,
                       _config, _errors))
       {
-        sdfdbg << "Parsing from urdf.\n";
+        sdfdbg << "Converting URDF to SDFormat and parsing it.\n";
         return true;
       }
       else
       {
-        sdferr << "parse as old deprecated model file failed.\n";
+        sdferr << "Failed to parse the URDF file after converting to"
+               << " SDFormat\n";
         return false;
       }
     }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -773,20 +773,28 @@ bool readFileInternal(const std::string &_filename, const bool _convert,
   {
     return true;
   }
-  else if (URDF2SDF::IsURDF(filename))
+  else
   {
-    URDF2SDF u2g;
-    auto doc = makeSdfDoc();
-    u2g.InitModelFile(filename, _config, &doc);
-    if (sdf::readDoc(&doc, _sdf, filename, _convert, _config, _errors))
+    tinyxml2::XMLElement *robotXml = xmlDoc.FirstChildElement("robot");
+    if (robotXml && URDF2SDF::IsURDF(filename))
     {
-      sdfdbg << "parse from urdf file [" << _filename << "].\n";
-      return true;
+      URDF2SDF u2g;
+      auto doc = makeSdfDoc();
+      u2g.InitModelFile(filename, _config, &doc);
+      if (sdf::readDoc(&doc, _sdf, filename, _convert, _config, _errors))
+      {
+        sdfdbg << "parse from urdf file [" << _filename << "].\n";
+        return true;
+      }
+      else
+      {
+        sdferr << "parse as old deprecated model file failed.\n";
+        return false;
+      }
     }
     else
     {
-      sdferr << "parse as old deprecated model file failed.\n";
-      return false;
+      sdferr << "XML does not seem to be an SDF or an URDF file.\n";
     }
   }
 
@@ -852,20 +860,28 @@ bool readStringInternal(const std::string &_xmlString, const bool _convert,
   }
   else
   {
-    URDF2SDF u2g;
-    auto doc = makeSdfDoc();
-    u2g.InitModelString(_xmlString, _config, &doc);
-
-    if (sdf::readDoc(&doc, _sdf, std::string(kUrdfStringSource), _convert,
-                    _config, _errors))
+    tinyxml2::XMLElement *robotXml = xmlDoc.FirstChildElement("robot");
+    if (robotXml)
     {
-      sdfdbg << "Parsing from urdf.\n";
-      return true;
+      URDF2SDF u2g;
+      auto doc = makeSdfDoc();
+      u2g.InitModelString(_xmlString, _config, &doc);
+
+      if (sdf::readDoc(&doc, _sdf, std::string(kUrdfStringSource), _convert,
+                      _config, _errors))
+      {
+        sdfdbg << "Parsing from urdf.\n";
+        return true;
+      }
+      else
+      {
+        sdferr << "parse as old deprecated model file failed.\n";
+        return false;
+      }
     }
     else
     {
-      sdferr << "parse as old deprecated model file failed.\n";
-      return false;
+      sdferr << "XML does not seem to be an SDF or an URDF string.\n";
     }
   }
 

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -891,6 +891,34 @@ TEST(Parser, ReadFileErrorNotSDForURDF)
 }
 
 /////////////////////////////////////////////////
+/// Check that malformed SDF files do not throw confusing error
+TEST(Parser, ReadFileMalformedSDFNoRobotError)
+{
+  // Capture sdferr output
+  std::stringstream buffer;
+  auto old = std::cerr.rdbuf(buffer.rdbuf());
+
+#ifdef _WIN32
+  sdf::Console::Instance()->SetQuiet(false);
+#endif
+
+  const auto path =
+      sdf::testing::TestFile("sdf", "bad_syntax_pose.sdf");
+
+  sdf::Errors errors;
+  sdf::SDFPtr sdf = sdf::readFile(path, errors);
+  // Check the old error is not printed anymore
+  EXPECT_EQ(std::string::npos, buffer.str().find(
+      "Could not find the 'robot' element in the xml file"));
+
+  // Revert cerr rdbug so as to not interfere with other tests
+  std::cerr.rdbuf(old);
+#ifdef _WIN32
+  sdf::Console::Instance()->SetQuiet(true);
+#endif
+}
+
+/////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)
 {

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -836,6 +836,61 @@ TEST(Parser, ElementRemovedAfterDeprecation)
 }
 
 /////////////////////////////////////////////////
+/// Check for non SDF non URDF error on a string
+TEST(Parser, ReadStringErrorNotSDForURDF)
+{
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
+  sdf::SDFPtr sdf = InitSDF();
+  const std::string testString = R"(<?xml version="1.0" ?>
+    <foo>
+    </foo>)";
+  sdf::Errors errors;
+  EXPECT_FALSE(sdf::readString(testString, sdf, errors));
+  ASSERT_EQ(errors.size(), 0u);
+  EXPECT_NE(std::string::npos, buffer.str().find(
+      "XML does not seem to be an SDFormat or an URDF string."));
+}
+
+/////////////////////////////////////////////////
+/// Check for non SDF non URDF error on a file
+TEST(Parser, ReadFileErrorNotSDForURDF)
+{
+  std::stringstream buffer;
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
+
+  #ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(false);
+    sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
+  #endif
+
+  const auto path =
+      sdf::testing::TestFile("sdf", "box.dae");
+
+  sdf::Errors errors;
+  sdf::SDFPtr sdf = sdf::readFile(path, errors);
+  ASSERT_EQ(errors.size(), 0u);
+  EXPECT_NE(std::string::npos, buffer.str().find(
+      "XML does not seem to be an SDFormat or an URDF file."));
+}
+
+/////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #151

## Summary
When a file fails to be parsed as SDF the `parser.cc` tries to parse it as URDF generating the following error:

```
Error:   Could not find the 'robot' element in the xml file
             at line 109 in ./urdf_parser/src/model.cpp
```

This becomes confusing the file could just be a malformed SDF. 

This PR adds a check for the `robot` tag before attempting the parse in order to avoid the misleading error. It also adds an error in case it's not found indicating that the file could not be identified as SDF nor URDF. 

NOTE: I'm targeting `sdf13` as I consider this a bug fix but let me know if this should go into `master`. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.