### PR TITLE
Fix version variable in reference manual PDF filename

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,7 +15,7 @@ if (DOXYGEN_FOUND)
             ${CMAKE_BINARY_DIR}/doxygen/html/search
     COMMAND make -C ${CMAKE_BINARY_DIR}/doxygen/latex
     COMMAND mv ${CMAKE_BINARY_DIR}/doxygen/latex/refman.pdf
-    ${CMAKE_BINARY_DIR}/doxygen/latex/sdf-${SDF_VERSION_FULL}.pdf
+    ${CMAKE_BINARY_DIR}/doxygen/latex/sdf-${PROJECT_VERSION_FULL}.pdf
 
     COMMENT "Generating API documentation with Doxygen" VERBATIM)
 endif()


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The variable `SDF_VERSION_FULL` is a C preprocessor macro which is set to the value of the CMake variable `PROJECT_VERSION_FULL` in `config.hh.in`. It is not defined as a CMake variable itself, and currently evaluates to an empty string resulting in `refman.pdf` being renamed to `sdf-.pdf`.

https://github.com/gazebosim/sdformat/blob/e7d7cefc8a4775c6bf0287be06da5c4c6cf9c493/include/sdf/config.hh.in#L43

```
$ grep SDF_VERSION_FULL . -R
./src/gz.cc:  return _strdup(SDF_VERSION_FULL);
./src/gz.cc:  return strdup(SDF_VERSION_FULL);
./src/gz_TEST.cc:  return " --force-version " + std::string(SDF_VERSION_FULL);
./doc/CMakeLists.txt:    ${CMAKE_BINARY_DIR}/doxygen/latex/sdf-${SDF_VERSION_FULL}.pdf
./include/sdf/config.hh.in:#define SDF_VERSION_FULL "${PROJECT_VERSION_FULL}"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.