### PR TITLE
Fix find Python3 logic and macOS workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,11 +19,11 @@ jobs:
     # Workaround for https://github.com/actions/setup-python/issues/577
     - name: Clean up python binaries
       run: |
-        rm -f /usr/local/bin/2to3*;
-        rm -f /usr/local/bin/idle3*;
-        rm -f /usr/local/bin/pydoc3*;
-        rm -f /usr/local/bin/python3*;
-        rm -f /usr/local/bin/python3*-config;
+        rm -f $(brew --prefix)/bin/2to3*;
+        rm -f $(brew --prefix)/bin/idle3*;
+        rm -f $(brew --prefix)/bin/pydoc3*;
+        rm -f $(brew --prefix)/bin/python3*;
+        rm -f $(brew --prefix)/bin/python3*-config;
     - name: Install base dependencies
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
@@ -50,8 +50,8 @@ jobs:
     - name: cmake
       working-directory: build
       run: |
-        export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python
-        cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/${PACKAGE}/HEAD
+        export PYTHONPATH=$PYTHONPATH:$(brew --prefix)/lib/python
+        cmake .. -DCMAKE_INSTALL_PREFIX=$(brew --prefix)/Cellar/${PACKAGE}/HEAD
     - run: make
       working-directory: build
     - run: make test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,7 +51,7 @@ jobs:
       working-directory: build
       run: |
         export PYTHONPATH=$PYTHONPATH:$(brew --prefix)/lib/python
-        cmake .. -DCMAKE_INSTALL_PREFIX=$(brew --prefix)/Cellar/${PACKAGE}/HEAD
+        cmake .. -DCMAKE_INSTALL_PREFIX=$(brew --prefix)/Cellar/${PACKAGE}/HEAD -DPython3_EXECUTABLE=$(brew --prefix)/bin/python3
     - run: make
       working-directory: build
     - run: make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,32 @@ if (BUILD_SDF)
   set(GZ_TOOLS_VER 2)
 
   #################################################
+  # Find python
+  if (SKIP_PYBIND11)
+    message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  else()
+    find_package(Python3 REQUIRED
+      COMPONENTS Interpreter
+      OPTIONAL_COMPONENTS Development
+    )
+    if (NOT Python3_Development_FOUND)
+      GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
+    else()
+      set(PYBIND11_PYTHON_VERSION 3)
+      find_package(pybind11 2.4 CONFIG QUIET)
+
+      if (pybind11_FOUND)
+        message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
+      else()
+        GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
+        message (STATUS "Searching for pybind11 - not found.")
+      endif()
+    endif()
+  endif()
+
+  #################################################
   # Copied from catkin/cmake/empy.cmake
-  include(GzPython)
   function(find_python_module module)
     # cribbed from http://www.cmake.org/pipermail/cmake/2011-January/041666.html
     string(TOUPPER ${module} module_upper)
@@ -120,29 +144,6 @@ if (BUILD_SDF)
   # Find gz utils
   gz_find_package(gz-utils3 REQUIRED COMPONENTS cli)
   set(GZ_UTILS_VER ${gz-utils3_VERSION_MAJOR})
-
-  ########################################
-  # Python interfaces
-  if (NOT PYTHON3_FOUND)
-    GZ_BUILD_ERROR("Python is missing - Needed to build/embed xml schemas")
-  else()
-    message (STATUS "Searching for Python - found version ${Python3_VERSION}.")
-
-    if (SKIP_PYBIND11)
-      message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
-    else()
-      set(PYBIND11_PYTHON_VERSION 3)
-      find_package(pybind11 2.4 QUIET)
-
-      if (${pybind11_FOUND})
-        find_package(Python3 ${GZ_PYTHON_VERSION} REQUIRED COMPONENTS Development)
-        message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
-      else()
-        GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
-        message (STATUS "Searching for pybind11 - not found.")
-      endif()
-    endif()
-  endif()
 
   gz_configure_build(QUIT_IF_BUILD_ERRORS)
 


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to https://github.com/gazebosim/gz-sim/issues/2249 and https://github.com/osrf/homebrew-simulation/pull/2545

## Summary

The homebrew formula for `sdformat15` was updated in https://github.com/osrf/homebrew-simulation/pull/2545 to explicitly set the `Python3_EXECUTABLE` cmake variable. This works when building `sdformat15` on its own ([![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat15-install_bottle-homebrew-amd64&build=46)](https://build.osrfoundation.org/view/gz-ionic/job/sdformat15-install_bottle-homebrew-amd64/46/)), but it fails when building `sdformat15` from source as a dependency of `gz-physics8` ([![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics8-install_bottle-homebrew-amd64&build=48)](https://build.osrfoundation.org/view/gz-ionic/job/gz_physics8-install_bottle-homebrew-amd64/48/)) due to the presence of an additional python version on the system.

This pull request changes the logic for finding python and moves it earlier. It's mostly based on the approach in [gz-sim](https://github.com/gazebosim/gz-sim/blob/f28f6797c0c0e8d9f6e1bb8498263ed4e1a43e0b/CMakeLists.txt#L204-L226) with the following changes:

* Python is required to generate the `Embedded.cc` file, so find the Python3 Interpreter as `REQUIRED` even if `SKIP_PYBIND11` is set. When bindings are not skipped, find `Development` as an optional component to preserve existing behavior that just warns if it is unable to build bindings. I've tested this with https://github.com/osrf/homebrew-simulation/commit/3a5b29ef247817d3457f826f37662ff7042a95c6 using `ci_matching_branch/` and it fixes the `sdformat15` build as a dependency of `gz-physics8` ([![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics8-install_bottle-homebrew-amd64&build=47)](https://build.osrfoundation.org/view/gz-ionic/job/gz_physics8-install_bottle-homebrew-amd64/47/)).

I've targeted `main` since it's easiest to confirm the failure and fix using these CI jobs, and I'll backport once this is merged.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
