### PR TITLE
Fix `gz sdf` command on windows

### DIFF
--- a/src/Console.cc
+++ b/src/Console.cc
@@ -34,13 +34,7 @@ using namespace sdf;
 static std::shared_ptr<Console> myself;
 static std::mutex g_instance_mutex;
 
-/// \todo Output disabled for windows, to allow tests to pass. We should
-/// disable output just for tests on windows.
-#ifndef _WIN32
 static bool g_quiet = false;
-#else
-static bool g_quiet = true;
-#endif
 
 static Console::ConsoleStream g_NullStream(nullptr);
 

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -31,7 +31,13 @@ set(cmd_script_configured "${CMAKE_CURRENT_BINARY_DIR}/cmd${PROJECT_NAME}.rb.con
 
 # Set the library_location variable to the relative path to the library file
 # within the install directory structure.
-set(library_location "../../../${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:${PROJECT_NAME}>")
+if (MSVC)
+  set(library_location_prefix "${CMAKE_INSTALL_BINDIR}")
+else()
+  set(library_location_prefix "${CMAKE_INSTALL_LIBDIR}")
+endif()
+
+set(library_location "../../../${library_location_prefix}/$<TARGET_FILE_NAME:${PROJECT_NAME}>")
 
 configure_file(
   "cmd${PROJECT_NAME_NO_VERSION_LOWER}.rb.in"

--- a/src/cmd/cmdsdformat.rb.in
+++ b/src/cmd/cmdsdformat.rb.in
@@ -26,6 +26,8 @@ else
 end
 
 require 'optparse'
+require 'pathname'
+
 
 # Constants.
 LIBRARY_NAME = '@library_location@'
@@ -174,7 +176,7 @@ class Cmd
     # puts options
 
     # Read the plugin that handles the command.
-    if LIBRARY_NAME[0] == '/'
+    if Pathname.new(LIBRARY_NAME).absolute?
       # If the first character is a slash, we'll assume that we've been given an
       # absolute path to the library. This is only used during test mode.
       plugin = LIBRARY_NAME

--- a/src/cmd/cmdsdformat.rb.in
+++ b/src/cmd/cmdsdformat.rb.in
@@ -177,8 +177,6 @@ class Cmd
 
     # Read the plugin that handles the command.
     if Pathname.new(LIBRARY_NAME).absolute?
-      # If the first character is a slash, we'll assume that we've been given an
-      # absolute path to the library. This is only used during test mode.
       plugin = LIBRARY_NAME
     else
       # We're assuming that the library path is relative to the current
@@ -189,8 +187,9 @@ class Cmd
 
     begin
       Importer.dlload plugin
-    rescue DLError
+    rescue DLError => error
       puts "Library error: [#{plugin}] not found."
+      puts "DLError: #{error.message}"
       exit(-1)
     end
 

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -72,7 +72,7 @@ std::string custom_exec_str(std::string _cmd)
 }
 
 /////////////////////////////////////////////////
-TEST(checkUnrecognizedElements, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(checkUnrecognizedElements, SDF)
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";
@@ -120,7 +120,7 @@ TEST(checkUnrecognizedElements, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(check, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(check, SDF)
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";
@@ -916,7 +916,7 @@ TEST(check, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(check_shapes_sdf, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(check_shapes_sdf, SDF)
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";
@@ -939,7 +939,7 @@ TEST(check_shapes_sdf, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(check_model_sdf, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(check_model_sdf, SDF)
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/integration/model/box";
@@ -965,7 +965,7 @@ TEST(check_model_sdf, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(describe, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(describe, SDF)
 {
   // Get the description
   std::string output =
@@ -977,7 +977,7 @@ TEST(describe, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(print, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print, SDF)
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";
@@ -1007,7 +1007,7 @@ TEST(print, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(print_rotations_in_degrees, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_rotations_in_degrees, SDF)
 {
   const std::string path =
       sdf::testing::TestFile("sdf", "rotations_in_degrees.sdf");
@@ -1075,7 +1075,7 @@ TEST(print_rotations_in_degrees, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(print_rotations_in_radians, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_rotations_in_radians, SDF)
 {
   const std::string path =
       sdf::testing::TestFile("sdf", "rotations_in_radians.sdf");
@@ -1143,7 +1143,7 @@ TEST(print_rotations_in_radians, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(print_rotations_in_quaternions, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_rotations_in_quaternions, SDF)
 {
   const auto path = sdf::testing::TestFile(
       "sdf", "rotations_in_quaternions.sdf");
@@ -1212,7 +1212,7 @@ TEST(print_rotations_in_quaternions, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(print_includes_rotations_in_degrees, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_includes_rotations_in_degrees, SDF)
 {
   // Set SDF_PATH so that included models can be found
   gz::utils::setenv(
@@ -1283,7 +1283,7 @@ TEST(print_includes_rotations_in_degrees, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(print_includes_rotations_in_radians, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_includes_rotations_in_radians, SDF)
 {
   // Set SDF_PATH so that included models can be found
   gz::utils::setenv(
@@ -1354,8 +1354,7 @@ TEST(print_includes_rotations_in_radians, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(print_includes_rotations_in_quaternions,
-     GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_includes_rotations_in_quaternions, SDF)
 {
   // Set SDF_PATH so that included models can be found
   gz::utils::setenv(
@@ -1427,8 +1426,7 @@ TEST(print_includes_rotations_in_quaternions,
 }
 
 /////////////////////////////////////////////////
-TEST(print_rotations_in_unnormalized_degrees,
-     GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_rotations_in_unnormalized_degrees, SDF)
 {
   const std::string path =
       sdf::testing::TestFile("sdf", "rotations_in_unnormalized_degrees.sdf");
@@ -1499,8 +1497,7 @@ TEST(print_rotations_in_unnormalized_degrees,
 }
 
 /////////////////////////////////////////////////
-TEST(print_rotations_in_unnormalized_radians,
-     GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_rotations_in_unnormalized_radians, SDF)
 {
   const std::string path =
       sdf::testing::TestFile("sdf", "rotations_in_unnormalized_radians.sdf");
@@ -1568,7 +1565,7 @@ TEST(print_rotations_in_unnormalized_radians,
 }
 
 /////////////////////////////////////////////////
-TEST(shuffled_cmd_flags, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(shuffled_cmd_flags, SDF)
 {
   const std::string path =
       sdf::testing::TestFile("sdf", "rotations_in_unnormalized_radians.sdf");
@@ -1617,8 +1614,7 @@ TEST(shuffled_cmd_flags, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(print_snap_to_degrees_tolerance_too_high,
-     GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(print_snap_to_degrees_tolerance_too_high, SDF)
 {
   const std::string path = sdf::testing::TestFile(
       "sdf",
@@ -1635,7 +1631,7 @@ TEST(print_snap_to_degrees_tolerance_too_high,
 }
 
 /////////////////////////////////////////////////
-TEST(GraphCmd, GZ_UTILS_TEST_DISABLED_ON_WIN32(WorldPoseRelativeTo))
+TEST(GraphCmd, WorldPoseRelativeTo)
 {
   const std::string pathBase = std::string(PROJECT_SOURCE_PATH) + "/test/sdf";
 
@@ -1686,7 +1682,7 @@ TEST(GraphCmd, GZ_UTILS_TEST_DISABLED_ON_WIN32(WorldPoseRelativeTo))
 }
 
 /////////////////////////////////////////////////
-TEST(GraphCmd, GZ_UTILS_TEST_DISABLED_ON_WIN32(ModelPoseRelativeTo))
+TEST(GraphCmd, ModelPoseRelativeTo)
 {
   const std::string pathBase = std::string(PROJECT_SOURCE_PATH) + "/test/sdf";
   const std::string path = pathBase + "/model_relative_to_nested_reference.sdf";
@@ -1762,7 +1758,7 @@ TEST(GraphCmd, GZ_UTILS_TEST_DISABLED_ON_WIN32(ModelPoseRelativeTo))
 }
 
 /////////////////////////////////////////////////
-TEST(GraphCmd, GZ_UTILS_TEST_DISABLED_ON_WIN32(WorldFrameAttachedTo))
+TEST(GraphCmd, WorldFrameAttachedTo)
 {
   const std::string pathBase = std::string(PROJECT_SOURCE_PATH) + "/test/sdf";
   const std::string path = pathBase + "/world_nested_frame_attached_to.sdf";
@@ -1808,7 +1804,7 @@ TEST(GraphCmd, GZ_UTILS_TEST_DISABLED_ON_WIN32(WorldFrameAttachedTo))
 }
 
 /////////////////////////////////////////////////
-TEST(GraphCmd, GZ_UTILS_TEST_DISABLED_ON_WIN32(ModelFrameAttachedTo))
+TEST(GraphCmd, ModelFrameAttachedTo)
 {
   const std::string pathBase = std::string(PROJECT_SOURCE_PATH) + "/test/sdf";
   const std::string path = pathBase + "/model_nested_frame_attached_to.sdf";
@@ -1859,7 +1855,7 @@ TEST(GraphCmd, GZ_UTILS_TEST_DISABLED_ON_WIN32(ModelFrameAttachedTo))
 // Disable on arm
 #if !defined __ARM_ARCH
 /////////////////////////////////////////////////
-TEST(inertial_stats, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+TEST(inertial_stats, SDF)
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";
@@ -1948,7 +1944,7 @@ TEST(inertial_stats, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 
 //////////////////////////////////////////////////
 /// \brief Check help message and bash completion script for consistent flags
-TEST(HelpVsCompletionFlags, SDF)
+TEST(HelpVsCompletionFlags, GZ_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 {
   // Flags in help message
   std::string helpOutput = custom_exec_str(GzCommand() + " sdf --help");


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1321 

## Summary
https://github.com/gazebosim/sdformat/pull/1339 fixed some issues related to the `gz` tool on windows, but as mentioned in https://github.com/gazebosim/sdformat/pull/1339#issuecomment-1767211376, the `UNIT_gz_TEST` weren't running. 

Needs https://github.com/gazebo-tooling/release-tools/pull/1063

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
