### PR TITLE
Add bullet and torsional friction DOM

### DIFF
--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -123,13 +123,13 @@ namespace sdf
     IGN_UTILS_IMPL_PTR(dataPtr)
   };
 
-  /// \brief Bullet information for a friction.
-  class SDFORMAT_VISIBLE Bullet
+  /// \brief BulletFriction information for a friction.
+  class SDFORMAT_VISIBLE BulletFriction
   {
     /// \brief Default constructor
-    public: Bullet();
+    public: BulletFriction();
 
-    /// \brief Load Bullet friction based on a element pointer. This is *not*
+    /// \brief Load BulletFriction friction based on a element pointer. This is *not*
     /// the usual entry point. Typical usage of the SDF DOM is through the Root
     /// object.
     /// \param[in] _sdf The SDF Element pointer
@@ -272,14 +272,14 @@ namespace sdf
     /// \param[in] _ode The ODE object.
     public: void SetODE(const sdf::ODE &_ode);
 
-    /// \brief Get the associated Bullet object
-    /// \return Pointer to the associated Bullet object,
-    /// nullptr if the Surface doesn't contain a Bullet element.
-    public: const sdf::Bullet *Bullet() const;
+    /// \brief Get the associated BulletFriction object
+    /// \return Pointer to the associated BulletFriction object,
+    /// nullptr if the Surface doesn't contain a BulletFriction element.
+    public: const sdf::BulletFriction *BulletFriction() const;
 
-    /// \brief Set the associated Bullet object.
-    /// \param[in] _bullet The Bullet object.
-    public: void SetBullet(const sdf::Bullet &_bullet);
+    /// \brief Set the associated BulletFriction object.
+    /// \param[in] _bullet The BulletFriction object.
+    public: void SetBulletFriction(const sdf::BulletFriction &_bullet);
 
     /// \brief Get the torsional friction
     /// \return Pointer to the torsional friction

--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -129,9 +129,9 @@ namespace sdf
     /// \brief Default constructor
     public: BulletFriction();
 
-    /// \brief Load BulletFriction friction based on a element pointer. This is *not*
-    /// the usual entry point. Typical usage of the SDF DOM is through the Root
-    /// object.
+    /// \brief Load BulletFriction friction based on a element pointer. This is
+    /// *not* the usual entry point. Typical usage of the SDF DOM is through
+    /// the Root object.
     /// \param[in] _sdf The SDF Element pointer
     /// \return Errors, which is a vector of Error objects. Each Error includes
     /// an error code and message. An empty vector indicates no error.

--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -194,7 +194,7 @@ namespace sdf
     /// an error code and message. An empty vector indicates no error.
     public: Errors Load(ElementPtr _sdf);
 
-    /// \brief Get the torsinoal friction coefficient.
+    /// \brief Get the torsional friction coefficient.
     /// \returns Torsional friction coefficient
     public: double Coefficient() const;
 

--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -128,8 +128,8 @@ namespace sdf
     /// \brief Default constructor
     public: Bullet();
 
-    /// \brief Load Bullet friction based on a element pointer. This is *not* the
-    /// usual entry point. Typical usage of the SDF DOM is through the Root
+    /// \brief Load Bullet friction based on a element pointer. This is *not*
+    /// the usual entry point. Typical usage of the SDF DOM is through the Root
     /// object.
     /// \param[in] _sdf The SDF Element pointer
     /// \return Errors, which is a vector of Error objects. Each Error includes
@@ -144,8 +144,9 @@ namespace sdf
     /// \param[in] _fricton Friction coefficient
     public: void SetFriction(double _friction);
 
-    /// \brief Get the friction coefficient in second friction pyramid direction.
-    /// \returns Second friction coefficient
+    /// \brief Get the friction coefficient in second friction pyramid
+    /// direction.
+    /// \return Second friction coefficient
     public: double Friction2() const;
 
     /// \brief Set friction coefficient in second friction pyramid direction.
@@ -154,7 +155,7 @@ namespace sdf
 
     /// \brief Get the first friction pyramid direction in collision-fixed
     /// reference
-    /// \returns First friction pyramid direction.
+    /// \return First friction pyramid direction.
     public: const gz::math::Vector3d &Fdir1() const;
 
     /// \brief Set the first friction pyramid direction in collision-fixed
@@ -163,7 +164,7 @@ namespace sdf
     public: void SetFdir1(const gz::math::Vector3d &_fdir);
 
     /// \brief Get the rolling friction coefficient
-    /// \returns Rolling friction coefficient
+    /// \return Rolling friction coefficient
     public: double RollingFriction() const;
 
     /// \brief Set the rolling friction coefficient
@@ -195,7 +196,7 @@ namespace sdf
     public: Errors Load(ElementPtr _sdf);
 
     /// \brief Get the torsional friction coefficient.
-    /// \returns Torsional friction coefficient
+    /// \return Torsional friction coefficient
     public: double Coefficient() const;
 
     /// \brief Set the torsional friction coefficient.
@@ -204,7 +205,7 @@ namespace sdf
 
     /// \brief Get whether the patch radius is used to calculate torsional
     /// friction.
-    /// \returns True if patch radius is used.
+    /// \return True if patch radius is used.
     public: bool UsePatchRadius() const;
 
     /// \brief Set whether to use patch radius for torsional friction
@@ -214,7 +215,7 @@ namespace sdf
     public: void SetUsePatchRadius(bool _usePatchRadius);
 
     /// \brief Get the radius of contact patch surface.
-    /// \returns Patch radius
+    /// \return Patch radius
     public: double PatchRadius() const;
 
     /// \brief Set the radius of contact patch surface.
@@ -222,7 +223,7 @@ namespace sdf
     public: void SetPatchRadius(double _radius);
 
     /// \brief Get the surface radius on the contact point
-    /// \returns Surface radius
+    /// \return Surface radius
     public: double SurfaceRadius() const;
 
     /// \brief Set the surface radius on the contact point.
@@ -230,7 +231,7 @@ namespace sdf
     public: void SetSurfaceRadius(double _radius);
 
     /// \brief Get the ODE force dependent slip for torsional friction
-    /// \returns Force dependent slip for torsional friction.
+    /// \return Force dependent slip for torsional friction.
     public: double ODESlip() const;
 
     /// \brief Set the ODE force dependent slip for torsional friction
@@ -271,7 +272,7 @@ namespace sdf
     public: void SetODE(const sdf::ODE &_ode);
 
     /// \brief Get the associated Bullet object
-    /// \returns Pointer to the associated Bullet object,
+    /// \return Pointer to the associated Bullet object,
     /// nullptr if the Surface doesn't contain a Bullet element.
     public: const sdf::Bullet *Bullet() const;
 
@@ -280,7 +281,7 @@ namespace sdf
     public: void SetBullet(const sdf::Bullet &_bullet);
 
     /// \brief Get the torsional friction
-    /// \returns Pointer to the torsional friction
+    /// \return Pointer to the torsional friction
     /// nullptr if the Surface doesn't contain a torsional friction element.
     public: const sdf::Torsional *Torsional() const;
 

--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -122,6 +122,157 @@ namespace sdf
     IGN_UTILS_IMPL_PTR(dataPtr)
   };
 
