### PR TITLE
Collision: add optional density parameter to API

### DIFF
--- a/include/sdf/Collision.hh
+++ b/include/sdf/Collision.hh
@@ -18,6 +18,7 @@
 #define SDF_COLLISION_HH_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <gz/math/Pose3.hh>
 #include <gz/math/Vector3.hh>
@@ -145,12 +146,16 @@ namespace sdf
     /// \brief Calculate and return the MassMatrix for the collision
     /// \param[out] _errors A vector of Errors objects. Each errors contains an
     /// Error code and a message. An empty errors vector indicates no errors
-    /// \param[in] _config Custom parser configuration
     /// \param[out] _inertial An inertial object which will be set with the
     /// calculated inertial values
-    public: void CalculateInertial(sdf::Errors &_errors,
-                                  gz::math::Inertiald &_inertial,
-                                  const ParserConfig &_config);
+    /// \param[in] _config Custom parser configuration
+    /// \param[in] _density An optional density value to override this
+    /// collision's density.
+    public: void CalculateInertial(
+                    sdf::Errors &_errors,
+                    gz::math::Inertiald &_inertial,
+                    const ParserConfig &_config,
+                    const std::optional<double> &_density = std::nullopt);
 
     /// \brief Get a pointer to the SDF element that was used during
     /// load.

--- a/src/Collision.cc
+++ b/src/Collision.cc
@@ -254,7 +254,8 @@ sdf::SemanticPose Collision::SemanticPose() const
 void Collision::CalculateInertial(
   sdf::Errors &_errors,
   gz::math::Inertiald &_inertial,
-  const ParserConfig &_config)
+  const ParserConfig &_config,
+  const std::optional<double> &/*_density*/)
 {
   // Check if density was not set during load & send a warning
   // about the default value being used


### PR DESCRIPTION
# 🎉 New feature

Quick API change in support of https://github.com/gazebosim/sdformat/issues/1329

## Summary

This adds a `std::optional<double>` parameter to override the density in `Collision::CalculateInertial` to support the `//link/inertial/density` parameter. This is submitted as a quick API change before the Harmonic release without the implementation of the parameter. If we don't merge this, then we can add an overloaded `Collision::CalculateInertial` method afterwards.

cc @jasmeet0915 

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
