### PR TITLE
Backport #1367 to Harmonic: Fix find Python3 logic and macOS workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,11 +19,11 @@ jobs:
     # Workaround for https://github.com/actions/setup-python/issues/577
     - name: Clean up python binaries
       run: |
-        rm -f /usr/local/bin/2to3*;
-        rm -f /usr/local/bin/idle3*;
-        rm -f /usr/local/bin/pydoc3*;
-        rm -f /usr/local/bin/python3*;
-        rm -f /usr/local/bin/python3*-config;
+        rm -f $(brew --prefix)/bin/2to3*;
+        rm -f $(brew --prefix)/bin/idle3*;
+        rm -f $(brew --prefix)/bin/pydoc3*;
+        rm -f $(brew --prefix)/bin/python3*;
+        rm -f $(brew --prefix)/bin/python3*-config;
     - name: Install base dependencies
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
@@ -50,8 +50,8 @@ jobs:
     - name: cmake
       working-directory: build
       run: |
-        export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python
-        cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/${PACKAGE}/HEAD
+        export PYTHONPATH=$PYTHONPATH:$(brew --prefix)/lib/python
+        cmake .. -DCMAKE_INSTALL_PREFIX=$(brew --prefix)/Cellar/${PACKAGE}/HEAD -DPython3_EXECUTABLE=$(brew --prefix)/bin/python3
     - run: make
       working-directory: build
     - run: make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,32 @@ if (BUILD_SDF)
   set(GZ_TOOLS_VER 2)
 
   #################################################
+  # Find python
+  if (SKIP_PYBIND11)
+    message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  else()
+    find_package(Python3 REQUIRED
+      COMPONENTS Interpreter
+      OPTIONAL_COMPONENTS Development
+    )
+    if (NOT Python3_Development_FOUND)
+      GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
+    else()
+      set(PYBIND11_PYTHON_VERSION 3)
+      find_package(pybind11 2.4 CONFIG QUIET)
+
+      if (pybind11_FOUND)
+        message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
+      else()
+        GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
+        message (STATUS "Searching for pybind11 - not found.")
+      endif()
+    endif()
+  endif()
+
+  #################################################
   # Copied from catkin/cmake/empy.cmake
-  include(GzPython)
   function(find_python_module module)
     # cribbed from http://www.cmake.org/pipermail/cmake/2011-January/041666.html
     string(TOUPPER ${module} module_upper)
@@ -120,29 +144,6 @@ if (BUILD_SDF)
   # Find gz utils
   gz_find_package(gz-utils2 REQUIRED COMPONENTS cli)
   set(GZ_UTILS_VER ${gz-utils2_VERSION_MAJOR})
-
-  ########################################
-  # Python interfaces
-  if (NOT PYTHON3_FOUND)
-    GZ_BUILD_ERROR("Python is missing - Needed to build/embed xml schemas")
-  else()
-    message (STATUS "Searching for Python - found version ${Python3_VERSION}.")
-
-    if (SKIP_PYBIND11)
-      message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
-    else()
-      set(PYBIND11_PYTHON_VERSION 3)
-      find_package(pybind11 2.4 QUIET)
-
-      if (${pybind11_FOUND})
-        find_package(Python3 ${GZ_PYTHON_VERSION} REQUIRED COMPONENTS Development)
-        message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
-      else()
-        GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
-        message (STATUS "Searching for pybind11 - not found.")
-      endif()
-    endif()
-  endif()
 
   gz_configure_build(HIDE_SYMBOLS_BY_DEFAULT QUIT_IF_BUILD_ERRORS)
 


### PR DESCRIPTION
# Backport

Backport #1367 to Harmonic. The patch applies cleanly to `sdf14` but will require small modifications to backport to `sdf13` since Python3 was not required in Garden.

## Original commit message:

Fix find Python3 logic and macOS workflow

* Find Python3 with find_package instead of GzPython, adapting the approach from gz-sim.
* macos workflow: use brew --prefix, not /usr/local
* macos workflow: set Python3_EXECUTABLE cmake var

**Note to maintainers**: Remember to use **Rebase-and-Merge**.