+  /// \brief Bullet information for a friction.
+  class SDFORMAT_VISIBLE Bullet
+  {
+    /// \brief Default constructor
+    public: Bullet();
+
+    /// \brief Load the ODE based on a element pointer. This is *not* the
+    /// usual entry point. Typical usage of the SDF DOM is through the Root
+    /// object.
+    /// \param[in] _sdf The SDF Element pointer
+    /// \return Errors, which is a vector of Error objects. Each Error includes
+    /// an error code and message. An empty vector indicates no error.
+    public: Errors Load(ElementPtr _sdf);
+
+    /// \brief Get the friction coefficient in first friction pyramid direction.
+    /// \returns Friction coefficient
+    public: double Friction() const;
+
+    /// \brief Set friction coefficient in first friction pyramid direction.
+    /// \param[in] _fricton Friction coefficient
+    public: void SetFriction(double _friction);
+
+    /// \brief Get the friction coefficient in second friction pyramid direction.
+    /// \returns Second friction coefficient
+    public: double Friction2() const;
+
+    /// \brief Set friction coefficient in second friction pyramid direction.
+    /// \param[in] _fricton Friction coefficient
+    public: void SetFriction2(double _friction);
+
+    /// \brief Get the first friction pyramid direction in collision-fixed
+    /// reference
+    /// \returns First friction pyramid direction.
+    public: const gz::math::Vector3d &Fdir1() const;
+
+    /// \brief Set the first friction pyramid direction in collision-fixed
+    /// reference
+    /// \param[in] _fdir First friction pyramid direction.
+    public: void SetFdir1(const gz::math::Vector3d &_fdir);
+
+    /// \brief Get the rolling friction coefficient
+    /// \returns Rolling friction coefficient
+    public: double RollingFriction() const;
+
+    /// \brief Set the rolling friction coefficient
+    /// \param[in] _slip1 Rolling friction coefficient
+    public: void SetRollingFriction(double _friction);
+
+    /// \brief Get a pointer to the SDF element that was used during
+    /// load.
+    /// \return SDF element pointer. The value will be nullptr if Load has
+    /// not been called.
+    public: sdf::ElementPtr Element() const;
+
+    /// \brief Private data pointer.
+    IGN_UTILS_IMPL_PTR(dataPtr)
+  };
+
+  /// \brief Torsional friction
+  class SDFORMAT_VISIBLE Torsional
+  {
+/*    /// \brief ODE information for a friction.
+    class SDFORMAT_VISIBLE ODE
+    {
+      /// \brief Default constructor
+      public: ODE();
+
+      /// \brief Load the ODE based on a element pointer. This is *not* the
+      /// usual entry point. Typical usage of the SDF DOM is through the Root
+      /// object.
+      /// \param[in] _sdf The SDF Element pointer
+      /// \return Errors, which is a vector of Error objects. Each Error includes
+      /// an error code and message. An empty vector indicates no error.
+      public: Errors Load(ElementPtr _sdf);
+
+      /// \brief Get the force dependent slip for torsional friction
+      /// \returns Force dependent slip for torsional friction.
+      public: double Slip() const;
+
+      /// \brief Get a pointer to the SDF element that was used during
+      /// load.
+      /// \return SDF element pointer. The value will be nullptr if Load has
+      /// not been called.
+      public: sdf::ElementPtr Element() const;
+    };
+*/
+
+    /// \brief Default constructor
+    public: Torsional();
+
+    /// \brief Load the ODE based on a element pointer. This is *not* the
+    /// usual entry point. Typical usage of the SDF DOM is through the Root
+    /// object.
+    /// \param[in] _sdf The SDF Element pointer
+    /// \return Errors, which is a vector of Error objects. Each Error includes
+    /// an error code and message. An empty vector indicates no error.
+    public: Errors Load(ElementPtr _sdf);
+
+    /// \brief Get the torsinoal friction coefficient.
+    /// \returns Torsional friction coefficient
+    public: double Coefficient() const;
+
+    /// \brief Set the torsional friction coefficient.
+    /// \param[in] _fricton Torsional friction coefficient
+    public: void SetCoefficient(double _coefficient);
+
+    /// \brief Get whether the patch radius is used to calculate torsional
+    /// friction.
+    /// \returns True if patch radius is used.
+    public: bool UsePatchRadius() const;
+
+    /// \brief Set whether to use patch radius for torsional friction
+    /// calculation.
+    /// \param[in] _usePatchRadius True to use patch radius.
+    /// False to use surface radius.
+    public: void SetUsePatchRadius(bool _usePatchRadius);
+
+    /// \brief Get the radius of contact patch surface.
+    /// \returns Patch radius
+    public: double PatchRadius() const;
+
+    /// \brief Set the radius of contact patch surface.
+    /// \param[in] _radius Patch radius
+    public: void SetPatchRadius(double _radius);
+
+    /// \brief Get the surface radius on the contact point
+    /// \returns Surface radius
+    public: double SurfaceRadius() const;
+
+    /// \brief Set the surface radius on the contact point.
+    /// \param[in] _radius Surface radius
+    public: void SetSurfaceRadius(double _radius);
+
+    /// \brief Get the ODE force dependent slip for torsional friction
+    /// \returns Force dependent slip for torsional friction.
+    public: double ODESlip() const;
+
+    /// \brief Set the ode force dependent slip for torsional friction
+    /// \param[in] _slip Force dependent slip for torsional fricion.
+    public: void SetODESlip(double _slip);
+
+    /// \brief Get a pointer to the SDF element that was used during
+    /// load.
+    /// \return SDF element pointer. The value will be nullptr if Load has
+    /// not been called.
+    public: sdf::ElementPtr Element() const;
+
+    /// \brief Private data pointer.
+    IGN_UTILS_IMPL_PTR(dataPtr)
+  };
+
   /// \brief Friction information for a surface.
   class SDFORMAT_VISIBLE Friction
   {
@@ -144,6 +295,24 @@ namespace sdf
     /// \brief Set the associated ODE object.
     /// \param[in] _ode The ODE object.
     public: void SetODE(const sdf::ODE &_ode);
+
+    /// \brief Get the associated Bullet object
+    /// \returns Pointer to the associated Bullet object,
+    /// nullptr if the Surface doesn't contain a Bullet element.
+    public: const sdf::Bullet *Bullet() const;
+
+    /// \brief Set the associated Bullet object.
+    /// \param[in] _bullet The Bullet object.
+    public: void SetBullet(const sdf::Bullet &_bullet);
+
+    /// \brief Get the torsional friction
+    /// \returns Pointer to the torsional friction
+    /// nullptr if the Surface doesn't contain a torsional friction element.
+    public: const sdf::Torsional *Torsional() const;
+
+    /// \brief Set the torsional friction
+    /// \param[in] _torsional The torsional friction.
+    public: void SetTorsional(const sdf::Torsional &_torsional);
 
     /// \brief Get a pointer to the SDF element that was used during
     /// load.

--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -128,7 +128,7 @@ namespace sdf
     /// \brief Default constructor
     public: Bullet();
 
-    /// \brief Load the ODE based on a element pointer. This is *not* the
+    /// \brief Load Bullet friction based on a element pointer. This is *not* the
     /// usual entry point. Typical usage of the SDF DOM is through the Root
     /// object.
     /// \param[in] _sdf The SDF Element pointer
@@ -183,37 +183,11 @@ namespace sdf
   /// \brief Torsional friction
   class SDFORMAT_VISIBLE Torsional
   {
-/*    /// \brief ODE information for a friction.
-    class SDFORMAT_VISIBLE ODE
-    {
-      /// \brief Default constructor
-      public: ODE();
-
-      /// \brief Load the ODE based on a element pointer. This is *not* the
-      /// usual entry point. Typical usage of the SDF DOM is through the Root
-      /// object.
-      /// \param[in] _sdf The SDF Element pointer
-      /// \return Errors, which is a vector of Error objects. Each Error includes
-      /// an error code and message. An empty vector indicates no error.
-      public: Errors Load(ElementPtr _sdf);
-
-      /// \brief Get the force dependent slip for torsional friction
-      /// \returns Force dependent slip for torsional friction.
-      public: double Slip() const;
-
-      /// \brief Get a pointer to the SDF element that was used during
-      /// load.
-      /// \return SDF element pointer. The value will be nullptr if Load has
-      /// not been called.
-      public: sdf::ElementPtr Element() const;
-    };
-*/
-
     /// \brief Default constructor
     public: Torsional();
 
-    /// \brief Load the ODE based on a element pointer. This is *not* the
-    /// usual entry point. Typical usage of the SDF DOM is through the Root
+    /// \brief Load torsional friction based on a element pointer. This is *not*
+    /// the usual entry point. Typical usage of the SDF DOM is through the Root
     /// object.
     /// \param[in] _sdf The SDF Element pointer
     /// \return Errors, which is a vector of Error objects. Each Error includes
@@ -259,8 +233,8 @@ namespace sdf
     /// \returns Force dependent slip for torsional friction.
     public: double ODESlip() const;
 
-    /// \brief Set the ode force dependent slip for torsional friction
-    /// \param[in] _slip Force dependent slip for torsional fricion.
+    /// \brief Set the ODE force dependent slip for torsional friction
+    /// \param[in] _slip Force dependent slip for torsional friction.
     public: void SetODESlip(double _slip);
 
     /// \brief Get a pointer to the SDF element that was used during

--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -17,6 +17,7 @@
 #ifndef SDF_SURFACE_HH_
 #define SDF_SURFACE_HH_
 
+#include <gz/math/Vector3.hh>
 #include <gz/utils/ImplPtr.hh>
 #include "sdf/Element.hh"
 #include "sdf/Types.hh"

--- a/src/Surface.cc
+++ b/src/Surface.cc
@@ -15,6 +15,9 @@
  *
  */
 
+#include <cstdint>
+#include <optional>
+
 #include "sdf/Element.hh"
 #include "sdf/parser.hh"
 #include "sdf/Surface.hh"

--- a/src/Surface.cc
+++ b/src/Surface.cc
@@ -171,8 +171,8 @@ Errors Torsional::Load(ElementPtr _sdf)
   if (_sdf->GetName() != "torsional")
   {
     errors.push_back({ErrorCode::ELEMENT_INCORRECT_TYPE,
-        "Attempting to load a BulletFriction, but the provided SDF element is not a "
-        "<ode>."});
+        "Attempting to load a BulletFriction, but the provided SDF element "
+        "is not a <torsional>."});
     return errors;
   }
 
@@ -287,8 +287,8 @@ Errors BulletFriction::Load(ElementPtr _sdf)
   if (_sdf->GetName() != "bullet")
   {
     errors.push_back({ErrorCode::ELEMENT_INCORRECT_TYPE,
-        "Attempting to load a BulletFriction, but the provided SDF element is not a "
-        "<ode>."});
+        "Attempting to load a BulletFriction, but the provided SDF element "
+        "is not a <bullet>."});
     return errors;
   }
 

--- a/src/Surface.cc
+++ b/src/Surface.cc
@@ -64,7 +64,7 @@ class sdf::ODE::Implementation
   public: double slip2 = 0.0;
 };
 
-class sdf::Bullet::Implementation
+class sdf::BulletFriction::Implementation
 {
   /// \brief The SDF element pointer used during load.
   public: sdf::ElementPtr sdf{nullptr};
@@ -119,8 +119,8 @@ class sdf::Friction::Implementation
   /// \brief The object storing ode parameters
   public: sdf::ODE ode;
 
-  /// \brief The object storing bullet parameters
-  public: std::optional<sdf::Bullet> bullet;
+  /// \brief The object storing bullet friction parameters
+  public: std::optional<sdf::BulletFriction> bullet;
 
   /// \brief The object storing torsional parameters
   public: std::optional<sdf::Torsional> torsional;
@@ -158,7 +158,7 @@ Errors Torsional::Load(ElementPtr _sdf)
   if (!_sdf)
   {
     errors.push_back({ErrorCode::ELEMENT_MISSING,
-        "Attempting to load a Bullet, but the provided SDF "
+        "Attempting to load a BulletFriction, but the provided SDF "
         "element is null."});
     return errors;
   }
@@ -168,7 +168,7 @@ Errors Torsional::Load(ElementPtr _sdf)
   if (_sdf->GetName() != "torsional")
   {
     errors.push_back({ErrorCode::ELEMENT_INCORRECT_TYPE,
-        "Attempting to load a Bullet, but the provided SDF element is not a "
+        "Attempting to load a BulletFriction, but the provided SDF element is not a "
         "<ode>."});
     return errors;
   }
@@ -258,13 +258,13 @@ sdf::ElementPtr Torsional::Element() const
 }
 
 /////////////////////////////////////////////////
