### PR TITLE
Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if (BUILD_SDF)
     endif()
   endif()
 
-  gz_configure_build(HIDE_SYMBOLS_BY_DEFAULT QUIT_IF_BUILD_ERRORS)
+  gz_configure_build(QUIT_IF_BUILD_ERRORS)
 
   gz_create_packages()
 


### PR DESCRIPTION
See https://github.com/gazebosim/gz-cmake/issues/166