### PR TITLE
In parser config test, use a filename less likely to exist

### DIFF
--- a/test/integration/parser_config.cc
+++ b/test/integration/parser_config.cc
@@ -82,7 +82,8 @@ TEST(ParserConfig, NonGlobalConfig)
 
   ASSERT_TRUE(config.FindFileCallback());
   EXPECT_EQ("test/dir2", config.FindFileCallback()("should_not_exist"));
-  EXPECT_EQ("test/dir2", sdf::findFile("should_not_exist", false, true, config));
+  EXPECT_EQ("test/dir2",
+      sdf::findFile("should_not_exist", false, true, config));
   EXPECT_EQ("test/dir2", sdf::findFile("should_not_exist", true, true, config));
 
   EXPECT_TRUE(sdf::ParserConfig::GlobalConfig().URIPathMap().empty());

--- a/test/integration/parser_config.cc
+++ b/test/integration/parser_config.cc
@@ -50,10 +50,10 @@ TEST(ParserConfig, GlobalConfig)
 
   ASSERT_TRUE(sdf::ParserConfig::GlobalConfig().FindFileCallback());
   EXPECT_EQ("test/dir2",
-      sdf::ParserConfig::GlobalConfig().FindFileCallback()("empty"));
+      sdf::ParserConfig::GlobalConfig().FindFileCallback()("should_not_exist"));
   // sdf::findFile requires explicitly enabling callbacks
-  EXPECT_EQ("test/dir2", sdf::findFile("empty", false, true));
-  EXPECT_EQ("test/dir2", sdf::findFile("empty", true, true));
+  EXPECT_EQ("test/dir2", sdf::findFile("should_not_exist", false, true));
+  EXPECT_EQ("test/dir2", sdf::findFile("should_not_exist", true, true));
 }
 
 /////////////////////////////////////////////////
@@ -81,9 +81,9 @@ TEST(ParserConfig, NonGlobalConfig)
   EXPECT_EQ(it->second.front(), testDir);
 
   ASSERT_TRUE(config.FindFileCallback());
-  EXPECT_EQ("test/dir2", config.FindFileCallback()("empty"));
-  EXPECT_EQ("test/dir2", sdf::findFile("empty", false, true, config));
-  EXPECT_EQ("test/dir2", sdf::findFile("empty", true, true, config));
+  EXPECT_EQ("test/dir2", config.FindFileCallback()("should_not_exist"));
+  EXPECT_EQ("test/dir2", sdf::findFile("should_not_exist", false, true, config));
+  EXPECT_EQ("test/dir2", sdf::findFile("should_not_exist", true, true, config));
 
   EXPECT_TRUE(sdf::ParserConfig::GlobalConfig().URIPathMap().empty());
   EXPECT_FALSE(sdf::ParserConfig::GlobalConfig().FindFileCallback());


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The file `/usr/share/empty` is not unique enough to guarantee that it does not exist, and the test seems to require that there be no file or directory with that name.

On Fedora, the directory `/usr/share/empty` is present on every single system.

I'm absolutely open to another more descriptive name for the file, but I chose `should_not_exist` to start.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.