-Bullet::Bullet()
+BulletFriction::BulletFriction()
   : dataPtr(gz::utils::MakeImpl<Implementation>())
 {
 }
 
 /////////////////////////////////////////////////
-Errors Bullet::Load(ElementPtr _sdf)
+Errors BulletFriction::Load(ElementPtr _sdf)
 {
   Errors errors;
 
@@ -274,7 +274,7 @@ Errors Bullet::Load(ElementPtr _sdf)
   if (!_sdf)
   {
     errors.push_back({ErrorCode::ELEMENT_MISSING,
-        "Attempting to load a Bullet, but the provided SDF "
+        "Attempting to load a BulletFriction, but the provided SDF "
         "element is null."});
     return errors;
   }
@@ -284,7 +284,7 @@ Errors Bullet::Load(ElementPtr _sdf)
   if (_sdf->GetName() != "bullet")
   {
     errors.push_back({ErrorCode::ELEMENT_INCORRECT_TYPE,
-        "Attempting to load a Bullet, but the provided SDF element is not a "
+        "Attempting to load a BulletFriction, but the provided SDF element is not a "
         "<ode>."});
     return errors;
   }
@@ -302,55 +302,55 @@ Errors Bullet::Load(ElementPtr _sdf)
 }
 
 /////////////////////////////////////////////////
-double Bullet::Friction() const
+double BulletFriction::Friction() const
 {
   return this->dataPtr->friction;
 }
 
 /////////////////////////////////////////////////
-void Bullet::SetFriction(double _friction)
+void BulletFriction::SetFriction(double _friction)
 {
   this->dataPtr->friction = _friction;
 }
 
 /////////////////////////////////////////////////
-double Bullet::Friction2() const
+double BulletFriction::Friction2() const
 {
   return this->dataPtr->friction2;
 }
 
 /////////////////////////////////////////////////
-void Bullet::SetFriction2(double _friction2)
+void BulletFriction::SetFriction2(double _friction2)
 {
   this->dataPtr->friction2 = _friction2;
 }
 
 /////////////////////////////////////////////////
-const gz::math::Vector3d &Bullet::Fdir1() const
+const gz::math::Vector3d &BulletFriction::Fdir1() const
 {
   return this->dataPtr->fdir1;
 }
 
 /////////////////////////////////////////////////
-void Bullet::SetFdir1(const gz::math::Vector3d &_fdir)
+void BulletFriction::SetFdir1(const gz::math::Vector3d &_fdir)
 {
   this->dataPtr->fdir1 = _fdir;
 }
 
 /////////////////////////////////////////////////
-double Bullet::RollingFriction() const
+double BulletFriction::RollingFriction() const
 {
   return this->dataPtr->rollingFriction;
 }
 
 /////////////////////////////////////////////////
-void Bullet::SetRollingFriction(double _rollingFriction)
+void BulletFriction::SetRollingFriction(double _rollingFriction)
 {
   this->dataPtr->rollingFriction = _rollingFriction;
 }
 
 /////////////////////////////////////////////////
-sdf::ElementPtr Bullet::Element() const
+sdf::ElementPtr BulletFriction::Element() const
 {
   return this->dataPtr->sdf;
 }
@@ -537,13 +537,13 @@ const sdf::ODE *Friction::ODE() const
 }
 
 /////////////////////////////////////////////////
-void Friction::SetBullet(const sdf::Bullet &_bullet)
+void Friction::SetBulletFriction(const sdf::BulletFriction &_bullet)
 {
   this->dataPtr->bullet = _bullet;
 }
 
 /////////////////////////////////////////////////
-const sdf::Bullet *Friction::Bullet() const
+const sdf::BulletFriction *Friction::BulletFriction() const
 {
   return optionalToPointer(this->dataPtr->bullet);
 }
@@ -715,17 +715,17 @@ sdf::ElementPtr Surface::ToElement() const
   ode->GetElement("slip2")->Set(this->dataPtr->friction.ODE()->Slip2());
   ode->GetElement("fdir1")->Set(this->dataPtr->friction.ODE()->Fdir1());
 
-  if (this->dataPtr->friction.Bullet())
+  if (this->dataPtr->friction.BulletFriction())
   {
     sdf::ElementPtr bullet = frictionElem->GetElement("bullet");
     bullet->GetElement("friction")->Set(
-      this->dataPtr->friction.Bullet()->Friction());
+      this->dataPtr->friction.BulletFriction()->Friction());
     bullet->GetElement("friction2")->Set(
-      this->dataPtr->friction.Bullet()->Friction2());
+      this->dataPtr->friction.BulletFriction()->Friction2());
     bullet->GetElement("fdir1")->Set(
-      this->dataPtr->friction.Bullet()->Fdir1());
+      this->dataPtr->friction.BulletFriction()->Fdir1());
     bullet->GetElement("rolling_friction")->Set(
-      this->dataPtr->friction.Bullet()->RollingFriction());
+      this->dataPtr->friction.BulletFriction()->RollingFriction());
   }
 
   if (this->dataPtr->friction.Torsional())

--- a/src/Surface.cc
+++ b/src/Surface.cc
@@ -21,6 +21,7 @@
 #include "sdf/Types.hh"
 #include "sdf/sdf_config.h"
 #include "sdf/system_util.hh"
+#include "Utils.hh"
 
 using namespace sdf;
 
@@ -63,10 +64,66 @@ class sdf::ODE::Implementation
   public: double slip2 = 0.0;
 };
 
