### PR TITLE
Prepare for 13.6.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.5.0)
+project (sdformat13 VERSION 13.6.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,32 @@
 ## libsdformat 13.X
 
+### libsdformat 13.6.0 (2023-08-30)
+
+1. Use relative path in an urdf include to avoid confusion between internal and system headers
+    * [Pull request #1259](https://github.com/gazebosim/sdformat/pull/1259)
+
+1. parser.cc update calls to use sdf::Errors output
+    * [Pull request #1294](https://github.com/gazebosim/sdformat/pull/1294)
+
+1. Fix deeply nested merge-include for custom parsed files
+    * [Pull request #1293](https://github.com/gazebosim/sdformat/pull/1293)
+
+1. World requires a scene and atmosphere
+    * [Pull request #1308](https://github.com/gazebosim/sdformat/pull/1308)
+
+1. Infrastructure
+    * [Pull request #1307](https://github.com/gazebosim/sdformat/pull/1307)
+    * [Pull request #1306](https://github.com/gazebosim/sdformat/pull/1306)
+
+1. Remove robot not found error when parsing fails
+    * [Pull request #1290](https://github.com/gazebosim/sdformat/pull/1290)
+
+1. Make some sdfdbg messages sdfmsgs
+    * [Pull request #1288](https://github.com/gazebosim/sdformat/pull/1288)
+
+1. Minor clean up of tests
+    * [Pull request #1289](https://github.com/gazebosim/sdformat/pull/1289)
+
 ### libsdformat 13.5.0 (2023-05-18)
 
 1. Added projector Python wrapper

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,9 @@
 1. Fix deeply nested merge-include for custom parsed files
     * [Pull request #1293](https://github.com/gazebosim/sdformat/pull/1293)
 
+1. Updated findfile() to search localpath first
+    * [Pull request #1292](https://github.com/gazebosim/sdformat/pull/1292)
+
 1. World requires a scene and atmosphere
     * [Pull request #1308](https://github.com/gazebosim/sdformat/pull/1308)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 13.6.0 release.

Comparison to 13.5.0: https://github.com/gazebosim/sdformat/compare/sdformat13_13.5.0...sdf13

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.