### PR TITLE
World requires a scene and atmosphere

### DIFF
--- a/python/test/pyWorld_TEST.py
+++ b/python/test/pyWorld_TEST.py
@@ -202,7 +202,7 @@ class WorldTEST(unittest.TestCase):
 
     def test_set_scene(self):
         world = World()
-        self.assertEqual(None, world.scene())
+        self.assertNotEqual(None, world.scene())
 
         scene = Scene()
         scene.set_ambient(Color.BLUE)

--- a/src/World.cc
+++ b/src/World.cc
@@ -47,8 +47,8 @@ class sdf::World::Implementation
   /// \return Errors, if any.
   public: Errors LoadSphericalCoordinates(sdf::ElementPtr _elem);
 
-  /// \brief Optional atmosphere model.
-  public: std::optional<sdf::Atmosphere> atmosphere;
+  /// \brief Required atmosphere model.
+  public: sdf::Atmosphere atmosphere;
 
   /// \brief Audio device name
   public: std::string audioDevice = "default";
@@ -60,8 +60,8 @@ class sdf::World::Implementation
   /// \brief Optional Gui parameters.
   public: std::optional<sdf::Gui> gui;
 
-  /// \brief Optional Scene parameters.
-  public: std::optional<sdf::Scene> scene;
+  /// \brief Required scene parameters.
+  public: sdf::Scene scene;
 
   /// \brief The frames specified in this world.
   public: std::vector<Frame> frames;
@@ -180,9 +180,8 @@ Errors World::Load(sdf::ElementPtr _sdf, const ParserConfig &_config)
   // Read the atmosphere element
   if (_sdf->HasElement("atmosphere"))
   {
-    this->dataPtr->atmosphere.emplace();
     Errors atmosphereLoadErrors =
-      this->dataPtr->atmosphere->Load(_sdf->GetElement("atmosphere"));
+      this->dataPtr->atmosphere.Load(_sdf->GetElement("atmosphere"));
     errors.insert(errors.end(), atmosphereLoadErrors.begin(),
         atmosphereLoadErrors.end());
   }
@@ -314,9 +313,8 @@ Errors World::Load(sdf::ElementPtr _sdf, const ParserConfig &_config)
   // Load the Scene
   if (_sdf->HasElement("scene"))
   {
-    this->dataPtr->scene.emplace();
     Errors sceneLoadErrors =
-        this->dataPtr->scene->Load(_sdf->GetElement("scene"), _config);
+        this->dataPtr->scene.Load(_sdf->GetElement("scene"), _config);
     errors.insert(errors.end(), sceneLoadErrors.begin(), sceneLoadErrors.end());
   }
 
@@ -459,7 +457,7 @@ Model *World::ModelByName(const std::string &_name)
 /////////////////////////////////////////////////
 const sdf::Atmosphere *World::Atmosphere() const
 {
-  return optionalToPointer(this->dataPtr->atmosphere);
+  return &(this->dataPtr->atmosphere);
 }
 
 /////////////////////////////////////////////////
@@ -497,7 +495,7 @@ void World::SetGui(const sdf::Gui &_gui)
 /////////////////////////////////////////////////
 const sdf::Scene *World::Scene() const
 {
-  return optionalToPointer(this->dataPtr->scene);
+  return &(this->dataPtr->scene);
 }
 
 /////////////////////////////////////////////////
@@ -1033,16 +1031,14 @@ sdf::ElementPtr World::ToElement(const OutputConfig &_config) const
   }
 
   // Atmosphere
-  if (this->dataPtr->atmosphere)
-    elem->InsertElement(this->dataPtr->atmosphere->ToElement(), true);
+  elem->InsertElement(this->dataPtr->atmosphere.ToElement(), true);
 
   // Gui
   if (this->dataPtr->gui)
     elem->InsertElement(this->dataPtr->gui->ToElement(), true);
 
   // Scene
-  if (this->dataPtr->scene)
-    elem->InsertElement(this->dataPtr->scene->ToElement(), true);
+  elem->InsertElement(this->dataPtr->scene.ToElement(), true);
 
   // Audio
   if (this->dataPtr->audioDevice != "default")

--- a/src/World_TEST.cc
+++ b/src/World_TEST.cc
@@ -39,6 +39,11 @@ TEST(DOMWorld, Construction)
   EXPECT_STREQ("default", world.AudioDevice().c_str());
   EXPECT_EQ(gz::math::Vector3d::Zero, world.WindLinearVelocity());
 
+  // The scene and atmosphere are requred, per the SDF spec. Make sure
+  // that they have been created.
+  EXPECT_TRUE(world.Scene());
+  EXPECT_TRUE(world.Atmosphere());
+
   EXPECT_EQ(0u, world.ModelCount());
   EXPECT_EQ(nullptr, world.ModelByIndex(0));
   EXPECT_EQ(nullptr, world.ModelByIndex(1));
@@ -358,7 +363,7 @@ TEST(DOMWorld, SetGui)
 TEST(DOMWorld, SetScene)
 {
   sdf::World world;
-  EXPECT_EQ(nullptr, world.Scene());
+  EXPECT_NE(nullptr, world.Scene());
 
   sdf::Scene scene;
   scene.SetAmbient(gz::math::Color::Blue);


### PR DESCRIPTION
# 🦟 Bug fix

The SDF specification for a world has `requires="1"` for both the scene and atmosphere elements. When loading from an SDF string/file these two elements appear, even if not directly listed in the SDF  string/file. However, these two elements are `std::optional` in the World class. As a result, when creating a World using the API the scene and atmosphere are not created by default. 

This PR aligns the behavior of loading a World from a string/file and creating a World using the DOM API. 
 
## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.