+class sdf::Bullet::Implementation
+{
+  /// \brief The SDF element pointer used during load.
+  public: sdf::ElementPtr sdf{nullptr};
+
+  /// \brief Coefficient of friction in first friction pyramid direction,
+  /// the unitless maximum ratio of force in first friction pyramid
+  /// direction to normal force.
+  public: double friction{1.0};
+
+  /// \brief Coefficient of friction in second friction pyramid direction,
+  /// the unitless maximum ratio of force in second friction pyramid
+  /// direction to normal force.
+  public: double friction2{1.0};
+
+  /// \brief Unit vector specifying first friction pyramid direction in
+  /// collision-fixed reference frame.
+  public: gz::math::Vector3d fdir1{0, 0, 0};
+
+  /// \brief Rolling friction coefficient.
+  public: double rollingFriction{1.0};
+};
+
+class sdf::Torsional::Implementation
+{
+  /// \brief The SDF element pointer used during load.
+  public: sdf::ElementPtr sdf{nullptr};
+
+  /// \brief Torsional friction coefficient. Uunitless maximum ratio of
+  /// tangential stress to normal stress.
+  public: double coefficient{1.0};
+
+  /// \brief If this flag is true, torsional friction is calculated using the
+  /// "patch_radius" parameter. If this flag is set to false,
+  /// "surface_radius" (R) and contact depth (d) are used to compute the patch
+  /// radius as sqrt(R*d).
+  public: bool usePatchRadius{true};
+
+  /// \brief Radius of contact patch surface.
+  public: double patchRadius{0.0};
+
+  /// \brief Surface radius on the point of contact.
+  public: double surfaceRadius{0.0};
+
+  /// \brief Force dependent slip for torsional friction.
+  /// equivalent to inverse of viscous damping coefficient with units of
+  /// rad/s/(Nm). A slip value of 0 is infinitely viscous.
+  public: double odeSlip{0.0};
+};
+
 class sdf::Friction::Implementation
 {
-  /// \brief The object storing contact parameters
+  /// \brief The object storing ode parameters
   public: sdf::ODE ode;
+
+  /// \brief The object storing bullet parameters
+  public: std::optional<sdf::Bullet> bullet;
+
+  /// \brief The object storing torsional parameters
+  public: std::optional<sdf::Torsional> torsional;
 
   /// \brief The SDF element pointer used during load.
   public: sdf::ElementPtr sdf{nullptr};
@@ -74,7 +131,7 @@ class sdf::Friction::Implementation
 
 class sdf::Surface::Implementation
 {
-  /// \brief The object storing contact parameters
+  /// \brief The object storing friction parameters
   public: sdf::Friction friction;
 
   /// \brief The object storing contact parameters
@@ -84,6 +141,219 @@ class sdf::Surface::Implementation
   public: sdf::ElementPtr sdf{nullptr};
 };
 
+/////////////////////////////////////////////////
+Torsional::Torsional()
+  : dataPtr(gz::utils::MakeImpl<Implementation>())
+{
+}
+
+/////////////////////////////////////////////////
+Errors Torsional::Load(ElementPtr _sdf)
+{
+  Errors errors;
+
+  this->dataPtr->sdf = _sdf;
+
+  // Check that sdf is a valid pointer
+  if (!_sdf)
+  {
+    errors.push_back({ErrorCode::ELEMENT_MISSING,
+        "Attempting to load a Bullet, but the provided SDF "
+        "element is null."});
+    return errors;
+  }
+
+  // Check that the provided SDF element is a <torsional>
+  // This is an error that cannot be recovered, so return an error.
+  if (_sdf->GetName() != "torsional")
+  {
+    errors.push_back({ErrorCode::ELEMENT_INCORRECT_TYPE,
+        "Attempting to load a Bullet, but the provided SDF element is not a "
+        "<ode>."});
+    return errors;
+  }
+
+  this->dataPtr->coefficient = _sdf->Get<double>(
+      "coefficient", this->dataPtr->coefficient).first;
+  this->dataPtr->usePatchRadius = _sdf->Get<bool>(
+      "use_patch_radius", this->dataPtr->usePatchRadius).first;
+  this->dataPtr->patchRadius = _sdf->Get<double>(
+      "patch_radius", this->dataPtr->patchRadius).first;
+  this->dataPtr->surfaceRadius = _sdf->Get<double>(
+      "surface_radius", this->dataPtr->surfaceRadius).first;
+
+  if (_sdf->HasElement("ode"))
+  {
+    this->dataPtr->odeSlip = _sdf->GetElement("ode")->Get<double>(
+        "slip", this->dataPtr->odeSlip).first;
+  }
+
+  return errors;
+}
+
+/////////////////////////////////////////////////
+double Torsional::Coefficient() const
+{
+  return this->dataPtr->coefficient;
+}
+
+/////////////////////////////////////////////////
+void Torsional::SetCoefficient(double _coefficient)
+{
+  this->dataPtr->coefficient = _coefficient;
+}
+
+/////////////////////////////////////////////////
+bool Torsional::UsePatchRadius() const
+{
+  return this->dataPtr->usePatchRadius;
+}
+
+/////////////////////////////////////////////////
+void Torsional::SetUsePatchRadius(bool _usePatchRadius)
+{
+  this->dataPtr->usePatchRadius = _usePatchRadius;
+}
+
+/////////////////////////////////////////////////
+double Torsional::PatchRadius() const
+{
+  return this->dataPtr->patchRadius;
+}
+
+/////////////////////////////////////////////////
+void Torsional::SetPatchRadius(double _radius)
+{
+  this->dataPtr->patchRadius = _radius;
+}
+
+/////////////////////////////////////////////////
+double Torsional::SurfaceRadius() const
+{
+  return this->dataPtr->surfaceRadius;
+}
+
+/////////////////////////////////////////////////
+void Torsional::SetSurfaceRadius(double _radius)
+{
+  this->dataPtr->surfaceRadius = _radius;
+}
+
+/////////////////////////////////////////////////
+double Torsional::ODESlip() const
+{
+  return this->dataPtr->odeSlip;
+}
+
+/////////////////////////////////////////////////
+void Torsional::SetODESlip(double _slip)
+{
+  this->dataPtr->odeSlip = _slip;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Torsional::Element() const
+{
+  return this->dataPtr->sdf;
+}
+
+/////////////////////////////////////////////////
+Bullet::Bullet()
+  : dataPtr(gz::utils::MakeImpl<Implementation>())
+{
+}
+
+/////////////////////////////////////////////////
+Errors Bullet::Load(ElementPtr _sdf)
+{
+  Errors errors;
+
+  this->dataPtr->sdf = _sdf;
+
+  // Check that sdf is a valid pointer
+  if (!_sdf)
+  {
+    errors.push_back({ErrorCode::ELEMENT_MISSING,
+        "Attempting to load a Bullet, but the provided SDF "
+        "element is null."});
+    return errors;
+  }
+
+  // Check that the provided SDF element is a <bullet>
+  // This is an error that cannot be recovered, so return an error.
+  if (_sdf->GetName() != "bullet")
+  {
+    errors.push_back({ErrorCode::ELEMENT_INCORRECT_TYPE,
+        "Attempting to load a Bullet, but the provided SDF element is not a "
+        "<ode>."});
+    return errors;
+  }
+
+  this->dataPtr->friction = _sdf->Get<double>(
+      "friction", this->dataPtr->friction).first;
+  this->dataPtr->friction2 = _sdf->Get<double>(
+      "friction2", this->dataPtr->friction2).first;
+  this->dataPtr->fdir1 = _sdf->Get<gz::math::Vector3d>("fdir1",
+        this->dataPtr->fdir1).first;
+  this->dataPtr->rollingFriction = _sdf->Get<double>(
+      "rolling_friction", this->dataPtr->rollingFriction).first;
+
+  return errors;
+}
+
+/////////////////////////////////////////////////
+double Bullet::Friction() const
+{
+  return this->dataPtr->friction;
+}
+
+/////////////////////////////////////////////////
+void Bullet::SetFriction(double _friction)
+{
+  this->dataPtr->friction = _friction;
+}
+
+/////////////////////////////////////////////////
+double Bullet::Friction2() const
+{
+  return this->dataPtr->friction2;
+}
+
+/////////////////////////////////////////////////
+void Bullet::SetFriction2(double _friction2)
+{
+  this->dataPtr->friction2 = _friction2;
+}
+
+/////////////////////////////////////////////////
+const gz::math::Vector3d &Bullet::Fdir1() const
+{
+  return this->dataPtr->fdir1;
+}
+
+/////////////////////////////////////////////////
+void Bullet::SetFdir1(const gz::math::Vector3d &_fdir)
+{
+  this->dataPtr->fdir1 = _fdir;
+}
+
+/////////////////////////////////////////////////
+double Bullet::RollingFriction() const
+{
+  return this->dataPtr->rollingFriction;
+}
+
+/////////////////////////////////////////////////
+void Bullet::SetRollingFriction(double _rollingFriction)
+{
+  this->dataPtr->rollingFriction = _rollingFriction;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Bullet::Element() const
+{
+  return this->dataPtr->sdf;
+}
 
 /////////////////////////////////////////////////
 ODE::ODE()
@@ -231,6 +501,20 @@ Errors Friction::Load(ElementPtr _sdf)
     errors.insert(errors.end(), err.begin(), err.end());
   }
 
+  if (_sdf->HasElement("bullet"))
+  {
+    this->dataPtr->bullet.emplace();
+    Errors err = this->dataPtr->bullet->Load(_sdf->GetElement("bullet"));
+    errors.insert(errors.end(), err.begin(), err.end());
+  }
+
+  if (_sdf->HasElement("torsional"))
+  {
+    this->dataPtr->torsional.emplace();
+    Errors err = this->dataPtr->torsional->Load(_sdf->GetElement("torsional"));
+    errors.insert(errors.end(), err.begin(), err.end());
+  }
+
   return errors;
 }
 
@@ -250,6 +534,30 @@ void Friction::SetODE(const sdf::ODE &_ode)
 const sdf::ODE *Friction::ODE() const
 {
   return &this->dataPtr->ode;
+}
+
+/////////////////////////////////////////////////
+void Friction::SetBullet(const sdf::Bullet &_bullet)
+{
+  this->dataPtr->bullet = _bullet;
+}
+
+/////////////////////////////////////////////////
+const sdf::Bullet *Friction::Bullet() const
+{
+  return optionalToPointer(this->dataPtr->bullet);
+}
+
+/////////////////////////////////////////////////
+void Friction::SetTorsional(const sdf::Torsional &_torsional)
+{
+  this->dataPtr->torsional = _torsional;
+}
+
+/////////////////////////////////////////////////
+const sdf::Torsional *Friction::Torsional() const
+{
+  return optionalToPointer(this->dataPtr->torsional);
 }
 
 /////////////////////////////////////////////////
@@ -406,6 +714,35 @@ sdf::ElementPtr Surface::ToElement() const
   ode->GetElement("slip1")->Set(this->dataPtr->friction.ODE()->Slip1());
   ode->GetElement("slip2")->Set(this->dataPtr->friction.ODE()->Slip2());
   ode->GetElement("fdir1")->Set(this->dataPtr->friction.ODE()->Fdir1());
+
+  if (this->dataPtr->friction.Bullet())
+  {
+    sdf::ElementPtr bullet = frictionElem->GetElement("bullet");
+    bullet->GetElement("friction")->Set(
+      this->dataPtr->friction.Bullet()->Friction());
+    bullet->GetElement("friction2")->Set(
+      this->dataPtr->friction.Bullet()->Friction2());
+    bullet->GetElement("fdir1")->Set(
+      this->dataPtr->friction.Bullet()->Fdir1());
+    bullet->GetElement("rolling_friction")->Set(
+      this->dataPtr->friction.Bullet()->RollingFriction());
+  }
+
+  if (this->dataPtr->friction.Torsional())
+  {
+    sdf::ElementPtr torsional = frictionElem->GetElement("torsional");
+    torsional->GetElement("coefficient")->Set(
+      this->dataPtr->friction.Torsional()->Coefficient());
+    torsional->GetElement("use_patch_radius")->Set(
+      this->dataPtr->friction.Torsional()->UsePatchRadius());
+    torsional->GetElement("patch_radius")->Set(
+      this->dataPtr->friction.Torsional()->PatchRadius());
+    torsional->GetElement("surface_radius")->Set(
+      this->dataPtr->friction.Torsional()->SurfaceRadius());
+
+    torsional->GetElement("ode")->GetElement("slip")->Set(
+      this->dataPtr->friction.Torsional()->ODESlip());
+  }
 
   return elem;
 }

--- a/src/Surface_TEST.cc
+++ b/src/Surface_TEST.cc
@@ -185,7 +185,8 @@ TEST(DOMsurface, ToElement)
   EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->BulletFriction()->Friction2());
   EXPECT_EQ(gz::math::Vector3d(2, 1, 4),
             surface2.Friction()->BulletFriction()->Fdir1());
-  EXPECT_DOUBLE_EQ(1.3, surface2.Friction()->BulletFriction()->RollingFriction());
+  EXPECT_DOUBLE_EQ(1.3,
+                  surface2.Friction()->BulletFriction()->RollingFriction());
 
   EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->Torsional()->Coefficient());
   EXPECT_FALSE(surface2.Friction()->Torsional()->UsePatchRadius());

--- a/src/Surface_TEST.cc
+++ b/src/Surface_TEST.cc
@@ -150,12 +150,12 @@ TEST(DOMsurface, ToElement)
   ode.SetSlip2(4);
   ode.SetFdir1(gz::math::Vector3d(1, 2, 3));
   friction.SetODE(ode);
-  sdf::Bullet bullet;
+  sdf::BulletFriction bullet;
   bullet.SetFriction(0.3);
   bullet.SetFriction2(0.5);
   bullet.SetFdir1(gz::math::Vector3d(2, 1, 4));
   bullet.SetRollingFriction(1.3);
-  friction.SetBullet(bullet);
+  friction.SetBulletFriction(bullet);
   sdf::Torsional torsional;
   torsional.SetCoefficient(0.5);
   torsional.SetUsePatchRadius(false);
@@ -181,11 +181,11 @@ TEST(DOMsurface, ToElement)
   EXPECT_EQ(surface2.Friction()->ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
 
-  EXPECT_DOUBLE_EQ(0.3, surface2.Friction()->Bullet()->Friction());
-  EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->Bullet()->Friction2());
+  EXPECT_DOUBLE_EQ(0.3, surface2.Friction()->BulletFriction()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->BulletFriction()->Friction2());
   EXPECT_EQ(gz::math::Vector3d(2, 1, 4),
-            surface2.Friction()->Bullet()->Fdir1());
-  EXPECT_DOUBLE_EQ(1.3, surface2.Friction()->Bullet()->RollingFriction());
+            surface2.Friction()->BulletFriction()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, surface2.Friction()->BulletFriction()->RollingFriction());
 
   EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->Torsional()->Coefficient());
   EXPECT_FALSE(surface2.Friction()->Torsional()->UsePatchRadius());
@@ -260,12 +260,12 @@ TEST(DOMfriction, SetFriction)
   sdf::Friction friction1;
   friction1.SetODE(ode1);
 
-  sdf::Bullet bullet;
+  sdf::BulletFriction bullet;
   bullet.SetFriction(0.3);
   bullet.SetFriction2(0.5);
   bullet.SetFdir1(gz::math::Vector3d(2, 1, 4));
   bullet.SetRollingFriction(1.3);
-  friction1.SetBullet(bullet);
+  friction1.SetBulletFriction(bullet);
 
   sdf::Torsional torsional;
   torsional.SetCoefficient(0.5);
@@ -282,10 +282,10 @@ TEST(DOMfriction, SetFriction)
   EXPECT_EQ(friction1.ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
 
-  EXPECT_DOUBLE_EQ(0.3, friction1.Bullet()->Friction());
-  EXPECT_DOUBLE_EQ(0.5, friction1.Bullet()->Friction2());
-  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction1.Bullet()->Fdir1());
-  EXPECT_DOUBLE_EQ(1.3, friction1.Bullet()->RollingFriction());
+  EXPECT_DOUBLE_EQ(0.3, friction1.BulletFriction()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, friction1.BulletFriction()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction1.BulletFriction()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, friction1.BulletFriction()->RollingFriction());
 
   EXPECT_DOUBLE_EQ(0.5, friction1.Torsional()->Coefficient());
   EXPECT_FALSE(friction1.Torsional()->UsePatchRadius());
@@ -306,12 +306,12 @@ TEST(DOMfriction, CopyOperator)
   sdf::Friction friction1;
   friction1.SetODE(ode1);
 
-  sdf::Bullet bullet;
+  sdf::BulletFriction bullet;
   bullet.SetFriction(0.3);
   bullet.SetFriction2(0.5);
   bullet.SetFdir1(gz::math::Vector3d(2, 1, 4));
   bullet.SetRollingFriction(1.3);
-  friction1.SetBullet(bullet);
+  friction1.SetBulletFriction(bullet);
 
   sdf::Torsional torsional;
   torsional.SetCoefficient(0.5);
@@ -329,10 +329,10 @@ TEST(DOMfriction, CopyOperator)
   EXPECT_EQ(friction2.ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
 
-  EXPECT_DOUBLE_EQ(0.3, friction2.Bullet()->Friction());
-  EXPECT_DOUBLE_EQ(0.5, friction2.Bullet()->Friction2());
-  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.Bullet()->Fdir1());
-  EXPECT_DOUBLE_EQ(1.3, friction2.Bullet()->RollingFriction());
+  EXPECT_DOUBLE_EQ(0.3, friction2.BulletFriction()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, friction2.BulletFriction()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.BulletFriction()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, friction2.BulletFriction()->RollingFriction());
 
   EXPECT_DOUBLE_EQ(0.5, friction2.Torsional()->Coefficient());
   EXPECT_FALSE(friction2.Torsional()->UsePatchRadius());
@@ -353,12 +353,12 @@ TEST(DOMfriction, CopyAssignmentOperator)
   sdf::Friction friction1;
   friction1.SetODE(ode1);
 
-  sdf::Bullet bullet;
+  sdf::BulletFriction bullet;
   bullet.SetFriction(0.3);
   bullet.SetFriction2(0.5);
   bullet.SetFdir1(gz::math::Vector3d(2, 1, 4));
   bullet.SetRollingFriction(1.3);
-  friction1.SetBullet(bullet);
+  friction1.SetBulletFriction(bullet);
 
   sdf::Torsional torsional;
   torsional.SetCoefficient(0.5);
@@ -376,10 +376,10 @@ TEST(DOMfriction, CopyAssignmentOperator)
   EXPECT_EQ(friction2.ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
 
-  EXPECT_DOUBLE_EQ(0.3, friction2.Bullet()->Friction());
-  EXPECT_DOUBLE_EQ(0.5, friction2.Bullet()->Friction2());
-  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.Bullet()->Fdir1());
-  EXPECT_DOUBLE_EQ(1.3, friction2.Bullet()->RollingFriction());
+  EXPECT_DOUBLE_EQ(0.3, friction2.BulletFriction()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, friction2.BulletFriction()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.BulletFriction()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, friction2.BulletFriction()->RollingFriction());
 
   EXPECT_DOUBLE_EQ(0.5, friction2.Torsional()->Coefficient());
   EXPECT_FALSE(friction2.Torsional()->UsePatchRadius());
@@ -409,19 +409,19 @@ TEST(DOMfriction, CopyAssignmentAfterMove)
   sdf::Friction friction2;
   friction2.SetODE(ode2);
 
-  sdf::Bullet bullet1;
+  sdf::BulletFriction bullet1;
   bullet1.SetFriction(0.3);
   bullet1.SetFriction2(0.5);
   bullet1.SetFdir1(gz::math::Vector3d(2, 1, 4));
   bullet1.SetRollingFriction(1.3);
-  friction1.SetBullet(bullet1);
+  friction1.SetBulletFriction(bullet1);
 
-  sdf::Bullet bullet2;
+  sdf::BulletFriction bullet2;
   bullet2.SetFriction(0.1);
   bullet2.SetFriction2(0.2);
   bullet2.SetFdir1(gz::math::Vector3d(3, 4, 5));
   bullet2.SetRollingFriction(3.1);
-  friction2.SetBullet(bullet2);
+  friction2.SetBulletFriction(bullet2);
 
   sdf::Torsional torsional1;
   torsional1.SetCoefficient(0.5);
@@ -456,14 +456,14 @@ TEST(DOMfriction, CopyAssignmentAfterMove)
   EXPECT_EQ(friction2.ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
 
-  EXPECT_DOUBLE_EQ(0.3, friction2.Bullet()->Friction());
-  EXPECT_DOUBLE_EQ(0.5, friction2.Bullet()->Friction2());
-  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.Bullet()->Fdir1());
-  EXPECT_DOUBLE_EQ(1.3, friction2.Bullet()->RollingFriction());
-  EXPECT_DOUBLE_EQ(0.1, friction1.Bullet()->Friction());
-  EXPECT_DOUBLE_EQ(0.2, friction1.Bullet()->Friction2());
-  EXPECT_EQ(gz::math::Vector3d(3, 4, 5), friction1.Bullet()->Fdir1());
-  EXPECT_DOUBLE_EQ(3.1, friction1.Bullet()->RollingFriction());
+  EXPECT_DOUBLE_EQ(0.3, friction2.BulletFriction()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, friction2.BulletFriction()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.BulletFriction()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, friction2.BulletFriction()->RollingFriction());
+  EXPECT_DOUBLE_EQ(0.1, friction1.BulletFriction()->Friction());
+  EXPECT_DOUBLE_EQ(0.2, friction1.BulletFriction()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(3, 4, 5), friction1.BulletFriction()->Fdir1());
+  EXPECT_DOUBLE_EQ(3.1, friction1.BulletFriction()->RollingFriction());
 
   EXPECT_DOUBLE_EQ(0.5, friction2.Torsional()->Coefficient());
   EXPECT_FALSE(friction2.Torsional()->UsePatchRadius());
@@ -591,7 +591,7 @@ TEST(DOMode, Set)
 /////////////////////////////////////////////////
 TEST(DOMbullet, DefaultValues)
 {
-  sdf::Bullet bullet;
+  sdf::BulletFriction bullet;
   EXPECT_EQ(nullptr, bullet.Element());
   EXPECT_DOUBLE_EQ(1.0, bullet.Friction());
   EXPECT_DOUBLE_EQ(1.0, bullet.Friction2());
@@ -602,13 +602,13 @@ TEST(DOMbullet, DefaultValues)
 /////////////////////////////////////////////////
 TEST(DOMbullet, CopyOperator)
 {
-  sdf::Bullet bullet1;
+  sdf::BulletFriction bullet1;
   bullet1.SetFriction(0.1);
   bullet1.SetFriction2(0.2);
   bullet1.SetFdir1(gz::math::Vector3d(1, 2, 3));
   bullet1.SetRollingFriction(4.0);
 
-  sdf::Bullet bullet2(bullet1);
+  sdf::BulletFriction bullet2(bullet1);
   EXPECT_DOUBLE_EQ(0.1, bullet2.Friction());
   EXPECT_DOUBLE_EQ(0.2, bullet2.Friction2());
   EXPECT_EQ(gz::math::Vector3d(1, 2, 3), bullet2.Fdir1());
@@ -618,13 +618,13 @@ TEST(DOMbullet, CopyOperator)
 /////////////////////////////////////////////////
 TEST(DOMbullet, CopyAssignmentOperator)
 {
-  sdf::Bullet bullet1;
+  sdf::BulletFriction bullet1;
   bullet1.SetFriction(0.1);
   bullet1.SetFriction2(0.2);
   bullet1.SetFdir1(gz::math::Vector3d(1, 2, 3));
   bullet1.SetRollingFriction(4.0);
 
-  sdf::Bullet bullet2 = bullet1;
+  sdf::BulletFriction bullet2 = bullet1;
   EXPECT_DOUBLE_EQ(0.1, bullet2.Friction());
   EXPECT_DOUBLE_EQ(0.2, bullet2.Friction2());
   EXPECT_EQ(gz::math::Vector3d(1, 2, 3), bullet2.Fdir1());
@@ -634,19 +634,19 @@ TEST(DOMbullet, CopyAssignmentOperator)
 /////////////////////////////////////////////////
 TEST(DOMbullet, CopyAssignmentAfterMove)
 {
-  sdf::Bullet bullet1;
+  sdf::BulletFriction bullet1;
   bullet1.SetFriction(0.1);
   bullet1.SetFriction2(0.2);
   bullet1.SetFdir1(gz::math::Vector3d(1, 2, 3));
   bullet1.SetRollingFriction(4.0);
 
-  sdf::Bullet bullet2;
+  sdf::BulletFriction bullet2;
   bullet2.SetFriction(0.2);
   bullet2.SetFriction2(0.1);
   bullet2.SetFdir1(gz::math::Vector3d(3, 2, 1));
   bullet2.SetRollingFriction(3.0);
 
-  sdf::Bullet tmp = std::move(bullet1);
+  sdf::BulletFriction tmp = std::move(bullet1);
   bullet1 = bullet2;
   bullet2 = tmp;
 
@@ -664,7 +664,7 @@ TEST(DOMbullet, CopyAssignmentAfterMove)
 /////////////////////////////////////////////////
 TEST(DOMbullet, Set)
 {
-  sdf::Bullet bullet1;
+  sdf::BulletFriction bullet1;
 
   EXPECT_DOUBLE_EQ(bullet1.Friction(), 1.0);
   EXPECT_DOUBLE_EQ(bullet1.Friction2(), 1.0);

--- a/src/Surface_TEST.cc
+++ b/src/Surface_TEST.cc
@@ -16,6 +16,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <gz/math/Vector3.hh>
 #include "sdf/Surface.hh"
 
 /////////////////////////////////////////////////

--- a/src/Surface_TEST.cc
+++ b/src/Surface_TEST.cc
@@ -149,6 +149,19 @@ TEST(DOMsurface, ToElement)
   ode.SetSlip2(4);
   ode.SetFdir1(gz::math::Vector3d(1, 2, 3));
   friction.SetODE(ode);
+  sdf::Bullet bullet;
+  bullet.SetFriction(0.3);
+  bullet.SetFriction2(0.5);
+  bullet.SetFdir1(gz::math::Vector3d(2, 1, 4));
+  bullet.SetRollingFriction(1.3);
+  friction.SetBullet(bullet);
+  sdf::Torsional torsional;
+  torsional.SetCoefficient(0.5);
+  torsional.SetUsePatchRadius(false);
+  torsional.SetPatchRadius(0.1);
+  torsional.SetSurfaceRadius(0.3);
+  torsional.SetODESlip(0.2);
+  friction.SetTorsional(torsional);
   contact.SetCollideBitmask(0x12);
   surface1.SetContact(contact);
   surface1.SetFriction(friction);
@@ -167,6 +180,16 @@ TEST(DOMsurface, ToElement)
   EXPECT_EQ(surface2.Friction()->ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
 
+  EXPECT_DOUBLE_EQ(0.3, surface2.Friction()->Bullet()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->Bullet()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), surface2.Friction()->Bullet()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, surface2.Friction()->Bullet()->RollingFriction());
+
+  EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->Torsional()->Coefficient());
+  EXPECT_FALSE(surface2.Friction()->Torsional()->UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.1, surface2.Friction()->Torsional()->PatchRadius());
+  EXPECT_DOUBLE_EQ(0.3, surface2.Friction()->Torsional()->SurfaceRadius());
+  EXPECT_DOUBLE_EQ(0.2, surface2.Friction()->Torsional()->ODESlip());
 }
 
 /////////////////////////////////////////////////
@@ -234,13 +257,39 @@ TEST(DOMfriction, SetFriction)
   ode1.SetFdir1(gz::math::Vector3d(1, 2, 3));
   sdf::Friction friction1;
   friction1.SetODE(ode1);
-  EXPECT_EQ(nullptr, friction1.Element());
+
+  sdf::Bullet bullet;
+  bullet.SetFriction(0.3);
+  bullet.SetFriction2(0.5);
+  bullet.SetFdir1(gz::math::Vector3d(2, 1, 4));
+  bullet.SetRollingFriction(1.3);
+  friction1.SetBullet(bullet);
+
+  sdf::Torsional torsional;
+  torsional.SetCoefficient(0.5);
+  torsional.SetUsePatchRadius(false);
+  torsional.SetPatchRadius(0.1);
+  torsional.SetSurfaceRadius(0.3);
+  torsional.SetODESlip(0.2);
+  friction1.SetTorsional(torsional);
+
   EXPECT_DOUBLE_EQ(friction1.ODE()->Mu(), 0.1);
   EXPECT_DOUBLE_EQ(friction1.ODE()->Mu2(), 0.2);
   EXPECT_DOUBLE_EQ(friction1.ODE()->Slip1(), 3);
   EXPECT_DOUBLE_EQ(friction1.ODE()->Slip2(), 4);
   EXPECT_EQ(friction1.ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
+
+  EXPECT_DOUBLE_EQ(0.3, friction1.Bullet()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, friction1.Bullet()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction1.Bullet()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, friction1.Bullet()->RollingFriction());
+
+  EXPECT_DOUBLE_EQ(0.5, friction1.Torsional()->Coefficient());
+  EXPECT_FALSE(friction1.Torsional()->UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.1, friction1.Torsional()->PatchRadius());
+  EXPECT_DOUBLE_EQ(0.3, friction1.Torsional()->SurfaceRadius());
+  EXPECT_DOUBLE_EQ(0.2, friction1.Torsional()->ODESlip());
 }
 
 /////////////////////////////////////////////////
@@ -255,6 +304,21 @@ TEST(DOMfriction, CopyOperator)
   sdf::Friction friction1;
   friction1.SetODE(ode1);
 
+  sdf::Bullet bullet;
+  bullet.SetFriction(0.3);
+  bullet.SetFriction2(0.5);
+  bullet.SetFdir1(gz::math::Vector3d(2, 1, 4));
+  bullet.SetRollingFriction(1.3);
+  friction1.SetBullet(bullet);
+
+  sdf::Torsional torsional;
+  torsional.SetCoefficient(0.5);
+  torsional.SetUsePatchRadius(false);
+  torsional.SetPatchRadius(0.1);
+  torsional.SetSurfaceRadius(0.3);
+  torsional.SetODESlip(0.2);
+  friction1.SetTorsional(torsional);
+
   sdf::Friction friction2(friction1);
   EXPECT_DOUBLE_EQ(friction2.ODE()->Mu(), 0.1);
   EXPECT_DOUBLE_EQ(friction2.ODE()->Mu2(), 0.2);
@@ -262,6 +326,17 @@ TEST(DOMfriction, CopyOperator)
   EXPECT_DOUBLE_EQ(friction2.ODE()->Slip2(), 4);
   EXPECT_EQ(friction2.ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
+
+  EXPECT_DOUBLE_EQ(0.3, friction2.Bullet()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, friction2.Bullet()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.Bullet()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, friction2.Bullet()->RollingFriction());
+
+  EXPECT_DOUBLE_EQ(0.5, friction2.Torsional()->Coefficient());
+  EXPECT_FALSE(friction2.Torsional()->UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.1, friction2.Torsional()->PatchRadius());
+  EXPECT_DOUBLE_EQ(0.3, friction2.Torsional()->SurfaceRadius());
+  EXPECT_DOUBLE_EQ(0.2, friction2.Torsional()->ODESlip());
 }
 
 /////////////////////////////////////////////////
@@ -276,6 +351,21 @@ TEST(DOMfriction, CopyAssignmentOperator)
   sdf::Friction friction1;
   friction1.SetODE(ode1);
 
+  sdf::Bullet bullet;
+  bullet.SetFriction(0.3);
+  bullet.SetFriction2(0.5);
+  bullet.SetFdir1(gz::math::Vector3d(2, 1, 4));
+  bullet.SetRollingFriction(1.3);
+  friction1.SetBullet(bullet);
+
+  sdf::Torsional torsional;
+  torsional.SetCoefficient(0.5);
+  torsional.SetUsePatchRadius(false);
+  torsional.SetPatchRadius(0.1);
+  torsional.SetSurfaceRadius(0.3);
+  torsional.SetODESlip(0.2);
+  friction1.SetTorsional(torsional);
+
   sdf::Friction friction2 = friction1;
   EXPECT_DOUBLE_EQ(friction2.ODE()->Mu(), 0.1);
   EXPECT_DOUBLE_EQ(friction2.ODE()->Mu2(), 0.2);
@@ -283,6 +373,17 @@ TEST(DOMfriction, CopyAssignmentOperator)
   EXPECT_DOUBLE_EQ(friction2.ODE()->Slip2(), 4);
   EXPECT_EQ(friction2.ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
+
+  EXPECT_DOUBLE_EQ(0.3, friction2.Bullet()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, friction2.Bullet()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.Bullet()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, friction2.Bullet()->RollingFriction());
+
+  EXPECT_DOUBLE_EQ(0.5, friction2.Torsional()->Coefficient());
+  EXPECT_FALSE(friction2.Torsional()->UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.1, friction2.Torsional()->PatchRadius());
+  EXPECT_DOUBLE_EQ(0.3, friction2.Torsional()->SurfaceRadius());
+  EXPECT_DOUBLE_EQ(0.2, friction2.Torsional()->ODESlip());
 }
 
 /////////////////////////////////////////////////
@@ -306,6 +407,36 @@ TEST(DOMfriction, CopyAssignmentAfterMove)
   sdf::Friction friction2;
   friction2.SetODE(ode2);
 
+  sdf::Bullet bullet1;
+  bullet1.SetFriction(0.3);
+  bullet1.SetFriction2(0.5);
+  bullet1.SetFdir1(gz::math::Vector3d(2, 1, 4));
+  bullet1.SetRollingFriction(1.3);
+  friction1.SetBullet(bullet1);
+
+  sdf::Bullet bullet2;
+  bullet2.SetFriction(0.1);
+  bullet2.SetFriction2(0.2);
+  bullet2.SetFdir1(gz::math::Vector3d(3, 4, 5));
+  bullet2.SetRollingFriction(3.1);
+  friction2.SetBullet(bullet2);
+
+  sdf::Torsional torsional1;
+  torsional1.SetCoefficient(0.5);
+  torsional1.SetUsePatchRadius(false);
+  torsional1.SetPatchRadius(0.1);
+  torsional1.SetSurfaceRadius(0.3);
+  torsional1.SetODESlip(0.2);
+  friction1.SetTorsional(torsional1);
+
+  sdf::Torsional torsional2;
+  torsional2.SetCoefficient(1.5);
+  torsional2.SetUsePatchRadius(true);
+  torsional2.SetPatchRadius(1.1);
+  torsional2.SetSurfaceRadius(3.3);
+  torsional2.SetODESlip(2.2);
+  friction2.SetTorsional(torsional2);
+
   sdf::Friction tmp = std::move(friction1);
   friction1 = friction2;
   friction2 = tmp;
@@ -322,34 +453,26 @@ TEST(DOMfriction, CopyAssignmentAfterMove)
   EXPECT_DOUBLE_EQ(friction2.ODE()->Slip2(), 4);
   EXPECT_EQ(friction2.ODE()->Fdir1(),
             gz::math::Vector3d(1, 2, 3));
-}
 
-/////////////////////////////////////////////////
-TEST(DOMfriction, Set)
-{
-  sdf::ODE ode1;
-  sdf::Friction friction1;
+  EXPECT_DOUBLE_EQ(0.3, friction2.Bullet()->Friction());
+  EXPECT_DOUBLE_EQ(0.5, friction2.Bullet()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), friction2.Bullet()->Fdir1());
+  EXPECT_DOUBLE_EQ(1.3, friction2.Bullet()->RollingFriction());
+  EXPECT_DOUBLE_EQ(0.1, friction1.Bullet()->Friction());
+  EXPECT_DOUBLE_EQ(0.2, friction1.Bullet()->Friction2());
+  EXPECT_EQ(gz::math::Vector3d(3, 4, 5), friction1.Bullet()->Fdir1());
+  EXPECT_DOUBLE_EQ(3.1, friction1.Bullet()->RollingFriction());
 
-  EXPECT_DOUBLE_EQ(friction1.ODE()->Mu(), 1.0);
-  EXPECT_DOUBLE_EQ(friction1.ODE()->Mu2(), 1.0);
-  EXPECT_DOUBLE_EQ(friction1.ODE()->Slip1(), 0);
-  EXPECT_DOUBLE_EQ(friction1.ODE()->Slip2(), 0);
-  EXPECT_EQ(friction1.ODE()->Fdir1(),
-            gz::math::Vector3d(0, 0, 0));
-
-  ode1.SetMu(0.1);
-  ode1.SetMu2(0.2);
-  ode1.SetSlip1(3);
-  ode1.SetSlip2(4);
-  ode1.SetFdir1(gz::math::Vector3d(1, 2, 3));
-  friction1.SetODE(ode1);
-
-  EXPECT_DOUBLE_EQ(friction1.ODE()->Mu(), 0.1);
-  EXPECT_DOUBLE_EQ(friction1.ODE()->Mu2(), 0.2);
-  EXPECT_DOUBLE_EQ(friction1.ODE()->Slip1(), 3);
-  EXPECT_DOUBLE_EQ(friction1.ODE()->Slip2(), 4);
-  EXPECT_EQ(friction1.ODE()->Fdir1(),
-            gz::math::Vector3d(1, 2, 3));
+  EXPECT_DOUBLE_EQ(0.5, friction2.Torsional()->Coefficient());
+  EXPECT_FALSE(friction2.Torsional()->UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.1, friction2.Torsional()->PatchRadius());
+  EXPECT_DOUBLE_EQ(0.3, friction2.Torsional()->SurfaceRadius());
+  EXPECT_DOUBLE_EQ(0.2, friction2.Torsional()->ODESlip());
+  EXPECT_DOUBLE_EQ(1.5, friction1.Torsional()->Coefficient());
+  EXPECT_TRUE(friction1.Torsional()->UsePatchRadius());
+  EXPECT_DOUBLE_EQ(1.1, friction1.Torsional()->PatchRadius());
+  EXPECT_DOUBLE_EQ(3.3, friction1.Torsional()->SurfaceRadius());
+  EXPECT_DOUBLE_EQ(2.2, friction1.Torsional()->ODESlip());
 }
 
 /////////////////////////////////////////////////
@@ -461,4 +584,205 @@ TEST(DOMode, Set)
   EXPECT_DOUBLE_EQ(ode1.Slip2(), 4);
   EXPECT_EQ(ode1.Fdir1(),
             gz::math::Vector3d(1, 2, 3));
+}
+
+/////////////////////////////////////////////////
+TEST(DOMbullet, DefaultValues)
+{
+  sdf::Bullet bullet;
+  EXPECT_EQ(nullptr, bullet.Element());
+  EXPECT_DOUBLE_EQ(1.0, bullet.Friction());
+  EXPECT_DOUBLE_EQ(1.0, bullet.Friction2());
+  EXPECT_EQ(gz::math::Vector3d(0, 0, 0), bullet.Fdir1());
+  EXPECT_DOUBLE_EQ(1.0, bullet.RollingFriction());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMbullet, CopyOperator)
+{
+  sdf::Bullet bullet1;
+  bullet1.SetFriction(0.1);
+  bullet1.SetFriction2(0.2);
+  bullet1.SetFdir1(gz::math::Vector3d(1, 2, 3));
+  bullet1.SetRollingFriction(4.0);
+
+  sdf::Bullet bullet2(bullet1);
+  EXPECT_DOUBLE_EQ(0.1, bullet2.Friction());
+  EXPECT_DOUBLE_EQ(0.2, bullet2.Friction2());
+  EXPECT_EQ(gz::math::Vector3d(1, 2, 3), bullet2.Fdir1());
+  EXPECT_DOUBLE_EQ(4.0, bullet2.RollingFriction());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMbullet, CopyAssignmentOperator)
+{
+  sdf::Bullet bullet1;
+  bullet1.SetFriction(0.1);
+  bullet1.SetFriction2(0.2);
+  bullet1.SetFdir1(gz::math::Vector3d(1, 2, 3));
+  bullet1.SetRollingFriction(4.0);
+
+  sdf::Bullet bullet2 = bullet1;
+  EXPECT_DOUBLE_EQ(0.1, bullet2.Friction());
+  EXPECT_DOUBLE_EQ(0.2, bullet2.Friction2());
+  EXPECT_EQ(gz::math::Vector3d(1, 2, 3), bullet2.Fdir1());
+  EXPECT_DOUBLE_EQ(4.0, bullet2.RollingFriction());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMbullet, CopyAssignmentAfterMove)
+{
+  sdf::Bullet bullet1;
+  bullet1.SetFriction(0.1);
+  bullet1.SetFriction2(0.2);
+  bullet1.SetFdir1(gz::math::Vector3d(1, 2, 3));
+  bullet1.SetRollingFriction(4.0);
+
+  sdf::Bullet bullet2;
+  bullet2.SetFriction(0.2);
+  bullet2.SetFriction2(0.1);
+  bullet2.SetFdir1(gz::math::Vector3d(3, 2, 1));
+  bullet2.SetRollingFriction(3.0);
+
+  sdf::Bullet tmp = std::move(bullet1);
+  bullet1 = bullet2;
+  bullet2 = tmp;
+
+  EXPECT_DOUBLE_EQ(0.2, bullet1.Friction());
+  EXPECT_DOUBLE_EQ(0.1, bullet1.Friction2());
+  EXPECT_EQ(gz::math::Vector3d(3, 2, 1), bullet1.Fdir1());
+  EXPECT_DOUBLE_EQ(3.0, bullet1.RollingFriction());
+
+  EXPECT_DOUBLE_EQ(0.1, bullet2.Friction());
+  EXPECT_DOUBLE_EQ(0.2, bullet2.Friction2());
+  EXPECT_EQ(gz::math::Vector3d(1, 2, 3), bullet2.Fdir1());
+  EXPECT_DOUBLE_EQ(4.0, bullet2.RollingFriction());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMbullet, Set)
+{
+  sdf::Bullet bullet1;
+
+  EXPECT_DOUBLE_EQ(bullet1.Friction(), 1.0);
+  EXPECT_DOUBLE_EQ(bullet1.Friction2(), 1.0);
+  EXPECT_EQ(bullet1.Fdir1(),
+            gz::math::Vector3d(0, 0, 0));
+  EXPECT_DOUBLE_EQ(bullet1.RollingFriction(), 1.0);
+
+  bullet1.SetFriction(0.1);
+  bullet1.SetFriction2(0.2);
+  bullet1.SetFdir1(gz::math::Vector3d(1, 2, 3));
+  bullet1.SetRollingFriction(4);
+
+  EXPECT_DOUBLE_EQ(0.1, bullet1.Friction());
+  EXPECT_DOUBLE_EQ(0.2, bullet1.Friction2());
+  EXPECT_EQ(gz::math::Vector3d(1, 2, 3), bullet1.Fdir1());
+  EXPECT_DOUBLE_EQ(4.0, bullet1.RollingFriction());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMtorsional, DefaultValues)
+{
+  sdf::Torsional torsional;
+  EXPECT_EQ(nullptr, torsional.Element());
+  EXPECT_DOUBLE_EQ(1.0, torsional.Coefficient());
+  EXPECT_TRUE(torsional.UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.0, torsional.PatchRadius());
+  EXPECT_DOUBLE_EQ(0.0, torsional.SurfaceRadius());
+  EXPECT_DOUBLE_EQ(0.0, torsional.ODESlip());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMtorsional, CopyOperator)
+{
+  sdf::Torsional torsional1;
+  torsional1.SetCoefficient(0.1);
+  torsional1.SetUsePatchRadius(false);
+  torsional1.SetPatchRadius(0.2);
+  torsional1.SetSurfaceRadius(4.0);
+  torsional1.SetODESlip(1.0);
+
+  sdf::Torsional torsional2(torsional1);
+  EXPECT_DOUBLE_EQ(0.1, torsional2.Coefficient());
+  EXPECT_FALSE(torsional2.UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.2, torsional2.PatchRadius());
+  EXPECT_DOUBLE_EQ(4.0, torsional2.SurfaceRadius());
+  EXPECT_DOUBLE_EQ(1.0, torsional2.ODESlip());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMtorsional, CopyAssignmentOperator)
+{
+  sdf::Torsional torsional1;
+  torsional1.SetCoefficient(0.1);
+  torsional1.SetUsePatchRadius(false);
+  torsional1.SetPatchRadius(0.2);
+  torsional1.SetSurfaceRadius(4.0);
+  torsional1.SetODESlip(1.0);
+
+  sdf::Torsional torsional2 = torsional1;
+  EXPECT_DOUBLE_EQ(0.1, torsional2.Coefficient());
+  EXPECT_FALSE(torsional2.UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.2, torsional2.PatchRadius());
+  EXPECT_DOUBLE_EQ(4.0, torsional2.SurfaceRadius());
+  EXPECT_DOUBLE_EQ(1.0, torsional2.ODESlip());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMtorsional, CopyAssignmentAfterMove)
+{
+  sdf::Torsional torsional1;
+  torsional1.SetCoefficient(0.1);
+  torsional1.SetUsePatchRadius(false);
+  torsional1.SetPatchRadius(0.2);
+  torsional1.SetSurfaceRadius(4.0);
+  torsional1.SetODESlip(1.0);
+
+  sdf::Torsional torsional2;
+  torsional2.SetCoefficient(1.1);
+  torsional2.SetUsePatchRadius(true);
+  torsional2.SetPatchRadius(1.2);
+  torsional2.SetSurfaceRadius(4.1);
+  torsional2.SetODESlip(1.1);
+
+  sdf::Torsional tmp = std::move(torsional1);
+  torsional1 = torsional2;
+  torsional2 = tmp;
+
+  EXPECT_DOUBLE_EQ(0.1, torsional2.Coefficient());
+  EXPECT_FALSE(torsional2.UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.2, torsional2.PatchRadius());
+  EXPECT_DOUBLE_EQ(4.0, torsional2.SurfaceRadius());
+  EXPECT_DOUBLE_EQ(1.0, torsional2.ODESlip());
+
+  EXPECT_DOUBLE_EQ(1.1, torsional1.Coefficient());
+  EXPECT_TRUE(torsional1.UsePatchRadius());
+  EXPECT_DOUBLE_EQ(1.2, torsional1.PatchRadius());
+  EXPECT_DOUBLE_EQ(4.1, torsional1.SurfaceRadius());
+  EXPECT_DOUBLE_EQ(1.1, torsional1.ODESlip());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMtorsional, Set)
+{
+  sdf::Torsional torsional1;
+
+  EXPECT_DOUBLE_EQ(1.0, torsional1.Coefficient());
+  EXPECT_TRUE(torsional1.UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.0, torsional1.PatchRadius());
+  EXPECT_DOUBLE_EQ(0.0, torsional1.SurfaceRadius());
+  EXPECT_DOUBLE_EQ(0.0, torsional1.ODESlip());
+
+  torsional1.SetCoefficient(0.1);
+  torsional1.SetUsePatchRadius(false);
+  torsional1.SetPatchRadius(0.2);
+  torsional1.SetSurfaceRadius(4);
+  torsional1.SetODESlip(1.0);
+
+  EXPECT_DOUBLE_EQ(0.1, torsional1.Coefficient());
+  EXPECT_FALSE(torsional1.UsePatchRadius());
+  EXPECT_DOUBLE_EQ(0.2, torsional1.PatchRadius());
+  EXPECT_DOUBLE_EQ(4.0, torsional1.SurfaceRadius());
+  EXPECT_DOUBLE_EQ(1.0, torsional1.ODESlip());
 }

--- a/src/Surface_TEST.cc
+++ b/src/Surface_TEST.cc
@@ -182,7 +182,8 @@ TEST(DOMsurface, ToElement)
 
   EXPECT_DOUBLE_EQ(0.3, surface2.Friction()->Bullet()->Friction());
   EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->Bullet()->Friction2());
-  EXPECT_EQ(gz::math::Vector3d(2, 1, 4), surface2.Friction()->Bullet()->Fdir1());
+  EXPECT_EQ(gz::math::Vector3d(2, 1, 4),
+            surface2.Friction()->Bullet()->Fdir1());
   EXPECT_DOUBLE_EQ(1.3, surface2.Friction()->Bullet()->RollingFriction());
 
   EXPECT_DOUBLE_EQ(0.5, surface2.Friction()->Torsional()->Coefficient());

--- a/test/integration/surface_dom.cc
+++ b/test/integration/surface_dom.cc
@@ -57,12 +57,14 @@ TEST(DOMSurface, Shapes)
   EXPECT_EQ(boxCol->Surface()->Friction()->ODE()->Fdir1(),
             gz::math::Vector3d(1.2, 3.4, 5.6));
 
-  EXPECT_DOUBLE_EQ(1.6, boxCol->Surface()->Friction()->Bullet()->Friction());
-  EXPECT_DOUBLE_EQ(1.7, boxCol->Surface()->Friction()->Bullet()->Friction2());
-  EXPECT_EQ(boxCol->Surface()->Friction()->Bullet()->Fdir1(),
+  EXPECT_DOUBLE_EQ(1.6,
+      boxCol->Surface()->Friction()->BulletFriction()->Friction());
+  EXPECT_DOUBLE_EQ(1.7,
+      boxCol->Surface()->Friction()->BulletFriction()->Friction2());
+  EXPECT_EQ(boxCol->Surface()->Friction()->BulletFriction()->Fdir1(),
             gz::math::Vector3d(6.5, 4.3, 2.1));
   EXPECT_DOUBLE_EQ(1.5,
-                   boxCol->Surface()->Friction()->Bullet()->RollingFriction());
+      boxCol->Surface()->Friction()->BulletFriction()->RollingFriction());
 
   EXPECT_DOUBLE_EQ(5.1,
                    boxCol->Surface()->Friction()->Torsional()->Coefficient());

--- a/test/integration/surface_dom.cc
+++ b/test/integration/surface_dom.cc
@@ -56,4 +56,20 @@ TEST(DOMSurface, Shapes)
   EXPECT_DOUBLE_EQ(boxCol->Surface()->Friction()->ODE()->Slip2(), 5);
   EXPECT_EQ(boxCol->Surface()->Friction()->ODE()->Fdir1(),
             gz::math::Vector3d(1.2, 3.4, 5.6));
+
+  EXPECT_DOUBLE_EQ(1.6, boxCol->Surface()->Friction()->Bullet()->Friction());
+  EXPECT_DOUBLE_EQ(1.7, boxCol->Surface()->Friction()->Bullet()->Friction2());
+  EXPECT_EQ(boxCol->Surface()->Friction()->Bullet()->Fdir1(),
+            gz::math::Vector3d(6.5, 4.3, 2.1));
+  EXPECT_DOUBLE_EQ(1.5,
+                   boxCol->Surface()->Friction()->Bullet()->RollingFriction());
+
+  EXPECT_DOUBLE_EQ(5.1,
+                   boxCol->Surface()->Friction()->Torsional()->Coefficient());
+  EXPECT_FALSE(boxCol->Surface()->Friction()->Torsional()->UsePatchRadius());
+  EXPECT_DOUBLE_EQ(1.3,
+                   boxCol->Surface()->Friction()->Torsional()->PatchRadius());
+  EXPECT_DOUBLE_EQ(3.7,
+                   boxCol->Surface()->Friction()->Torsional()->SurfaceRadius());
+  EXPECT_DOUBLE_EQ(3.1, boxCol->Surface()->Friction()->Torsional()->ODESlip());
 }

--- a/test/sdf/shapes.sdf
+++ b/test/sdf/shapes.sdf
@@ -14,12 +14,27 @@
           </contact>
           <friction>
               <ode>
-                  <mu>0.6</mu>
-                  <mu2>0.7</mu2>
-                  <slip1>4</slip1>
-                  <slip2>5</slip2>
-                  <fdir1>1.2 3.4 5.6</fdir1>
+                <mu>0.6</mu>
+                <mu2>0.7</mu2>
+                <slip1>4</slip1>
+                <slip2>5</slip2>
+                <fdir1>1.2 3.4 5.6</fdir1>
               </ode>
+              <bullet>
+                <friction>1.6</friction>
+                <friction2>1.7</friction2>
+                <fdir1>6.5 4.3 2.1</fdir1>
+                <rolling_friction>1.5</rolling_friction>
+              </bullet>
+              <torsional>
+                <coefficient>5.1</coefficient>
+                <use_patch_radius>false</use_patch_radius>
+                <patch_radius>1.3</patch_radius>
+                <surface_radius>3.7</surface_radius>
+                <ode>
+                  <slip>3.1</slip>
+                </ode>
+              </torsional>
           </friction>
         </surface>
       </collision>


### PR DESCRIPTION


# 🎉 New feature

## Summary

Add Bullet, Torsional friction DOM classes

## Test it
Run the `UNIT_Surface_TEST` and `INTEGRATION_surface_dom` tests

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

