### PR TITLE
Copy 1.11 spec to 1.12 for libsdformat15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project (sdformat15 VERSION 15.0.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software
-set (SDF_PROTOCOL_VERSION 1.11)
+set (SDF_PROTOCOL_VERSION 1.12)
 
 OPTION(SDFORMAT_DISABLE_CONSOLE_LOGFILE "Disable the sdformat console logfile" OFF)
 

--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,14 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## libsdformat 14.x to 15.x
+
+### Additions
+
+1. **New SDFormat specification version 1.12**
+    + Details about the 1.11 to 1.12 transition are explained below in this same
+      document
+
 ## libsdformat 13.x to 14.x
 
 ### Additions
@@ -575,6 +583,8 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 1. **Lump:: prefix in link names**
     + Changed to `_fixed_joint_lump__` to avoid confusion with scoped names
     + [BitBucket pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/245)
+
+## SDFormat specification 1.11 to 1.12
 
 ## SDFormat specification 1.10 to 1.11
 

--- a/sdf/1.12/1_11.convert
+++ b/sdf/1.12/1_11.convert
@@ -1,0 +1,2 @@
+<convert name="sdf">
+</convert> <!-- End SDF -->

--- a/sdf/1.12/CMakeLists.txt
+++ b/sdf/1.12/CMakeLists.txt
@@ -1,0 +1,89 @@
+set (sdfs
+  actor.sdf
+  air_pressure.sdf
+  air_speed.sdf
+  altimeter.sdf
+  atmosphere.sdf
+  audio_source.sdf
+  audio_sink.sdf
+  battery.sdf
+  box_shape.sdf
+  camera.sdf
+  capsule_shape.sdf
+  collision.sdf
+  contact.sdf
+  cylinder_shape.sdf
+  ellipsoid_shape.sdf
+  frame.sdf
+  forcetorque.sdf
+  geometry.sdf
+  gps.sdf
+  gripper.sdf
+  gui.sdf
+  heightmap_shape.sdf
+  image_shape.sdf
+  imu.sdf
+  inertial.sdf
+  joint.sdf
+  lidar.sdf
+  light.sdf
+  light_state.sdf
+  link.sdf
+  link_state.sdf
+  logical_camera.sdf
+  magnetometer.sdf
+  material.sdf
+  mesh_shape.sdf
+  mimic.sdf
+  model.sdf
+  model_state.sdf
+  navsat.sdf
+  noise.sdf
+  particle_emitter.sdf
+  physics.sdf
+  plane_shape.sdf
+  plugin.sdf
+  polyline_shape.sdf
+  population.sdf
+  pose.sdf
+  projector.sdf
+  ray.sdf
+  rfidtag.sdf
+  rfid.sdf
+  road.sdf
+  root.sdf
+  scene.sdf
+  sensor.sdf
+  spherical_coordinates.sdf
+  sphere_shape.sdf
+  sonar.sdf
+  state.sdf
+  surface.sdf
+  transceiver.sdf
+  visual.sdf
+  world.sdf
+)
+
+set (SDF_SCHEMA)
+
+foreach(FIL ${sdfs})
+  get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
+  get_filename_component(FIL_WE ${FIL} NAME_WE)
+
+  list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd")
+
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
+    ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${ABS_FIL}
+    COMMENT "Running xml schema compiler on ${FIL}"
+    VERBATIM)
+endforeach()
+
+add_custom_target(schema1_12 ALL DEPENDS ${SDF_SCHEMA})
+
+set_source_files_properties(${SDF_SCHEMA} PROPERTIES GENERATED TRUE)
+
+install(FILES 1_11.convert ${sdfs} DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/sdformat${PROJECT_VERSION_MAJOR}/1.12)
+install(FILES ${SDF_SCHEMA} DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/sdformat${PROJECT_VERSION_MAJOR}/1.12)

--- a/sdf/1.12/actor.sdf
+++ b/sdf/1.12/actor.sdf
@@ -1,0 +1,86 @@
+<!-- Actor -->
+<element name="actor" required="*">
+  <description>A special kind of model which can have a scripted motion. This includes both global waypoint type animations and skeleton animations.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>A unique name for the actor.</description>
+  </attribute>
+
+  <include filename="pose.sdf" required="0"/>
+
+  <element name="skin" required="0">
+    <description>Skin file which defines a visual and the underlying skeleton which moves it.</description>
+
+    <element name="filename" type="string" default="__default__" required="1">
+      <description>Path to skin file, accepted formats: COLLADA, BVH.</description>
+    </element>
+
+    <element name="scale" type="double" default="1.0" required="0">
+      <description>Scale the skin's size.</description>
+    </element>
+  </element> <!-- End Skin -->
+
+  <element name="animation" required="*">
+    <description>Animation file defines an animation for the skeleton in the skin. The skeleton must be compatible with the skin skeleton.</description>
+
+    <attribute name="name" type="string" default="__default__" required="1">
+      <description>Unique name for animation.</description>
+    </attribute>
+
+    <element name="filename" type="string" default="__default__" required="1">
+      <description>Path to animation file. Accepted formats: COLLADA, BVH.</description>
+    </element>
+    <element name="scale" type="double" default="1.0" required="0">
+      <description>Scale for the animation skeleton.</description>
+    </element>
+    <element name="interpolate_x" type="bool" default="false" required="0">
+      <description>Set to true so the animation is interpolated on X.</description>
+    </element>
+  </element> <!-- End Animation -->
+
+  <element name="script" required="1">
+    <description>Adds scripted trajectories to the actor.</description>
+
+    <element name="loop" type="bool" default="true" required="0">
+      <description>Set this to true for the script to be repeated in a loop. For a fluid continuous motion, make sure the last waypoint matches the first one.</description>
+    </element>
+
+    <element name="delay_start" type="double" default="0.0" required="0">
+      <description>This is the time to wait before starting the script. If running in a loop, this time will be waited before starting each cycle.</description>
+    </element>
+
+    <element name="auto_start" type="bool" default="true" required="0">
+      <description>Set to true if the animation should start as soon as the simulation starts playing. It is useful to set this to false if the animation should only start playing only when triggered by a plugin, for example.</description>
+    </element>
+
+    <element name="trajectory" required="*">
+      <description>The trajectory contains a series of keyframes to be followed.</description>
+      <attribute name="id" type="int" default="0" required="1">
+        <description>Unique id for a trajectory.</description>
+      </attribute>
+
+      <attribute name="type" type="string" default="__default__" required="1">
+        <description>If it matches the type of an animation, they will be played at the same time.</description>
+      </attribute>
+
+      <attribute name="tension" type="double" default="0.0" required="0" min="0.0" max="1.0">
+        <description>The tension of the trajectory spline. The default value of zero equates to a Catmull-Rom spline, which may also cause the animation to overshoot keyframes. A value of one will cause the animation to stick to the keyframes.</description>
+      </attribute>
+
+      <element name="waypoint" required="*">
+        <description>Each point in the trajectory.</description>
+        <element name="time" type="double" default="0.0" required="1">
+          <description>The time in seconds, counted from the beginning of the script, when the pose should be reached.</description>
+        </element>
+        <element name="pose" type="pose" default="0 0 0 0 0 0" required="1">
+          <description>The pose which should be reached at the given time.</description>
+        </element> <!-- End Pose -->
+      </element> <!-- End Waypoint -->
+    </element> <!-- End Trajectory -->
+  </element> <!-- End Script -->
+
+  <include filename="link.sdf" required="+"/>
+  <include filename="joint.sdf" required="*"/>
+  <include filename="plugin.sdf" required="*"/>
+
+</element> <!-- End Actor -->

--- a/sdf/1.12/air_pressure.sdf
+++ b/sdf/1.12/air_pressure.sdf
@@ -1,0 +1,15 @@
+<element name="air_pressure" required="0">
+  <description>These elements are specific to an air pressure sensor.</description>
+
+  <element name="reference_altitude" type="double" default="0.0" required="0">
+    <description>The initial altitude in meters. This value can be used by a sensor implementation to augment the altitude of the sensor. For example, if you are using simulation instead of creating a 1000 m mountain model on which to place your sensor, you could instead set this value to 1000 and place your model on a ground plane with a Z height of zero.</description>
+  </element>
+
+  <element name="pressure" required="0">
+    <description>
+      Noise parameters for the pressure data.
+    </description>
+    <include filename="noise.sdf" required="0"/>
+  </element>
+
+</element>

--- a/sdf/1.12/air_speed.sdf
+++ b/sdf/1.12/air_speed.sdf
@@ -1,0 +1,11 @@
+<element name="air_speed" required="0">
+  <description>These elements are specific to an air speed sensor. This sensor determines speed based on the differential between static and dynamic pressure.</description>
+
+  <element name="pressure" required="0">
+    <description>
+      Noise parameters for the pressure data.
+    </description>
+    <include filename="noise.sdf" required="0"/>
+  </element>
+
+</element>

--- a/sdf/1.12/altimeter.sdf
+++ b/sdf/1.12/altimeter.sdf
@@ -1,0 +1,18 @@
+<element name="altimeter" required="0">
+  <description>These elements are specific to an altimeter sensor.</description>
+
+  <element name="vertical_position" required="0">
+    <description>
+      Noise parameters for vertical position
+    </description>
+    <include filename="noise.sdf" required="0"/>
+  </element>
+
+  <element name="vertical_velocity" required="0">
+    <description>
+      Noise parameters for vertical velocity
+    </description>
+    <include filename="noise.sdf" required="0"/>
+  </element>
+
+</element>

--- a/sdf/1.12/atmosphere.sdf
+++ b/sdf/1.12/atmosphere.sdf
@@ -1,0 +1,21 @@
+<!-- Atmosphere -->
+<element name="atmosphere" required="1">
+  <description>The atmosphere tag specifies the type and properties of the atmosphere model.</description>
+
+  <attribute name="type" type="string" default="adiabatic" required="1">
+    <description>The type of the atmosphere engine. Current options are adiabatic.  Defaults to adiabatic if left unspecified.</description>
+  </attribute>
+
+  <element name="temperature" type="double" default="288.15" required="0">
+    <description>Temperature at sea level in kelvins.</description>
+  </element>
+
+  <element name="pressure" type="double" default="101325" required="0">
+    <description>Pressure at sea level in pascals.</description>
+  </element>
+
+  <element name="temperature_gradient" type="double" default="-0.0065" required="0">
+    <description>Temperature gradient with respect to increasing altitude at sea level in units of K/m.</description>
+  </element>
+
+</element> <!-- Atmosphere -->

--- a/sdf/1.12/audio_sink.sdf
+++ b/sdf/1.12/audio_sink.sdf
@@ -1,0 +1,4 @@
+<!-- Audio Sink -->
+<element name="audio_sink" required="*">
+  <description>An audio sink.</description>
+</element>

--- a/sdf/1.12/audio_source.sdf
+++ b/sdf/1.12/audio_source.sdf
@@ -1,0 +1,30 @@
+<!-- Audio Source -->
+<element name="audio_source" required="*">
+  <description>An audio source.</description>
+
+  <element name="uri" type="string" default="__default__" required="1">
+    <description>URI of the audio media.</description>
+  </element>
+
+  <element name="pitch" type="double" default="1.0" required="0">
+    <description>Pitch for the audio media, in Hz</description>
+  </element>
+
+  <element name="gain" type="double" default="1.0" required="0">
+    <description>Gain for the audio media, in dB.</description>
+  </element>
+
+  <element name="contact" required="0">
+    <description>List of collision objects that will trigger audio playback.</description>
+    <element name="collision" type="string" default="__default__" required="+">
+      <description>Name of child collision element that will trigger audio playback.</description>
+    </element>
+  </element>
+
+  <element name="loop" type="bool" default="false" required="0">
+    <description>True to make the audio source loop playback.</description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+
+</element>

--- a/sdf/1.12/battery.sdf
+++ b/sdf/1.12/battery.sdf
@@ -1,0 +1,12 @@
+<!-- Battery -->
+<element name="battery" required="*">
+  <description>Description of a battery.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Unique name for the battery.</description>
+  </attribute>
+
+  <element name="voltage" type="double" default="0.0" required="1">
+    <description>Initial voltage in volts.</description>
+  </element>
+</element>

--- a/sdf/1.12/box_shape.sdf
+++ b/sdf/1.12/box_shape.sdf
@@ -1,0 +1,6 @@
+<element name="box" required="0">
+  <description>Box shape</description>
+  <element name="size" type="vector3" default="1 1 1" required="1">
+    <description>The three side lengths of the box. The origin of the box is in its geometric center (inside the center of the box).</description>
+  </element>
+</element>

--- a/sdf/1.12/camera.sdf
+++ b/sdf/1.12/camera.sdf
@@ -1,0 +1,230 @@
+<element name="camera" required="0">
+  <description>These elements are specific to camera sensors.</description>
+
+  <attribute name="name" type="string" default="__default__" required="0">
+    <description>An optional name for the camera.</description>
+  </attribute>
+
+  <element name="triggered" type="bool" default="false" required="0">
+    <description>If the camera will be triggered by a topic</description>
+  </element> <!-- End Triggered -->
+
+  <element name="camera_info_topic" type="string" default="__default__" required="0">
+    <description>Name of the camera info</description>
+  </element> <!-- End Trigger_Topic -->
+
+  <element name="trigger_topic" type="string" default="" required="0">
+    <description>Name of the topic that will trigger the camera if enabled</description>
+  </element> <!-- End Trigger_Topic -->
+
+  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+    <description>Horizontal field of view</description>
+  </element> <!-- End Horizontal_FOV -->
+
+  <element name="image" required="1">
+    <description>The image size in pixels and format.</description>
+    <element name="width" type="int" default="320" required="1">
+      <description>Width in pixels</description>
+    </element>
+    <element name="height" type="int" default="240" required="1">
+      <description>Height in pixels </description>
+    </element>
+    <element name="format" type="string" default="R8G8B8" required="0">
+      <description>(L8|L16|R_FLOAT16|R_FLOAT32|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)</description>
+    </element>
+    <element name="anti_aliasing" type="int" default="4" required="0">
+      <description>Value used for anti-aliasing</description>
+    </element>
+  </element> <!-- End Image -->
+
+  <element name="clip" required="1">
+    <description>The near and far clip planes. Objects closer or farther than these planes are not rendered.</description>
+
+    <element name="near" type="double" default=".1" min="0.0" required="1">
+      <description>Near clipping plane</description>
+    </element>
+
+    <element name="far" type="double" default="100" min="0.1" required="1">
+      <description>Far clipping plane</description>
+    </element>
+  </element> <!-- End Clip -->
+
+  <element name="save" required="0">
+    <description>Enable or disable saving of camera frames.</description>
+    <attribute name="enabled" type="bool" default="false" required="1">
+      <description>True = saving enabled</description>
+    </attribute>
+    <element name="path" type="string" default="__default__" required="1">
+      <description>The path name which will hold the frame data. If path name is relative, then directory is relative to current working directory.</description>
+    </element>
+  </element> <!-- End Save -->
+
+  <element name="depth_camera" required="0">
+    <description>Depth camera parameters</description>
+    <element name="output" type="string" default="depths" required="1">
+      <description>Type of output</description>
+    </element>
+    <element name="clip" required="0">
+      <description>The near and far clip planes. Objects closer or farther than these planes are not detected by the depth camera.</description>
+
+      <element name="near" type="double" default=".1" min="0.0" required="0">
+        <description>Near clipping plane for depth camera</description>
+      </element>
+
+      <element name="far" type="double" default="10.0" min="0.1" required="0">
+        <description>Far clipping plane for depth camera</description>
+      </element>
+    </element>
+  </element> <!-- End depth_camera -->
+
+  <element name="segmentation_type" type="string" default="semantic" required="0">
+    <description>
+      The segmentation type of the segmentation camera. Valid options are:
+        - semantic: Semantic segmentation, which provides 2 images:
+                    1. A grayscale image, with the pixel values representing the label of an object
+                    2. A colored image, with the pixel values being a unique color for each label
+
+        - panoptic | instance: Panoptic segmentation, which provides an image where each pixel
+                              has 1 channel for label value of the object and 2 channels for the
+                              number of the instances of that label, and a colored image which its
+                              pixels have a unique color for each instance.
+    </description>
+  </element>  <!-- End segmentation_type -->
+
+  <element name="box_type" type="string" default="2d" required="0">
+    <description>
+      The boundingbox type of the boundingbox camera. Valid options are:
+        - 2d | visible_2d | visible_box_2d: a visible 2d box mode which provides axis aligned 2d boxes
+                                            on the visible parts of the objects
+
+        - full_2d | full_box_2d: a full 2d box mode which provides axis aligned 2d boxes that fills the
+                                 object dimentions, even if it has an occluded part
+
+        - 3d: a 3d mode which provides oriented 3d boxes
+    </description>
+  </element> <!-- End box_type -->
+
+  <element name="noise" required="0">
+    <description>The properties of the noise model that should be applied to generated images</description>
+    <element name="type" type="string" default="gaussian" required="1">
+      <description>The type of noise.  Currently supported types are: "gaussian" (draw additive noise values independently for each pixel from a Gaussian distribution).</description>
+    </element>
+    <element name="mean" type="double" default="0.0" required="0">
+      <description>For type "gaussian," the mean of the Gaussian distribution from which noise values are drawn.</description>
+    </element>
+    <element name="stddev" type="double" default="0.0" required="0">
+      <description>For type "gaussian," the standard deviation of the Gaussian distribution from which noise values are drawn.</description>
+    </element>
+  </element> <!-- End Noise -->
+
+  <element name="distortion" required="0">
+    <description>Lens distortion to be applied to camera images. See http://en.wikipedia.org/wiki/Distortion_(optics)#Software_correction</description>
+    <element name="k1" type="double" default="0.0" required="0">
+      <description>The radial distortion coefficient k1</description>
+    </element>
+    <element name="k2" type="double" default="0.0" required="0">
+      <description>The radial distortion coefficient k2</description>
+    </element>
+    <element name="k3" type="double" default="0.0" required="0">
+      <description>The radial distortion coefficient k3</description>
+    </element>
+    <element name="p1" type="double" default="0.0" required="0">
+      <description>The tangential distortion coefficient p1</description>
+    </element>
+    <element name="p2" type="double" default="0.0" required="0">
+      <description>The tangential distortion coefficient p2</description>
+    </element>
+    <element name="center" type="vector2d" default="0.5 0.5" required="0">
+      <description>The distortion center or principal point</description>
+    </element>
+  </element> <!-- End Distortion -->
+
+  <element name="lens" required="0">
+    <description>Lens projection description</description>
+
+    <element name="type" type="string" default="stereographic" required="1">
+      <description>Type of the lens mapping. Supported values are gnomonical, stereographic, equidistant, equisolid_angle, orthographic, custom. For gnomonical (perspective) projection, it is recommended to specify a horizontal_fov of less than or equal to 90°</description>
+    </element>
+    <element name="scale_to_hfov" type="bool" default="true" required="1">
+      <description>If true the image will be scaled to fit horizontal FOV, otherwise it will be shown according to projection type parameters</description>
+    </element>
+
+    <element name="custom_function" required="0">
+      <description>Definition of custom mapping function in a form of r=c1*f*fun(theta/c2 + c3). See https://en.wikipedia.org/wiki/Fisheye_lens#Mapping_function</description>
+      <element name="c1" type="double" default="1" required="0">
+        <description>Linear scaling constant</description>
+      </element>
+      <element name="c2" type="double" default="1" required="0">
+        <description>Angle scaling constant</description>
+      </element>
+      <element name="c3" type="double" default="0" required="0">
+        <description>Angle offset constant</description>
+      </element>
+      <element name="f" type="double" default="1" required="0">
+        <description>Focal length of the optical system. Note: It's not a focal length of the lens in a common sense! This value is ignored if 'scale_to_fov' is set to true</description>
+      </element>
+      <element name="fun" type="string" default="tan" required="1">
+        <description>Possible values are 'sin', 'tan' and 'id'</description>
+      </element>
+    </element> <!-- End Custom Function -->
+
+    <element name="cutoff_angle" type="double" default="1.5707" min="0.0" max="3.141592653" required="0">
+      <description>Everything outside of the specified angle will be hidden, 90° by default</description>
+    </element>
+
+    <element name="env_texture_size" type="int" default="256" min="4" max="2048" required="0">
+      <description>Resolution of the environment cube map used to draw the world</description>
+    </element>
+
+    <element name="intrinsics" required="0">
+      <description>Camera intrinsic parameters for setting a custom perspective projection matrix (cannot be used with WideAngleCamera since this class uses image stitching from 6 different cameras for achieving a wide field of view). The focal lengths can be computed using focal_length_in_pixels = (image_width_in_pixels * 0.5) / tan(field_of_view_in_degrees * 0.5 * PI/180)</description>
+      <element name="fx" type="double" default="277" required="1">
+        <description>X focal length (in pixels, overrides horizontal_fov)</description>
+      </element>
+      <element name="fy" type="double" default="277" required="1">
+        <description>Y focal length (in pixels, overrides horizontal_fov)</description>
+      </element>
+      <element name="cx" type="double" default="160" required="1">
+        <description>X principal point (in pixels)</description>
+      </element>
+      <element name="cy" type="double" default="120" required="1">
+        <description>Y principal point (in pixels)</description>
+      </element>
+      <element name="s" type="double" default="0.0" required="1">
+        <description>XY axis skew</description>
+      </element>
+    </element> <!-- End Intrinsics -->
+
+    <element name="projection" required="0">
+    <description>Camera projection matrix P for overriding camera intrinsic matrix K values so that users can configure P independently of K. This is useful when working with stereo cameras where P may be different from K due to the transform between the two cameras.</description>
+      <element name="p_fx" type="double" default="277" required="0">
+        <description>X focal length for projection matrix(in pixels, overrides fx)</description>
+      </element>
+      <element name="p_fy" type="double" default="277" required="0">
+        <description>Y focal length for projection matrix(in pixels, overrides fy)</description>
+      </element>
+      <element name="p_cx" type="double" default="160" required="0">
+        <description>X principal point for projection matrix(in pixels, overrides cx)</description>
+      </element>
+      <element name="p_cy" type="double" default="120" required="0">
+        <description>Y principal point for projection matrix(in pixels, overrides cy)</description>
+      </element>
+      <element name="tx" type="double" default="0.0" required="0">
+        <description>X translation for projection matrix (in pixels)</description>
+      </element>
+      <element name="ty" type="double" default="0.0" required="0">
+        <description>Y translation for projection matrix (in pixels)</description>
+      </element>
+    </element> <!-- End Projection -->
+  </element> <!-- End Lens -->
+
+  <element name="visibility_mask" type="unsigned int" default="4294967295" required="0">
+    <description><![CDATA[Visibility mask of a camera. When (camera's visibility_mask & visual's visibility_flags) evaluates to non-zero, the visual will be visible to the camera.]]></description>
+  </element>
+
+  <element name="optical_frame_id" type="string" default="" required="0">
+    <description>An optional frame id name to be used in the camera_info message header.</description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+</element> <!-- End Camera -->

--- a/sdf/1.12/capsule_shape.sdf
+++ b/sdf/1.12/capsule_shape.sdf
@@ -1,0 +1,9 @@
+<element name="capsule" required="0">
+  <description>Capsule shape</description>
+  <element name="radius" type="double" default="0.5" required="1">
+    <description>Radius of the capsule</description>
+  </element>
+  <element name="length" type="double" default="1" required="1">
+    <description>Length of the cylindrical portion of the capsule along the z axis</description>
+  </element>
+</element>

--- a/sdf/1.12/collision.sdf
+++ b/sdf/1.12/collision.sdf
@@ -1,0 +1,34 @@
+<!-- Collision -->
+<element name="collision" required="*">
+  <description>The collision properties of a link. Note that this can be different from the visual properties of a link, for example, simpler collision models are often used to reduce computation time.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Unique name for the collision element within the scope of the parent link.</description>
+  </attribute>
+
+  <element name="laser_retro" type="double" default="0" required="0">
+    <description>intensity value returned by laser sensor.</description>
+  </element>
+
+  <element name="max_contacts" type="int" default="10" required="0">
+    <description>Maximum number of contacts allowed between two entities. This value overrides the max_contacts element defined in physics.</description>
+  </element>
+
+  <element name="density" type="double" default="1000.0" required="0">
+    <description>
+      Mass Density of the collision geometry. 
+      This is used to determine mass and inertia values during automatic calculation.
+      Default is the density of water 1000 kg/m^3.
+    </description>
+  </element>
+
+  <element name="auto_inertia_params" required="0">
+    <description>Parent tag to hold user-defined custom params for mesh inertia calculator</description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+
+  <include filename="geometry.sdf" required="1"/>
+  <include filename="surface.sdf" required="0"/>
+
+</element> <!-- End Collision -->

--- a/sdf/1.12/contact.sdf
+++ b/sdf/1.12/contact.sdf
@@ -1,0 +1,12 @@
+<element name="contact" required="0">
+  <description>These elements are specific to the contact sensor.</description>
+
+  <element name="collision" type="string" default="__default__" required="1">
+    <description>name of the collision element within a link that acts as the contact sensor.</description>
+  </element> <!-- End Collision -->
+
+  <element name="topic" type="string" default="__default_topic__" required="1">
+    <description>Topic on which contact data is published.</description>
+  </element>
+
+</element> <!-- End Contact -->

--- a/sdf/1.12/cylinder_shape.sdf
+++ b/sdf/1.12/cylinder_shape.sdf
@@ -1,0 +1,9 @@
+<element name="cylinder" required="0">
+  <description>Cylinder shape</description>
+  <element name="radius" type="double" default="1" required="1">
+    <description>Radius of the cylinder</description>
+  </element>
+  <element name="length" type="double" default="1" required="1">
+    <description>Length of the cylinder along the z axis</description>
+  </element>
+</element>

--- a/sdf/1.12/ellipsoid_shape.sdf
+++ b/sdf/1.12/ellipsoid_shape.sdf
@@ -1,0 +1,6 @@
+<element name="ellipsoid" required="0">
+  <description>Ellipsoid shape</description>
+  <element name="radii" type="vector3" default="1 1 1" required="1">
+    <description>The three radii of the ellipsoid. The origin of the ellipsoid is in its geometric center (inside the center of the ellipsoid).</description>
+  </element>
+</element>

--- a/sdf/1.12/forcetorque.sdf
+++ b/sdf/1.12/forcetorque.sdf
@@ -1,0 +1,54 @@
+<element name="force_torque" required="0">
+  <description>These elements are specific to the force torque sensor.</description>
+  <element name="frame" type="string" default="child" required="0">
+    <description>
+      Frame in which to report the wrench values. Currently supported frames are:
+        "parent" report the wrench expressed in the orientation of the parent link frame,
+        "child" report the wrench expressed in the orientation of the child link frame,
+        "sensor" report the wrench expressed in the orientation of the joint sensor frame.
+      Note that for each option the point with respect to which the
+      torque component of the wrench is expressed is the joint origin.
+    </description>
+  </element>
+  <element name="measure_direction" type="string" default="child_to_parent" required="0">
+    <description>
+      Direction of the wrench measured by the sensor. The supported options are:
+        "parent_to_child" if the measured wrench is the one applied by the parent link on the child link,
+        "child_to_parent" if the measured wrench is the one applied by the child link on the parent link.
+    </description>
+  </element>
+
+  <element name="force" required="0">
+    <description>These elements are specific to measurement-frame force,
+    which is expressed in Newtons</description>
+    <element name="x" required="0">
+      <description>Force along the X axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="y" required="0">
+      <description>Force along the Y axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="z" required="0">
+      <description>Force along the Z axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+  </element>
+
+  <element name="torque" required="0">
+    <description>These elements are specific to measurement-frame torque,
+    which is expressed in Newton-meters</description>
+    <element name="x" required="0">
+      <description>Torque about the X axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="y" required="0">
+      <description>Force about the Y axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="z" required="0">
+      <description>Torque about the Z axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+  </element>
+</element>

--- a/sdf/1.12/frame.sdf
+++ b/sdf/1.12/frame.sdf
@@ -1,0 +1,35 @@
+<!-- Frame -->
+<element name="frame" required="*">
+  <description>A frame of reference in which poses may be expressed.</description>
+
+  <attribute name="name" type="string" default="" required="1">
+    <description>
+      Name of the frame. It must be unique whithin its scope (model/world),
+      i.e., it must not match the name of another frame, link, joint, or model
+      within the same scope.
+    </description>
+  </attribute>
+
+  <attribute name="attached_to" type="string" default="" required="*">
+    <description>
+      If specified, this frame is attached to the specified frame. The specified
+      frame must be within the same scope and may be defined implicitly, i.e.,
+      the name of any //frame, //model, //joint, or //link within the same scope
+      may be used.
+
+      If missing, this frame is attached to the containing scope's frame. Within
+      a //world scope this is the implicit world frame, and within a //model
+      scope this is the implicit model frame.
+
+      A frame moves jointly with the frame it is @attached_to. This is different
+      from //pose/@relative_to. @attached_to defines how the frame is attached
+      to a //link, //model, or //world frame, while //pose/@relative_to defines
+      how the frame's pose is represented numerically. As a result, following
+      the chain of @attached_to attributes must always lead to a //link,
+      //model, //world, or //joint (implicitly attached_to its child //link).
+    </description>
+  </attribute>
+
+  <include filename="pose.sdf" required="0"/>
+
+</element> <!-- End Frame -->

--- a/sdf/1.12/geometry.sdf
+++ b/sdf/1.12/geometry.sdf
@@ -1,0 +1,20 @@
+<!-- Geometry -->
+<element name="geometry" required="1">
+  <description>The shape of the visual or collision object.</description>
+
+  <element name="empty" required="0">
+    <description>You can use the empty tag to make empty geometries.</description>
+  </element> <!-- End empty -->
+
+  <include filename="box_shape.sdf" required="0"/>
+  <include filename="capsule_shape.sdf" required="0"/>
+  <include filename="cylinder_shape.sdf" required="0"/>
+  <include filename="ellipsoid_shape.sdf" required="0"/>
+  <include filename="heightmap_shape.sdf" required="0"/>
+  <include filename="image_shape.sdf" required="0"/>
+  <include filename="mesh_shape.sdf" required="0"/>
+  <include filename="plane_shape.sdf" required="0"/>
+  <include filename="polyline_shape.sdf" required="0"/>
+  <include filename="sphere_shape.sdf" required="0"/>
+
+</element><!-- End Geometry -->

--- a/sdf/1.12/gps.sdf
+++ b/sdf/1.12/gps.sdf
@@ -1,0 +1,40 @@
+<element name="gps" required="0">
+  <description>These elements are specific to the GPS sensor.</description>
+
+  <element name="position_sensing" required="0">
+    <description>
+      Parameters related to GPS position measurement.
+    </description>
+    <element name="horizontal" required="0">
+      <description>
+        Noise parameters for horizontal position measurement, in units of meters.
+      </description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="vertical" required="0">
+      <description>
+        Noise parameters for vertical position measurement, in units of meters.
+      </description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+  </element>
+
+  <element name="velocity_sensing" required="0">
+    <description>
+      Parameters related to GPS position measurement.
+    </description>
+    <element name="horizontal" required="0">
+      <description>
+        Noise parameters for horizontal velocity measurement, in units of meters/second.
+      </description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="vertical" required="0">
+      <description>
+        Noise parameters for vertical velocity measurement, in units of meters/second.
+      </description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+  </element>
+
+</element>

--- a/sdf/1.12/gripper.sdf
+++ b/sdf/1.12/gripper.sdf
@@ -1,0 +1,30 @@
+<!-- Gripper -->
+<element name="gripper" required="*">
+  <description></description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description></description>
+  </attribute>
+
+  <element name="grasp_check" required="0">
+    <description></description>
+    <element name="detach_steps" type="int" default="40" required="0">
+      <description></description>
+    </element>
+    <element name="attach_steps" type="int" default="20" required="0">
+      <description></description>
+    </element>
+    <element name="min_contact_count" type="unsigned int" default="2" required="0">
+      <description></description>
+    </element>
+  </element>
+
+  <element name="gripper_link" type="string" default="__default__" required="+">
+    <description></description>
+  </element>
+
+  <element name="palm_link" type="string" default="__default__" required="1">
+    <description></description>
+  </element>
+
+</element>

--- a/sdf/1.12/gui.sdf
+++ b/sdf/1.12/gui.sdf
@@ -1,0 +1,60 @@
+<!-- gui -->
+<element name="gui" required="0">
+  <attribute name="fullscreen" type="bool" default="false" required="0">
+    <description></description>
+  </attribute>
+
+  <include filename="plugin.sdf" required="*"/>
+
+  <element name="camera" required="0">
+    <description> </description>
+
+    <attribute name="name" type="string" default="user_camera" required="1">
+      <description></description>
+    </attribute>
+
+    <element name="view_controller" type="string" default="orbit" required="0">
+      <description></description>
+    </element>
+
+    <element name="projection_type" type="string" default="perspective" required="0">
+      <description>Set the type of projection for the camera. Valid values are "perspective" and "orthographic".</description>
+    </element>
+
+    <element name="track_visual" required="0">
+      <description></description>
+
+      <element name="name" type="string" default="__default__" required="0">
+        <description>Name of the tracked visual. If no name is provided, the remaining settings will be applied whenever tracking is triggered in the GUI.</description>
+      </element>
+
+      <element name="min_dist" type="double" default="0" required="0">
+        <description>Minimum distance between the camera and the tracked visual. This parameter is only used if static is set to false.</description>
+      </element>
+
+      <element name="max_dist" type="double" default="0" required="0">
+        <description>Maximum distance between the camera and the tracked visual. This parameter is only used if static is set to false.</description>
+      </element>
+
+      <element name="static" type="bool" default="false" required="0">
+        <description>If set to true, the position of the camera is fixed relatively to the model or to the world, depending on the value of the use_model_frame element. Otherwise, the position of the camera may vary but the distance between the camera and the model will depend on the value of the min_dist and max_dist elements. In any case, the camera will always follow the model by changing its orientation.</description>
+      </element>
+
+      <element name="use_model_frame" type="bool" default="true" required="0">
+        <description>If set to true, the position of the camera is relative to the model reference frame, which means that its position relative to the model will not change. Otherwise, the position of the camera is relative to the world reference frame, which means that its position relative to the world will not change. This parameter is only used if static is set to true.</description>
+      </element>
+
+      <element name="xyz" type="vector3" default="-5.0 0.0 3.0" required="0">
+        <description>The position of the camera's reference frame. This parameter is only used if static is set to true. If use_model_frame is set to true, the position is relative to the model reference frame, otherwise it represents world coordinates.</description>
+      </element>
+
+      <element name="inherit_yaw" type="bool" default="false" required="0">
+        <description>If set to true, the camera will inherit the yaw rotation of the tracked model. This parameter is only used if static and use_model_frame are set to true.</description>
+      </element>
+
+    </element>
+
+    <include filename="pose.sdf" required="0"/>
+
+  </element>
+</element>

--- a/sdf/1.12/heightmap_shape.sdf
+++ b/sdf/1.12/heightmap_shape.sdf
@@ -1,0 +1,44 @@
+<element name="heightmap" required="0">
+  <description>A heightmap based on a 2d grayscale image.</description>
+  <element name="uri" type="string" default="__default__" required="1">
+    <description>URI to a grayscale image file</description>
+  </element>
+  <element name="size" type="vector3" default="1 1 1" required="0">
+    <description>The size of the heightmap in world units.
+      When loading an image: "size" is used if present, otherwise defaults to 1x1x1.
+      When loading a DEM: "size" is used if present, otherwise defaults to true size of DEM.
+  </description>
+  </element>
+  <element name="pos" type="vector3" default="0 0 0" required="0">
+    <description>A position offset.</description>
+  </element>
+
+  <element name="texture" required="*">
+    <description>The heightmap can contain multiple textures. The order of the texture matters. The first texture will appear at the lowest height, and the last texture at the highest height. Use blend to control the height thresholds and fade between textures.</description>
+    <element name="size" type="double" default="10" required="1">
+      <description>Size of the applied texture in meters.</description>
+    </element>
+    <element name="diffuse" type="string" default="__default__" required="1">
+      <description>Diffuse texture image filename</description>
+    </element>
+    <element name="normal" type="string" default="__default__" required="1">
+      <description>Normalmap texture image filename</description>
+    </element>
+  </element>
+  <element name="blend" required="*">
+    <description>The blend tag controls how two adjacent textures are mixed. The number of blend elements should equal one less than the number of textures.</description>
+    <element name="min_height" type="double" default="0" required="1">
+      <description>Min height of a blend layer</description>
+    </element>
+    <element name="fade_dist" type="double" default="0" required="1">
+      <description>Distance over which the blend occurs</description>
+    </element>
+  </element>
+  <element name="use_terrain_paging" type="bool" default="false" required="0">
+    <description>Set if the rendering engine will use terrain paging</description>
+  </element>
+  <element name="sampling" type="unsigned int" default="1" required="0">
+    <description>Samples per heightmap datum. For rasterized heightmaps, this indicates the number of samples to take per pixel. Using a higher value, e.g. 2, will generally improve the quality of the heightmap but lower performance.
+    </description>
+  </element>
+</element>

--- a/sdf/1.12/image_shape.sdf
+++ b/sdf/1.12/image_shape.sdf
@@ -1,0 +1,18 @@
+<element name="image" required="0">
+  <description>Extrude a set of boxes from a grayscale image.</description>
+  <element name="uri" type="string" default="__default__" required="1">
+    <description>URI of the grayscale image file</description>
+  </element>
+  <element name="scale" type="double" default="1" required="1">
+    <description>Scaling factor applied to the image</description>
+  </element>
+  <element name="threshold" type="int" default="200" required="1">
+    <description>Grayscale threshold</description>
+  </element>
+  <element name="height" type="double" default="1" required="1">
+    <description>Height of the extruded boxes</description>
+  </element>
+  <element name="granularity" type="int" default="1" required="1">
+    <description>The amount of error in the model</description>
+  </element>
+</element>

--- a/sdf/1.12/imu.sdf
+++ b/sdf/1.12/imu.sdf
@@ -1,0 +1,120 @@
+<element name="imu" required="0">
+  <description>These elements are specific to the IMU sensor.</description>
+
+  <element name="orientation_reference_frame" required="0">
+    <!-- move this under custom_rpy? -->
+    <element name="localization" type="string" default="CUSTOM" required="1">
+      <description>
+        This string represents special hardcoded use cases that are commonly seen with typical robot IMU's:
+          - CUSTOM: use Euler angle custom_rpy orientation specification.
+                 The orientation of the IMU's reference frame is defined by adding the custom_rpy rotation
+                 to the parent_frame.
+          - NED: The IMU XYZ aligns with NED, where NED orientation relative to Gazebo world
+                 is defined by the SphericalCoordinates class.
+          - ENU: The IMU XYZ aligns with ENU, where ENU orientation relative to Gazebo world
+                 is defined by the SphericalCoordinates class.
+          - NWU: The IMU XYZ aligns with NWU, where NWU orientation relative to Gazebo world
+                 is defined by the SphericalCoordinates class.
+          - GRAV_UP: where direction of gravity maps to IMU reference frame Z-axis with Z-axis pointing in
+                     the opposite direction of gravity. IMU reference frame X-axis direction is defined by grav_dir_x.
+                     Note if grav_dir_x is parallel to gravity direction, this configuration fails.
+                     Otherwise, IMU reference frame X-axis is defined by projection of grav_dir_x onto a plane
+                     normal to the gravity vector. IMU reference frame Y-axis is a vector orthogonal to both
+                     X and Z axis following the right hand rule.
+          - GRAV_DOWN: where direction of gravity maps to IMU reference frame Z-axis with Z-axis pointing in
+                       the direction of gravity. IMU reference frame X-axis direction is defined by grav_dir_x.
+                       Note if grav_dir_x is parallel to gravity direction, this configuration fails.
+                       Otherwise, IMU reference frame X-axis is defined by projection of grav_dir_x onto a plane
+                       normal to the gravity vector. IMU reference frame Y-axis is a vector orthogonal to both
+                       X and Z axis following the right hand rule.
+      </description>
+    </element>
+    <element name="custom_rpy" type="vector3" default="0 0 0" required="0">
+      <description>
+        This field and parent_frame are used when localization is set to CUSTOM.
+        Orientation (fixed axis roll, pitch yaw) transform from parent_frame to this IMU's reference frame.
+        Some common examples are:
+          - IMU reports in its local frame on boot. IMU sensor frame is the reference frame.
+             Example: parent_frame="", custom_rpy="0 0 0"
+          - IMU reports in Gazebo world frame.
+             Example sdf: parent_frame="world", custom_rpy="0 0 0"
+          - IMU reports in NWU frame.
+             Uses SphericalCoordinates class to determine world frame in relation to magnetic north and gravity;
+             i.e. rotation between North-West-Up and world (+X,+Y,+Z) frame is defined by SphericalCoordinates class.
+             Example sdf given world is NWU: parent_frame="world", custom_rpy="0 0 0"
+          - IMU reports in NED frame.
+             Uses SphericalCoordinates class to determine world frame in relation to magnetic north and gravity;
+             i.e. rotation between North-East-Down and world (+X,+Y,+Z) frame is defined by SphericalCoordinates class.
+             Example sdf given world is NWU: parent_frame="world", custom_rpy="M_PI 0 0"
+          - IMU reports in ENU frame.
+             Uses SphericalCoordinates class to determine world frame in relation to magnetic north and gravity;
+             i.e. rotation between East-North-Up and world (+X,+Y,+Z) frame is defined by SphericalCoordinates class.
+             Example sdf given world is NWU: parent_frame="world", custom_rpy="0 0 -0.5*M_PI"
+          - IMU reports in ROS optical frame as described in http://www.ros.org/reps/rep-0103.html#suffix-frames, which is
+             (z-forward, x-left to right when facing +z, y-top to bottom when facing +z).
+             (default gazebo camera is +x:view direction, +y:left, +z:up).
+             Example sdf: parent_frame="local", custom_rpy="-0.5*M_PI 0 -0.5*M_PI"
+      </description>
+      <attribute name="parent_frame" type="string" default="" required="0">
+        <description>
+          Name of parent frame which the custom_rpy transform is defined relative to.
+          It can be any valid fully scoped Gazebo Link name or the special reserved "world" frame.
+          If left empty, use the sensor's own local frame.
+        </description>
+      </attribute>
+    </element>
+    <element name="grav_dir_x" type="vector3" default="1 0 0" required="0">
+      <description>
+        Used when localization is set to GRAV_UP or GRAV_DOWN, a projection of this vector
+        into a plane that is orthogonal to the gravity vector
+        defines the direction of the IMU reference frame's X-axis.
+        grav_dir_x is  defined in the coordinate frame as defined by the parent_frame element.
+      </description>
+      <attribute name="parent_frame" type="string" default="" required="0">
+        <description>
+          Name of parent frame in which the grav_dir_x vector is defined.
+          It can be any valid fully scoped Gazebo Link name or the special reserved "world" frame.
+          If left empty, use the sensor's own local frame.
+        </description>
+      </attribute>
+    </element>
+  </element>
+
+  <element name="angular_velocity" required="0">
+    <description>These elements are specific to body-frame angular velocity,
+    which is expressed in radians per second</description>
+    <element name="x" required="0">
+      <description>Angular velocity about the X axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="y" required="0">
+      <description>Angular velocity about the Y axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="z" required="0">
+      <description>Angular velocity about the Z axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+  </element>
+
+  <element name="linear_acceleration" required="0">
+    <description>These elements are specific to body-frame linear acceleration,
+    which is expressed in meters per second squared</description>
+    <element name="x" required="0">
+      <description>Linear acceleration about the X axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="y" required="0">
+      <description>Linear acceleration about the Y axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="z" required="0">
+      <description>Linear acceleration about the Z axis</description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+  </element>
+
+  <element name="enable_orientation" type="bool" default="true" required="0">
+    <description>Some IMU sensors rely on external filters to produce orientation estimates. True to generate and output orientation data, false to disable orientation data generation.</description>
+  </element>
+</element>

--- a/sdf/1.12/inertial.sdf
+++ b/sdf/1.12/inertial.sdf
@@ -1,0 +1,233 @@
+<!-- Inertial -->
+<element name="inertial" required="0">
+  <description>
+    The link's mass, position of its center of mass, its central inertia
+    properties, and optionally its fluid added mass.
+  </description>
+
+  <attribute name="auto" type="bool" default="false" required="0">
+    <description>
+      Set to true if you want automatic computation for the moments of inertia (ixx, iyy, izz) 
+      and products of inertia(ixy, iyz, ixz). Default value is false.
+    </description>
+  </attribute>
+
+  <element name="mass" type="double" default="1.0" required="0">
+    <description>The mass of the link.</description>
+  </element>
+
+  <element name="density" type="double" default="1000.0" required="0">
+    <description>
+      Mass Density of the collision geometry. 
+      This is used to determine mass and inertia values during automatic calculation.
+      This density value would be overwritten by the density value in collision.
+      Default is the density of water 1000 kg/m^3.
+    </description>
+  </element>
+
+  <element name="auto_inertia_params" required="0">
+    <description>
+      Parent tag to hold user-defined custom params for mesh inertia calculator
+      The elements used under this would be overwritten by the elements in auto_inertia_params
+      in collision.
+    </description>
+  </element>
+
+  <element name="pose" type="pose" default="0 0 0 0 0 0" required="0">
+    <description>
+      This pose (translation, rotation) describes the position and orientation
+      of the link's center-of-mass-frame C relative to the link-frame L.
+      The first three components (x y z) specify the position vector from Lo
+      (the link-frame origin) to Co (the link's center of mass) as
+      `x L̂x + y L̂y + z L̂ᴢ`, where L̂x, L̂y, L̂ᴢ are link-frame L's orthogonal unit
+      vectors. The subsequent values characterize C's orientation relative to
+      link-frame L as a sequence of Euler rotations
+      (r p y) documented in http://sdformat.org/tutorials?tut=specify_pose,
+      or as a quaternion (x y z w), where w is the scalar component.
+    </description>
+
+    <attribute name="rotation_format" type="string" default="euler_rpy" required="0">
+      <description>'euler_rpy' by default. Supported rotation formats are
+        'euler_rpy', Euler angles representation in roll, pitch, yaw. The pose is expected to have 6 values.
+        'quat_xyzw', Quaternion representation in x, y, z, w. The pose is expected to have 7 values.
+      </description>
+    </attribute>
+
+    <attribute name="degrees" type="bool" default="false" required="0">
+      <description>
+        Whether or not the euler angles are in degrees, otherwise they will be interpreted as radians by default.
+      </description>
+    </attribute>
+
+  </element>
+
+  <element name="inertia" required="0">
+    <description>
+      This link's moments of inertia ixx, iyy, izz and products of inertia
+      ixy, ixz, iyz about Co (the link's center of mass) for the unit vectors
+      Ĉx, Ĉy, Ĉᴢ fixed in the center-of-mass-frame C.
+      Note: the orientation of Ĉx, Ĉy, Ĉᴢ relative to L̂x, L̂y, L̂ᴢ is specified
+      by the `pose` tag.
+      To avoid compatibility issues associated with the negative sign
+      convention for product of inertia, align Ĉx, Ĉy, Ĉᴢ with principal
+      inertia directions so that all the products of inertia are zero.
+      For more information about this sign convention, see the following
+      MathWorks documentation for working with CAD tools:
+      https://www.mathworks.com/help/releases/R2021b/physmod/sm/ug/specify-custom-inertia.html#mw_b043ec69-835b-4ca9-8769-af2e6f1b190c
+    </description>
+    <element name="ixx" type="double" default="1.0" required="1">
+      <description>
+        The link's moment of inertia about Co (the link's center of mass) for Ĉx.
+      </description>
+    </element>
+    <element name="ixy" type="double" default="0.0" required="1">
+      <description>
+        The link's product of inertia about Co (the link's center of mass) for
+        Ĉx and Ĉy, where the product of inertia convention -m x y  (not +m x y)
+        is used. If Ĉx or Ĉy is a principal inertia direction, ixy = 0.
+      </description>
+    </element>
+    <element name="ixz" type="double" default="0.0" required="1">
+      <description>
+        The link's product of inertia about Co (the link's center of mass) for
+        Ĉx and Ĉz, where the product of inertia convention -m x z  (not +m x z)
+        is used. If Ĉx or Ĉz is a principal inertia direction, ixz = 0.
+      </description>
+    </element>
+    <element name="iyy" type="double" default="1.0" required="1">
+      <description>
+        The link's moment of inertia about Co (the link's center of mass) for Ĉy.
+      </description>
+    </element>
+    <element name="iyz" type="double" default="0.0" required="1">
+      <description>
+        The link's product of inertia about Co (the link's center of mass) for
+        Ĉy and Ĉz, where the product of inertia convention -m y z  (not +m y z)
+        is used. If Ĉy or Ĉz is a principal inertia direction, iyz = 0.
+      </description>
+    </element>
+    <element name="izz" type="double" default="1.0" required="1">
+      <description>
+        The link's moment of inertia about Co (the link's center of mass) for Ĉz.
+      </description>
+    </element>
+  </element> <!-- End Inertia -->
+
+  <element name="fluid_added_mass" required="0">
+    <description>
+      This link's fluid added mass matrix about the link's origin.
+      This matrix represents the inertia of the fluid that is dislocated when the
+      body moves. Added mass should be zero if the density of the surrounding
+      fluid is negligible with respect to the body's density.
+      The 6x6 matrix is symmetric, therefore only 21 unique elements can be set.
+      The elements of the matrix follow the [x, y, z, p, q, r] notation, where
+      [x, y, z] correspond to translation and [p, q, r] to rotation
+      (i.e. roll, pitch, yaw).
+    </description>
+    <element name="xx" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the X axis due to linear acceleration in the X axis, in kg.
+      </description>
+    </element>
+    <element name="xy" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the X axis due to linear acceleration in the Y axis, and vice-versa, in kg.
+      </description>
+    </element>
+    <element name="xz" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the X axis due to linear acceleration in the Z axis, and vice-versa, in kg.
+      </description>
+    </element>
+    <element name="xp" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the X axis due to angular acceleration about the X axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="xq" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the X axis due to angular acceleration about the Y axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="xr" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the X axis due to angular acceleration about the Z axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="yy" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Y axis due to linear acceleration in the Y axis, in kg.
+      </description>
+    </element>
+    <element name="yz" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Y axis due to linear acceleration in the Z axis, and vice-versa, in kg.
+      </description>
+    </element>
+    <element name="yp" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Y axis due to angular acceleration about the X axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="yq" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Y axis due to angular acceleration about the Y axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="yr" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Y axis due to angular acceleration about the Z axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="zz" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Z axis due to linear acceleration in the Z axis, in kg.
+      </description>
+    </element>
+    <element name="zp" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Z axis due to angular acceleration about the X axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="zq" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Z axis due to angular acceleration about the Y axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="zr" type="double" default="0.0" required="0">
+      <description>
+        Added mass in the Z axis due to angular acceleration about the Z axis, and vice-versa, in kg * m.
+      </description>
+    </element>
+    <element name="pp" type="double" default="0.0" required="0">
+      <description>
+        Added mass moment about the X axis due to angular acceleration about the X axis, in kg * m^2.
+      </description>
+    </element>
+    <element name="pq" type="double" default="0.0" required="0">
+      <description>
+        Added mass moment about the X axis due to angular acceleration about the Y axis, and vice-versa, in kg * m^2.
+      </description>
+    </element>
+    <element name="pr" type="double" default="0.0" required="0">
+      <description>
+        Added mass moment about the X axis due to angular acceleration about the Z axis, and vice-versa, in kg * m^2.
+      </description>
+    </element>
+    <element name="qq" type="double" default="0.0" required="0">
+      <description>
+        Added mass moment about the Y axis due to angular acceleration about the Y axis, in kg * m^2.
+      </description>
+    </element>
+    <element name="qr" type="double" default="0.0" required="0">
+      <description>
+        Added mass moment about the Y axis due to angular acceleration about the Z axis, and vice-versa, in kg * m^2.
+      </description>
+    </element>
+    <element name="rr" type="double" default="0.0" required="0">
+      <description>
+        Added mass moment about the Z axis due to angular acceleration about the Z axis, in kg * m^2.
+      </description>
+    </element>
+  </element> <!-- End fluid added mass -->
+</element> <!-- End Inertial -->

--- a/sdf/1.12/joint.sdf
+++ b/sdf/1.12/joint.sdf
@@ -1,0 +1,246 @@
+<!-- Joint -->
+<element name="joint" required="*">
+  <description>A joint connects two links with kinematic and dynamic properties. By default, the pose of a joint is expressed in the child link frame.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>A unique name for the joint within its scope.</description>
+  </attribute>
+
+  <attribute name="type" type="string" default="__default__" required="1">
+    <description>The type of joint, which must be one of the following:
+      (continuous) a hinge joint that rotates on a single axis with a continuous range of motion,
+      (revolute) a hinge joint that rotates on a single axis with a fixed range of motion,
+      (gearbox) geared revolute joints,
+      (revolute2) same as two revolute joints connected in series,
+      (prismatic) a sliding joint that slides along an axis with a limited range specified by upper and lower limits,
+      (ball) a ball and socket joint,
+      (screw) a single degree of freedom joint with coupled sliding and rotational motion,
+      (universal) like a ball joint, but constrains one degree of freedom,
+      (fixed) a joint with zero degrees of freedom that rigidly connects two links.
+    </description>
+  </attribute>
+
+  <element name="parent" type="string" default="__default__" required="1">
+    <description>Name of the parent frame or "world".</description>
+  </element> <!-- End Parent -->
+
+  <element name="child" type="string" default="__default__" required="1">
+    <description>Name of the child frame. The value "world" may not be specified.</description>
+  </element> <!-- End Child -->
+
+  <element name="gearbox_ratio" type="double" default="1.0" required="0">
+    <description>Parameter for gearbox joints.  Given theta_1 and theta_2 defined in description for gearbox_reference_body, theta_2 = -gearbox_ratio * theta_1.</description>
+  </element>
+
+  <element name="gearbox_reference_body" type="string" default="__default__" required="0">
+    <description>Parameter for gearbox joints.  Gearbox ratio is enforced over two joint angles.  First joint angle (theta_1) is the angle from the gearbox_reference_body to the parent link in the direction of the axis element and the second joint angle (theta_2) is the angle from the gearbox_reference_body to the child link in the direction of the axis2 element.</description>
+  </element>
+
+  <element name="thread_pitch" type="double" default="1.0" required="-1">
+    <description>
+      Parameter for screw joints representing the ratio between rotation
+      and translation of the joint. This parameter has been interpreted by
+      gazebo-classic as having units of radians / meter with a positive value
+      corresponding to a left-handed thread.
+      The parameter is now deprecated in favor of `screw_thread_pitch`.
+    </description>
+  </element>
+
+  <element name="screw_thread_pitch" type="double" default="1.0" required="0">
+    <description>
+      A parameter for screw joint kinematics, representing the
+      axial distance traveled for each revolution of the joint,
+      with units of meters / revolution with a positive value corresponding
+      to a right-handed thread.
+      This parameter supersedes `thread_pitch`.
+    </description>
+  </element>
+
+  <element name="axis" required="0">
+    <description>
+      Parameters related to the axis of rotation for revolute joints,
+      the axis of translation for prismatic joints.
+    </description>
+    <element name="xyz" type="vector3" default="0 0 1" required="1">
+      <description>
+        Represents the x,y,z components of the axis unit vector. The axis is
+        expressed in the joint frame unless a different frame is expressed in
+        the expressed_in attribute. The vector should be normalized.
+      </description>
+      <attribute name="expressed_in" type="string" default="" required="0">
+        <description>
+          Name of frame in whose coordinates the xyz unit vector is expressed.
+        </description>
+      </attribute>
+    </element>
+    <element name="dynamics" required="0">
+      <description>An element specifying physical properties of the joint. These values are used to specify modeling properties of the joint, particularly useful for simulation.</description>
+      <element name="damping" type="double" default="0" required="0">
+        <description>The physical velocity dependent viscous damping coefficient of the joint.</description>
+      </element>
+      <element name="friction" type="double" default="0" required="0">
+        <description>The physical static friction value of the joint.</description>
+      </element>
+      <element name="spring_reference" type="double" default="0" required="1">
+        <description>The spring reference position for this joint axis.</description>
+      </element>
+      <element name="spring_stiffness" type="double" default="0" required="1">
+        <description>The spring stiffness for this joint axis.</description>
+      </element>
+    </element> <!-- End Dynamics -->
+    <element name="limit" required="1">
+      <description>specifies the limits of this joint</description>
+      <element name="lower" type="double" default="-inf" required="1">
+        <description>Specifies the lower joint limit (radians for revolute joints, meters for prismatic joints). Omit if joint is continuous.</description>
+      </element>
+      <element name="upper" type="double" default="inf" required="1">
+        <description>Specifies the upper joint limit (radians for revolute joints, meters for prismatic joints). Omit if joint is continuous.</description>
+      </element>
+      <element name="effort" type="double" default="inf" required="0">
+        <description>A value for enforcing the maximum joint effort applied. Limit is not enforced if value is negative.</description>
+      </element>
+      <element name="velocity" type="double" default="inf" required="0">
+        <description>A value for enforcing the maximum joint velocity.</description>
+      </element>
+
+      <element name="stiffness" type="double" default="1e8" required="0">
+        <description>Joint stop stiffness.</description>
+      </element>
+
+      <element name="dissipation" type="double" default="1.0" required="0">
+        <description>Joint stop dissipation.</description>
+      </element>
+
+    </element> <!-- End Limit -->
+
+    <include filename="mimic.sdf" required="0"/>
+
+  </element> <!-- End Axis -->
+
+  <element name="axis2" required="0">
+    <description>
+      Parameters related to the second axis of rotation for revolute2 joints and universal joints.
+    </description>
+    <element name="xyz" type="vector3" default="0 0 1" required="1">
+      <description>
+        Represents the x,y,z components of the axis unit vector. The axis is
+        expressed in the joint frame unless a different frame is expressed in
+        the expressed_in attribute. The vector should be normalized.
+      </description>
+      <attribute name="expressed_in" type="string" default="" required="0">
+        <description>
+          Name of frame in whose coordinates the xyz unit vector is expressed.
+        </description>
+      </attribute>
+    </element>
+    <element name="dynamics" required="0">
+      <description>An element specifying physical properties of the joint. These values are used to specify modeling properties of the joint, particularly useful for simulation.</description>
+      <element name="damping" type="double" default="0" required="0">
+        <description>The physical velocity dependent viscous damping coefficient of the joint.  EXPERIMENTAL: if damping coefficient is negative and implicit_spring_damper is true, adaptive damping is used.</description>
+      </element>
+      <element name="friction" type="double" default="0" required="0">
+        <description>The physical static friction value of the joint.</description>
+      </element>
+      <element name="spring_reference" type="double" default="0" required="1">
+        <description>The spring reference position for this joint axis.</description>
+      </element>
+      <element name="spring_stiffness" type="double" default="0" required="1">
+        <description>The spring stiffness for this joint axis.</description>
+      </element>
+    </element> <!-- End Dynamics -->
+
+    <element name="limit" required="1">
+      <description></description>
+      <element name="lower" type="double" default="-inf" required="0">
+        <description>An attribute specifying the lower joint limit (radians for revolute joints, meters for prismatic joints). Omit if joint is continuous.</description>
+      </element>
+      <element name="upper" type="double" default="inf" required="0">
+        <description>An attribute specifying the upper joint limit (radians for revolute joints, meters for prismatic joints). Omit if joint is continuous.</description>
+      </element>
+      <element name="effort" type="double" default="inf" required="0">
+        <description>An attribute for enforcing the maximum joint effort applied by Joint::SetForce.  Limit is not enforced if value is negative.</description>
+      </element>
+      <element name="velocity" type="double" default="inf" required="0">
+        <description>(not implemented) An attribute for enforcing the maximum joint velocity.</description>
+      </element>
+
+      <element name="stiffness" type="double" default="1e8" required="0">
+        <description>Joint stop stiffness. Supported physics engines: SimBody.</description>
+      </element>
+
+      <element name="dissipation" type="double" default="1.0" required="0">
+        <description>Joint stop dissipation. Supported physics engines: SimBody.</description>
+      </element>
+
+    </element> <!-- End Limit -->
+
+    <include filename="mimic.sdf" required="0"/>
+
+  </element> <!-- End Axis2 -->
+
+  <element name="physics" required="0">
+    <description>Parameters that are specific to a certain physics engine.</description>
+    <element name="simbody" required="0">
+      <description>Simbody specific parameters</description>
+      <element name="must_be_loop_joint" type="bool" default="false" required="0">
+        <description>Force cut in the multibody graph at this joint.</description>
+      </element>
+    </element>
+    <element name="ode" required="0">
+      <description>ODE specific parameters</description>
+      <element name="cfm_damping" type="bool" default="false" required="0">
+        <description>If cfm damping is set to true, ODE will use CFM to simulate damping, allows for infinite damping, and one additional constraint row (previously used for joint limit) is always active.</description>
+      </element>
+
+      <element name="implicit_spring_damper" type="bool" default="false" required="0">
+        <description>If implicit_spring_damper is set to true, ODE will use CFM, ERP to simulate stiffness and damping, allows for infinite damping, and one additional constraint row (previously used for joint limit) is always active.  This replaces cfm_damping parameter in SDFormat 1.4.</description>
+      </element>
+
+      <element name="fudge_factor" type="double" default="0" required="0">
+        <description>Scale the excess for in a joint motor at joint limits. Should be between zero and one.</description>
+      </element>
+      <element name="cfm" type="double" default="0" required="0">
+        <description>Constraint force mixing for constrained directions</description>
+      </element>
+      <element name="erp" type="double" default="0.2" required="0">
+        <description>Error reduction parameter for constrained directions</description>
+      </element>
+      <element name="bounce" type="double" default="0" required="0">
+        <description>Bounciness of the limits</description>
+      </element>
+      <element name="max_force" type="double" default="0" required="0">
+        <description>Maximum force or torque used to reach the desired velocity.</description>
+      </element>
+      <element name="velocity" type="double" default="0" required="0">
+        <description>The desired velocity of the joint. Should only be set if you want the joint to move on load.</description>
+      </element>
+
+      <element name="limit" required="0">
+        <description></description>
+        <element name="cfm" type="double" default="0.0" required="1">
+          <description>Constraint force mixing parameter used by the joint stop</description>
+        </element>
+        <element name="erp" type="double" default="0.2" required="1">
+          <description>Error reduction parameter used by the joint stop</description>
+        </element>
+      </element>
+
+      <element name="suspension" required="0">
+        <description></description>
+        <element name="cfm" type="double" default="0.0" required="1">
+          <description>Suspension constraint force mixing parameter</description>
+        </element>
+        <element name="erp" type="double" default="0.2" required="1">
+          <description>Suspension error reduction parameter</description>
+        </element>
+      </element>
+    </element>
+
+    <element name="provide_feedback" type="bool" default="false" required="0">
+      <description>If provide feedback is set to true, physics engine will compute the constraint forces at this joint.</description>
+    </element>
+  </element> <!-- End Physics -->
+
+  <include filename="pose.sdf" required="0"/>
+  <include filename="sensor.sdf" required="*"/>
+</element> <!-- End Joint -->

--- a/sdf/1.12/lidar.sdf
+++ b/sdf/1.12/lidar.sdf
@@ -1,0 +1,78 @@
+<element name="lidar" required="0">
+  <description>These elements are specific to the lidar sensor.</description>
+
+  <element name="scan" required="1">
+    <description></description>
+    <element name="horizontal" required="1">
+      <description></description>
+
+      <element name="samples" type="unsigned int" default="640" required="1">
+        <description>The number of simulated lidar rays to generate per complete laser sweep cycle.</description>
+      </element>
+
+      <element name="resolution" type="double" default="1" required="1">
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is not equal to one, range data is interpolated.</description>
+      </element>
+
+      <element name="min_angle" type="double" default="0" required="1">
+        <description></description>
+      </element>
+
+      <element name="max_angle" type="double" default="0" required="1">
+        <description>Must be greater or equal to min_angle</description>
+      </element>
+
+    </element> <!-- End Horizontal -->
+
+    <element name="vertical" required="0">
+      <description></description>
+      <element name="samples" type="unsigned int" default="1" required="1">
+        <description>The number of simulated lidar rays to generate per complete laser sweep cycle.</description>
+      </element>
+
+      <element name="resolution" type="double" default="1" required="0">
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is not equal to one, range data is interpolated.</description>
+      </element>
+
+      <element name="min_angle" type="double" default="0" required="1">
+        <description></description>
+      </element>
+
+      <element name="max_angle" type="double" default="0" required="1">
+        <description>Must be greater or equal to min_angle</description>
+      </element>
+
+    </element> <!-- End Vertical -->
+  </element> <!-- End Scan -->
+
+  <element name="range" required="1">
+    <description>specifies range properties of each simulated lidar</description>
+    <element name="min" type="double" default="0" required="1">
+      <description>The minimum distance for each lidar ray.</description>
+    </element>
+    <element name="max" type="double" default="0" required="1">
+      <description>The maximum distance for each lidar ray.</description>
+    </element>
+    <element name="resolution" type="double" default="0" required="0">
+      <description>Linear resolution of each lidar ray.</description>
+    </element>
+  </element> <!-- End Range -->
+
+  <element name="noise" required="0">
+    <description>The properties of the noise model that should be applied to generated scans</description>
+    <element name="type" type="string" default="gaussian" required="1">
+      <description>The type of noise.  Currently supported types are: "gaussian" (draw noise values independently for each beam from a Gaussian distribution).</description>
+    </element>
+    <element name="mean" type="double" default="0.0" required="0">
+      <description>For type "gaussian," the mean of the Gaussian distribution from which noise values are drawn.</description>
+    </element>
+    <element name="stddev" type="double" default="0.0" required="0">
+      <description>For type "gaussian," the standard deviation of the Gaussian distribution from which noise values are drawn.</description>
+    </element>
+  </element> <!-- End Noise -->
+
+  <element name="visibility_mask" type="unsigned int" default="4294967295" required="0">
+    <description><![CDATA[Visibility mask of a lidar. When (lidar's visibility_mask & object's visibility_flags) evaluates to non-zero, the object will be visible to the lidar.]]></description>
+  </element>
+
+</element> <!-- End Lidar -->

--- a/sdf/1.12/light.sdf
+++ b/sdf/1.12/light.sdf
@@ -1,0 +1,71 @@
+<!-- Light -->
+<element name="light" required="*">
+  <description>The light element describes a light source.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>A unique name for the light.</description>
+  </attribute>
+
+  <attribute name="type" type="string" default="point" required="1">
+    <description>The light type: point, directional, spot.</description>
+  </attribute>
+
+  <element name="cast_shadows" type="bool" default="false" required="0">
+    <description>When true, the light will cast shadows.</description>
+  </element>
+
+  <element name="light_on" type="bool" default="true" required="0">
+    <description>When true, the light is on.</description>
+  </element>
+
+  <element name="visualize" type="bool" default="true" required="0">
+    <description>If true, the light is visualized in the GUI</description>
+  </element>
+
+  <element name="intensity" type="double" default="1" required="0">
+    <description>Scale factor to set the relative power of a light.</description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+
+  <element name="diffuse" type="color" default="1 1 1 1" required="0">
+    <description>Diffuse light color</description>
+  </element>
+  <element name="specular" type="color" default=".1 .1 .1 1" required="0">
+    <description>Specular light color</description>
+  </element>
+
+  <element name="attenuation" required="0">
+    <description>Light attenuation</description>
+    <element name="range" type="double" default="10" required="1">
+      <description>Range of the light</description>
+    </element>
+    <element name="linear" type="double" default="1" required="0">
+      <description>The linear attenuation factor: 1 means attenuate evenly over the distance.</description>
+    </element>
+    <element name="constant" type="double" default="1" required="0">
+      <description>The constant attenuation factor: 1.0 means never attenuate, 0.0 is complete attenutation.</description>
+    </element>
+    <element name="quadratic" type="double" default="0" required="0">
+      <description>The quadratic attenuation factor: adds a curvature to the attenuation.</description>
+    </element>
+  </element> <!-- End Attenuation -->
+
+  <element name="direction" type="vector3" default="0 0 -1" required="1">
+    <description>Direction of the light, only applicable for spot and directional lights.</description>
+  </element><!-- End Directional -->
+
+  <element name="spot" required="0">
+    <description>Spot light parameters</description>
+    <element name="inner_angle" type="double" default="0" required="1">
+      <description>Angle covered by the bright inner cone</description>
+    </element>
+    <element name="outer_angle" type="double" default="0" required="1">
+      <description>Angle covered by the outer cone</description>
+    </element>
+    <element name="falloff" type="double" default="0" required="1">
+      <description>The rate of falloff between the inner and outer cones. 1.0 means a linear falloff, less means slower falloff, higher means faster falloff.</description>
+    </element>
+  </element> <!-- End Spot -->
+
+</element> <!-- End Light -->

--- a/sdf/1.12/light_state.sdf
+++ b/sdf/1.12/light_state.sdf
@@ -1,0 +1,10 @@
+<!-- State information for a light -->
+<element name="light" required="*">
+  <description>Light state</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Name of the light</description>
+  </attribute>
+
+  <include filename="pose.sdf" required="0"/>
+</element> <!-- End Light -->

--- a/sdf/1.12/link.sdf
+++ b/sdf/1.12/link.sdf
@@ -1,0 +1,51 @@
+<!-- Link -->
+<element name="link" required="*">
+  <description>A physical link with inertia, collision, and visual properties. A link must be a child of a model, and any number of links may exist in a model.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>A unique name for the link within the scope of the model.</description>
+  </attribute>
+
+  <element name="gravity" type="bool" default="true" required="0">
+    <description>If true, the link is affected by gravity.</description>
+  </element>
+
+  <element name="enable_wind" type="bool" default="false" required="0">
+    <description>If true, the link is affected by the wind.</description>
+  </element>
+
+  <element name="self_collide" type="bool" default="false" required="0">
+    <description>If true, the link can collide with other links in the model. Two links within a model will collide if link1.self_collide OR link2.self_collide. Links connected by a joint will never collide.</description>
+  </element>
+
+  <element name="kinematic" type="bool" default="false" required="0">
+    <description>If true, the link is kinematic only</description>
+  </element>
+
+  <element name="must_be_base_link" type="bool" default="false" required="0">
+    <description>If true, the link will have 6DOF and be a direct child of world.</description>
+  </element>
+
+  <element name="velocity_decay" required="0">
+    <description>Exponential damping of the link's velocity.</description>
+    <element name="linear" type="double" default="0.0" required="0">
+      <description>Linear damping</description>
+    </element>
+    <element name="angular" type="double" default="0.0" required="0">
+      <description>Angular damping</description>
+    </element>
+  </element> <!-- End velocity decay -->
+
+  <include filename="pose.sdf" required="0"/>
+  <include filename="inertial.sdf" required="0"/>
+  <include filename="collision.sdf" required="*"/>
+  <include filename="visual.sdf" required="*"/>
+  <include filename="sensor.sdf" required="*"/>
+  <include filename="projector.sdf" required="*"/>
+  <include filename="audio_sink.sdf" required="*"/>
+  <include filename="audio_source.sdf" required="*"/>
+  <include filename="battery.sdf" required="*"/>
+  <include filename="light.sdf" required="*"/>
+  <include filename="particle_emitter.sdf" required="*"/>
+
+</element> <!-- End Link -->

--- a/sdf/1.12/link_state.sdf
+++ b/sdf/1.12/link_state.sdf
@@ -1,0 +1,40 @@
+<!-- State information for a link -->
+<element name="link" required="*">
+  <description>Link state</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Name of the link</description>
+  </attribute>
+
+  <element name="velocity" type="pose" default="0 0 0 0 0 0" required="0">
+    <description>Velocity of the link. The x, y, z components of the pose
+      correspond to the linear velocity of the link, and the roll, pitch, yaw
+      components correspond to the angular velocity of the link
+    </description>
+  </element>
+
+  <element name="acceleration" type="pose" default="0 0 0 0 0 0" required="0">
+    <description>Acceleration of the link. The x, y, z components of the pose
+      correspond to the linear acceleration of the link, and the roll,
+      pitch, yaw components correspond to the angular acceleration of the link
+    </description>
+  </element>
+
+  <element name="wrench" type="pose" default="0 0 0 0 0 0" required="0">
+    <description>Force and torque applied to the link. The x, y, z components
+      of the pose correspond to the force applied to the link, and the roll,
+      pitch, yaw components correspond to the torque applied to the link
+    </description>
+  </element>
+
+  <element name="collision" required="*">
+    <description>Collision state</description>
+
+    <attribute name="name" type="string" default="__default__" required="1">
+      <description>Name of the collision</description>
+    </attribute>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+
+</element> <!-- End Link -->

--- a/sdf/1.12/logical_camera.sdf
+++ b/sdf/1.12/logical_camera.sdf
@@ -1,0 +1,19 @@
+<element name="logical_camera" required="0">
+  <description>These elements are specific to logical camera sensors. A logical camera reports objects that fall within a frustum. Computation should be performed on the CPU.</description>
+
+  <element name="near" type="double" default="0" required="1">
+    <description>Near clipping distance of the view frustum</description>
+  </element>
+
+  <element name="far" type="double" default="1" required="1">
+    <description>Far clipping distance of the view frustum</description>
+  </element>
+
+  <element name="aspect_ratio" type="double" default="1" required="1">
+    <description>Aspect ratio of the near and far planes. This is the width divided by the height of the near or far planes.</description>
+  </element>
+
+  <element name="horizontal_fov" type="double" default="1" required="1">
+    <description>Horizontal field of view of the frustum, in radians. This is the angle between the frustum's vertex and the edges of the near or far plane.</description>
+  </element>
+</element>

--- a/sdf/1.12/magnetometer.sdf
+++ b/sdf/1.12/magnetometer.sdf
@@ -1,0 +1,21 @@
+<element name="magnetometer" required="0">
+  <description>These elements are specific to a Magnetometer sensor.</description>
+  <element name="x" required="0">
+    <description>
+      Parameters related to the body-frame X axis of the magnetometer
+    </description>
+    <include filename="noise.sdf" required="0"/>
+  </element>
+  <element name="y" required="0">
+    <description>
+      Parameters related to the body-frame Y axis of the magnetometer
+    </description>
+    <include filename="noise.sdf" required="0"/>
+  </element>
+  <element name="z" required="0">
+    <description>
+      Parameters related to the body-frame Z axis of the magnetometer
+    </description>
+    <include filename="noise.sdf" required="0"/>
+  </element>
+</element>

--- a/sdf/1.12/material.sdf
+++ b/sdf/1.12/material.sdf
@@ -1,0 +1,166 @@
+<!-- Material -->
+<element name="material" required="0">
+  <description>The material of the visual element.</description>
+
+  <element name="script" required="0">
+    <description>Name of material from an installed script file. This will override the color element if the script exists.</description>
+
+    <element name="uri" type="string" default="__default__" required="+">
+      <description>URI of the material script file</description>
+    </element>
+
+    <element name="name" type="string" default="__default__" required="1">
+      <description>Name of the script within the script file</description>
+    </element>
+  </element>
+
+  <element name="shader" required="0">
+
+    <attribute name="type" type="string" default="pixel" required="1">
+      <description>vertex, pixel, normal_map_object_space, normal_map_tangent_space</description>
+    </attribute>
+
+    <element name="normal_map" type="string" default="__default__" required="0">
+      <description>filename of the normal map</description>
+    </element>
+  </element>
+
+  <element name="render_order" type="float" default="0.0" required="0">
+    <description>Set render order for coplanar polygons. The higher value will be rendered on top of the other coplanar polygons</description>
+  </element>
+
+  <element name="lighting" type="bool" default="true" required="0">
+    <description>If false, dynamic lighting will be disabled</description>
+  </element>
+
+  <element name="ambient" type="color" default="0 0 0 1" required="0">
+    <description>The ambient color of a material specified by set of four numbers representing red/green/blue, each in the range of [0,1].</description>
+  </element>
+
+  <element name="diffuse"  type="color" default="0 0 0 1" required="0">
+    <description>The diffuse color of a material specified by set of four numbers representing red/green/blue/alpha, each in the range of [0,1].</description>
+  </element>
+
+  <element name="specular" type="color" default="0 0 0 1" required="0">
+    <description>The specular color of a material specified by set of four numbers representing red/green/blue/alpha, each in the range of [0,1].</description>
+  </element>
+
+  <element name="shininess" type="double" default="0" required="0">
+    <description>The specular exponent of a material</description>
+  </element>
+
+  <element name="emissive" type="color" default="0 0 0 1" required="0">
+    <description>The emissive color of a material specified by set of four numbers representing red/green/blue, each in the range of [0,1].</description>
+  </element>
+
+  <element name="double_sided" type="bool" default="false" required="0">
+    <description>If true, the mesh that this material is applied to will be rendered as double sided</description>
+  </element>
+
+
+  <element name="pbr" required="0">
+    <description>Physically Based Rendering (PBR) material. There are two PBR workflows: metal and specular. While both workflows and their parameters can be specified at the same time, typically only one of them will be used (depending on the underlying renderer capability). It is also recommended to use the same workflow for all materials in the world.</description>
+
+    <element name="metal" required="0">
+      <description>PBR using the Metallic/Roughness workflow.</description>
+
+      <element name="albedo_map" type="string" default="" required="0">
+        <description>Filename of the diffuse/albedo map.</description>
+      </element>
+
+      <element name="roughness_map" type="string" default="" required="0">
+        <description>Filename of the roughness map.</description>
+      </element>
+
+      <element name="roughness" type="string" default="0.5" required="0">
+        <description>Material roughness in the range of [0,1], where 0 represents a smooth surface and 1 represents a rough surface. This is the inverse of a specular map in a PBR specular workflow.</description>
+      </element>
+
+      <element name="metalness_map" type="string" default="" required="0">
+        <description>Filename of the metalness map.</description>
+      </element>
+
+      <element name="metalness" type="string" default="0.5" required="0">
+        <description>Material metalness in the range of [0,1], where 0 represents non-metal and 1 represents raw metal</description>
+      </element>
+
+      <element name="environment_map" type="string" default="" required="0">
+        <description>Filename of the environment / reflection map, typically in the form of a cubemap</description>
+      </element>
+
+      <element name="ambient_occlusion_map" type="string" default="" required="0">
+        <description>Filename of the ambient occlusion map. The map defines the amount of ambient lighting on the surface.</description>
+      </element>
+
+      <element name="normal_map" type="string" default="" required="0">
+        <attribute name="type" type="string" default="tangent" required="0">
+          <description>The space that the normals are in. Values are: 'object' or 'tangent'</description>
+        </attribute>
+
+        <description>Filename of the normal map. The normals can be in the object space or tangent space as specified in the 'type' attribute</description>
+      </element>
+
+      <element name="emissive_map" type="string" default="" required="0">
+        <description>Filename of the emissive map.</description>
+      </element>
+
+      <element name="light_map" type="string" default="" required="0">
+        <attribute name="uv_set" type="unsigned int" default="0" required="0">
+          <description>Index of the texture coordinate set to use.</description>
+        </attribute>
+        <description>Filename of the light map. The light map is a prebaked light texture that is applied over the albedo map</description>
+      </element>
+
+    </element>
+
+    <element name="specular" required="0">
+      <description>PBR using the Specular/Glossiness workflow.</description>
+
+      <element name="albedo_map" type="string" default="" required="0">
+        <description>Filename of the diffuse/albedo map.</description>
+      </element>
+
+      <element name="specular_map" type="string" default="" required="0">
+        <description>Filename of the specular map.</description>
+      </element>
+
+      <element name="glossiness_map" type="string" default="" required="0">
+        <description>Filename of the glossiness map.</description>
+      </element>
+
+      <element name="glossiness" type="string" default="0" required="0">
+        <description>Material glossiness in the range of [0-1], where 0 represents a rough surface and 1 represents a smooth surface. This is the inverse of a roughness map in a PBR metal workflow.</description>
+      </element>
+
+      <element name="environment_map" type="string" default="" required="0">
+        <description>Filename of the environment / reflection map, typically in the form of a cubemap</description>
+      </element>
+
+      <element name="ambient_occlusion_map" type="string" default="" required="0">
+        <description>Filename of the ambient occlusion map. The map defines the amount of ambient lighting on the surface.</description>
+      </element>
+
+      <element name="normal_map" type="string" default="" required="0">
+        <attribute name="type" type="string" default="tangent" required="0">
+          <description>The space that the normals are in. Values are: 'object' or 'tangent'</description>
+        </attribute>
+
+        <description>Filename of the normal map. The normals can be in the object space or tangent space as specified in the 'type' attribute</description>
+      </element>
+
+      <element name="emissive_map" type="string" default="" required="0">
+        <description>Filename of the emissive map.</description>
+      </element>
+
+      <element name="light_map" type="string" default="" required="0">
+        <attribute name="uv_set" type="unsigned int" default="0" required="0">
+          <description>Index of the texture coordinate set to use.</description>
+        </attribute>
+        <description>Filename of the light map. The light map is a prebaked light texture that is applied over the albedo map</description>
+      </element>
+    </element>
+
+  </element>
+
+
+</element> <!-- End Material -->

--- a/sdf/1.12/mesh_shape.sdf
+++ b/sdf/1.12/mesh_shape.sdf
@@ -1,0 +1,20 @@
+<element name="mesh" required="0">
+  <description>Mesh shape</description>
+  <element name="uri" type="string" default="__default__" required="1">
+    <description>Mesh uri</description>
+  </element>
+
+  <element name="submesh" required="0">
+    <description>Use a named submesh. The submesh must exist in the mesh specified by the uri</description>
+    <element name="name" type="string" default="__default__" required="1">
+      <description>Name of the submesh within the parent mesh</description>
+    </element>
+    <element name="center" type="bool" default="false" required="0">
+      <description>Set to true to center the vertices of the submesh at 0,0,0. This will effectively remove any transformations on the submesh before the poses from parent links and models are applied.</description>
+    </element>
+  </element> <!-- End submesh -->
+
+  <element name="scale" type="vector3" default="1 1 1" required="0">
+    <description>Scaling factor applied to the mesh</description>
+  </element>
+</element>

--- a/sdf/1.12/mimic.sdf
+++ b/sdf/1.12/mimic.sdf
@@ -1,0 +1,37 @@
+<!-- Mimic -->
+<element name="mimic" required="0">
+  <description>Specifies a linear equality constraint between the position of two joint
+    axes. One joint axis is labeled as the leader and the other as the follower.
+    The joint axis containing a mimic tag is the follower, and the leader
+    is specified by the joint and axis attributes.
+    The multiplier, offset, and reference parameters determine the linear relationship
+    according to the following equation:
+    follower_position = multiplier * (leader_position - reference) + offset.
+    Note that the multiplier and offset parameters match the parameters of
+    the URDF mimic tag if the reference parameter is 0.
+  </description>
+  <attribute name="joint" type="string" default="" required="1">
+    <description>Name of the joint containing the leader axis, i.e. the axis to be mimicked</description>
+  </attribute>
+  <attribute name="axis" type="string" default="axis" required="0">
+    <description>Name of the leader axis, i.e. the axis to be mimicked.
+      The only valid values are "axis" and "axis2", and "axis2" may only be
+      used if the leader joint has multiple axes.
+    </description>
+  </attribute>
+  <element name="multiplier" type="double" default="1.0" required="1">
+    <description>A parameter representing the ratio between changes in the
+      follower joint axis position relative to changes in the leader joint
+      axis position. It can be expressed as follows:
+      multiplier = (follower_position - offset) / (leader_position - reference)
+    </description>
+  </element>
+  <element name="offset" type="double" default="0" required="1">
+    <description>Offset to the follower position in the linear constraint.</description>
+  </element>
+  <element name="reference" type="double" default="0" required="1">
+    <description>Reference for the leader position before applying the
+      multiplier in the linear constraint.
+    </description>
+  </element>
+</element> <!-- End Mimic -->

--- a/sdf/1.12/model.sdf
+++ b/sdf/1.12/model.sdf
@@ -1,0 +1,92 @@
+<!-- Model -->
+<element name="model" required="*">
+  <description>The model element defines a complete robot or any other physical object.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>
+      The name of the model and its implicit frame. This name must be unique
+      among all elements defining frames within the same scope, i.e., it must
+      not match another //model, //frame, //joint, or //link within the same
+      scope.
+    </description>
+  </attribute>
+
+  <attribute name="canonical_link" type="string" default="" required="0">
+    <description>
+      The name of the model's canonical link, to which the model's implicit
+      coordinate frame is attached. If unset or set to an empty string, the
+      first `/link` listed as a direct child of this model is chosen as the
+      canonical link. If the model has no direct `/link` children, it will
+      instead be attached to the first nested (or included) model's implicit
+      frame.
+    </description>
+  </attribute>
+  <attribute name="placement_frame" type="string" default="" required="0">
+    <description>The frame inside this model whose pose will be set by the pose element of the model. i.e, the pose element specifies the pose of this frame instead of the model frame.</description>
+  </attribute>
+
+  <element name="static" type="bool" default="false" required="0">
+    <description>
+      If set to true, the model is immovable; i.e., a dynamics engine will not
+      update its position. This will also overwrite this model's `@canonical_link`
+      and instead attach the model's implicit frame to the world's implicit frame.
+      This holds even if this model is nested (or included) by another model
+      instead of being a direct child of `//world`.
+    </description>
+  </element>
+
+  <element name="self_collide" type="bool" default="false" required="0">
+    <description>If set to true, all links in the model will collide with each other (except those connected by a joint). Can be overridden by the link or collision element self_collide property. Two links within a model will collide if link1.self_collide OR link2.self_collide. Links connected by a joint will never collide.</description>
+  </element>
+
+  <element name="allow_auto_disable" type="bool" default="true" required="0">
+    <description>Allows a model to auto-disable, which is means the physics engine can skip updating the model when the model is at rest. This parameter is only used by models with no joints.</description>
+  </element>
+
+  <include filename="frame.sdf" required="*"/>
+  <include filename="pose.sdf" required="0"/>
+  <include filename="link.sdf" required="*"/>
+  <include filename="joint.sdf" required="*"/>
+  <include filename="plugin.sdf" required="*"/>
+  <include filename="gripper.sdf" required="*"/>
+
+  <element name="include" required="*">
+    <description>
+      Include resources from a URI. This can be used to nest models. The included resource can only contain one 'model' element. The URI can point to a directory or a file. If the URI is a directory, it must conform to the model database structure (see /tutorials?tut=composition&amp;cat=specification&amp;#defining-models-in-separate-files).
+    </description>
+    <attribute name="merge" type="bool" default="false" required="0">
+      <description>Merge the included nested model into the top model</description>
+    </attribute>
+
+    <element name="uri" type="string" default="__default__" required="1">
+      <description>URI to a resource, such as a model</description>
+    </element>
+
+    <include filename="pose.sdf" required="0"/>
+    <include filename="plugin.sdf" required="*"/>
+
+    <element name="name" type="string" default="" required="0">
+      <description>Override the name of the included model.</description>
+    </element>
+
+    <element name="static" type="bool" default="false" required="0">
+      <description>Override the static value of the included model.</description>
+    </element>
+
+    <element name="placement_frame" type="string" default="" required="0">
+      <description>The frame inside the included model whose pose will be set by the specified pose element. If this element is specified, the pose must be specified.</description>
+    </element>
+  </element>
+
+  <element name="model" ref="model" required="*">
+    <description>A nested model element</description>
+    <attribute name="name" type="string" default="__default__" required="1">
+      <description>A unique name for the model. This name must not match another nested model in the same level as this model.</description>
+    </attribute>
+  </element>
+
+  <element name="enable_wind" type="bool" default="false" required="0">
+    <description>If set to true, all links in the model will be affected by the wind. Can be overriden by the link wind property.</description>
+  </element>
+
+</element> <!-- End Model -->

--- a/sdf/1.12/model_state.sdf
+++ b/sdf/1.12/model_state.sdf
@@ -1,0 +1,41 @@
+<!-- State information for a model -->
+<element name="model" required="*">
+  <description>Model state</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Name of the model</description>
+  </attribute>
+
+  <element name="joint" required="*">
+    <description>Joint angle</description>
+
+    <attribute name="name" type="string" default="__default__" required="1">
+      <description>Name of the joint</description>
+    </attribute>
+
+    <element name="angle" type="double" default="0" required="+">
+      <attribute name="axis" type="unsigned int" default="0" required="1">
+        <description>Index of the axis.</description>
+      </attribute>
+
+      <description>Angle of an axis</description>
+    </element>
+  </element>
+
+  <element name="model" ref="model_state" required="*">
+    <description>A nested model state element</description>
+    <attribute name="name" type="string" default="__default__" required="1">
+      <description>Name of the model. </description>
+    </attribute>
+  </element>
+
+  <include filename="frame.sdf" required="*"/>
+  <include filename="pose.sdf" required="0"/>
+
+  <element name="scale" type="vector3" default="1 1 1" required="0">
+    <description>Scale for the 3 dimensions of the model.</description>
+  </element>
+
+  <include filename="link_state.sdf" required="*"/>
+
+</element> <!-- End Model -->

--- a/sdf/1.12/navsat.sdf
+++ b/sdf/1.12/navsat.sdf
@@ -1,0 +1,40 @@
+<element name="navsat" required="0">
+  <description>These elements are specific to the NAVSAT sensor.</description>
+
+  <element name="position_sensing" required="0">
+    <description>
+      Parameters related to NAVSAT position measurement.
+    </description>
+    <element name="horizontal" required="0">
+      <description>
+        Noise parameters for horizontal position measurement, in units of meters.
+      </description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="vertical" required="0">
+      <description>
+        Noise parameters for vertical position measurement, in units of meters.
+      </description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+  </element>
+
+  <element name="velocity_sensing" required="0">
+    <description>
+      Parameters related to NAVSAT position measurement.
+    </description>
+    <element name="horizontal" required="0">
+      <description>
+        Noise parameters for horizontal velocity measurement, in units of meters/second.
+      </description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+    <element name="vertical" required="0">
+      <description>
+        Noise parameters for vertical velocity measurement, in units of meters/second.
+      </description>
+      <include filename="noise.sdf" required="0"/>
+    </element>
+  </element>
+
+</element>

--- a/sdf/1.12/noise.sdf
+++ b/sdf/1.12/noise.sdf
@@ -1,0 +1,43 @@
+<element name="noise" required="1">
+  <description>The properties of a sensor noise model.</description>
+
+  <attribute name="type" type="string" default="none" required="1">
+    <description>
+      The type of noise. Currently supported types are:
+      "none" (no noise).
+      "gaussian" (draw noise values independently for each measurement from a Gaussian distribution).
+      "gaussian_quantized" ("gaussian" plus quantization of outputs (ie. rounding))
+    </description>
+  </attribute>
+  <element name="mean" type="double" default="0.0" required="0">
+    <description>
+      For type "gaussian*", the mean of the Gaussian distribution from which
+      noise values are drawn.
+    </description>
+  </element>
+  <element name="stddev" type="double" default="0.0" min="0.0" required="0">
+    <description>For type "gaussian*", the standard deviation of the Gaussian distribution from which noise values are drawn.</description>
+  </element>
+  <element name="bias_mean" type="double" default="0.0" required="0">
+    <description>For type "gaussian*", the mean of the Gaussian distribution from which bias values are drawn.</description>
+  </element>
+  <element name="bias_stddev" type="double" default="0.0" min="0.0" required="0">
+    <description>For type "gaussian*", the standard deviation of the Gaussian distribution from which bias values are drawn.</description>
+  </element>
+
+  <element name="dynamic_bias_stddev" type="double" default="0.0" min="0.0" required="0">
+    <description>For type "gaussian*", the standard deviation of the noise used to drive a process to model slow variations in a sensor bias.</description>
+  </element>
+
+  <element name="dynamic_bias_correlation_time" type="double" default="0.0" required="0">
+    <description>For type "gaussian*", the correlation time in seconds of the noise used to drive a process to model slow variations in a sensor bias. A typical value, when used, would be on the order of 3600 seconds (1 hour).</description>
+  </element>
+
+  <element name="precision" type="double" default="0.0" required="0">
+    <description>
+      For type "gaussian_quantized", the precision of output signals. A value
+      of zero implies infinite precision / no quantization.
+    </description>
+  </element>
+
+</element>

--- a/sdf/1.12/particle_emitter.sdf
+++ b/sdf/1.12/particle_emitter.sdf
@@ -1,0 +1,120 @@
+<!-- Particle emitter -->
+<element name="particle_emitter" required="*">
+  <description>A particle emitter that can be used to describe fog, smoke, and dust.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>A unique name for the particle emitter.</description>
+  </attribute>
+
+  <attribute name="type" type="string" default="point" required="1">
+    <description>The type of a particle emitter. One of "box", "cylinder", "ellipsoid", or "point".</description>
+  </attribute>
+
+  <element name="emitting" type="bool" default="true" required="0">
+    <description>True indicates that the particle emitter should generate particles when loaded</description>
+  </element>
+
+  <element name="duration" type="double" default="0" required="0">
+    <description>The number of seconds the emitter is active. A value less than or equal to zero means infinite duration.</description>
+  </element>
+
+  <element name="size" type="vector3" default="1 1 1" required="0">
+    <description>
+    The size of the emitter where the particles are sampled.
+    Default value is (1, 1, 1).
+    Note that the interpretation of the emitter area varies
+    depending on the emmiter type:
+      - point: The area is ignored.
+      - box: The area is interpreted as width X height X depth.
+      - cylinder: The area is interpreted as the bounding box of the
+                  cylinder. The cylinder is oriented along the Z-axis.
+      - ellipsoid: The area is interpreted as the bounding box of an
+                   ellipsoid shaped area, i.e. a sphere or
+                   squashed-sphere area. The parameters are again
+                   identical to EM_BOX, except that the dimensions
+                   describe the widest points along each of the axes.
+    </description>
+  </element>
+
+  <element name="particle_size" type="vector3" default="1 1 1" required="0">
+    <description>The particle dimensions (width, height, depth).</description>
+  </element>
+
+  <element name="lifetime" type="double" default="5" required="0">
+    <description>The number of seconds each particle will ’live’ for before being destroyed. This value must be greater than zero.</description>
+  </element>
+
+  <element name="rate" type="double" default="10" required="0" min="0.0">
+    <description>The number of particles per second that should be emitted.</description>
+  </element>
+
+  <element name="min_velocity" type="double" default="1" required="0" min="0.0">
+    <description>Sets a minimum velocity for each particle (m/s).</description>
+  </element>
+
+  <element name="max_velocity" type="double" default="1" required="0" min="0.0">
+    <description>Sets a maximum velocity for each particle (m/s).</description>
+  </element>
+
+  <element name="scale_rate" type="double" default="0" required="0" min="0.0">
+    <description>Sets the amount by which to scale the particles in both x and y direction per second.</description>
+  </element>
+
+  <element name="color_start" type="color" default="1 1 1 1" required="0">
+    <description>
+     Sets the starting color for all particles emitted.
+     The actual color will be interpolated between this color
+     and the one set under color_end.
+     Color::White is the default color for the particles
+     unless a specific function is used.
+     To specify a color, RGB values should be passed in.
+     For example, to specify red, a user should enter:
+     <color_start>1 0 0</color_start>
+     Note that this function overrides the particle colors set
+     with color_range_image.
+    </description>
+  </element>
+
+  <element name="color_end" type="color" default="1 1 1 1" required="0">
+    <description>
+    Sets the end color for all particles emitted.
+    The actual color will be interpolated between this color
+    and the one set under color_start.
+    Color::White is the default color for the particles
+    unless a specific function is used (see color_start for
+    more information about defining custom colors with RGB
+    values).
+    Note that this function overrides the particle colors set
+    with color_range_image.
+    </description>
+  </element>
+
+  <element name="color_range_image" type="string" default="" required="0">
+    <description>
+    Sets the path to the color image used as an affector. This affector modifies the color of particles in flight. The colors are taken from a specified image file. The range of color values begins from the left side of the image and moves to the right over the lifetime of the particle, therefore only the horizontal dimension of the image is used.  Note that this function overrides the particle colors set with color_start and color_end.
+    </description>
+  </element>
+
+  <element name="topic" type="string" default="" required="0">
+    <description>
+     Topic used to update particle emitter properties at runtime.
+     The default topic is
+     /model/{model_name}/particle_emitter/{emitter_name}
+     Note that the emitter id and name may not be changed.
+    </description>
+  </element>
+
+  <element name="particle_scatter_ratio" type="float" default="0.65" required="0">
+    <description>
+    This is used to determine the ratio of particles that will be detected
+    by sensors. Increasing the ratio means there is a higher chance of
+    particles reflecting and interfering with depth sensing, making the
+    emitter appear more dense. Decreasing the ratio decreases the chance
+    of particles reflecting and interfering with depth sensing, making it
+    appear less dense.
+    </description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+  <include filename="material.sdf" required="0"/>
+</element>

--- a/sdf/1.12/physics.sdf
+++ b/sdf/1.12/physics.sdf
@@ -1,0 +1,238 @@
+<!-- Physics -->
+<element name="physics" required="1">
+  <description>The physics tag specifies the type and properties of the dynamics engine.</description>
+
+  <attribute name="name" type="string" default="default_physics" required="0">
+    <description>The name of this set of physics parameters.</description>
+  </attribute>
+
+  <attribute name="default" type="bool" default="false" required="0">
+    <description>If true, this physics element is set as the default physics profile for the world. If multiple default physics elements exist, the first element marked as default is chosen. If no default physics element exists, the first physics element is chosen.</description>
+  </attribute>
+
+  <attribute name="type" type="string" default="ode" required="1">
+    <description>The type of the dynamics engine. Current options are ode, bullet, simbody and dart.  Defaults to ode if left unspecified.</description>
+  </attribute>
+
+  <element name="max_step_size" type="double" default="0.001" required="1">
+    <description>Maximum time step size at which every system in simulation can interact with the states of the world.  (was physics.sdf's dt).</description>
+  </element>
+
+  <!-- real_time_factor (simulation speedup) might be more intuitive to end
+       users than real_time_update_rate -->
+  <element name="real_time_factor" type="double" default="1.0" required="1">
+    <description>target simulation speedup factor, defined by ratio of simulation time to real-time.</description>
+  </element>
+
+  <!-- to be deprecated by real_time_factor -->
+  <element name="real_time_update_rate" type="double" default="1000" required="1">
+    <description>Rate at which to update the physics engine (UpdatePhysics calls per real-time second). (was physics.sdf's update_rate).</description>
+  </element>
+
+  <element name="max_contacts" type="int" default="20" required="0">
+    <description>Maximum number of contacts allowed between two entities. This value can be over ridden by a max_contacts element in a collision element.</description>
+  </element>
+
+  <element name="dart" required="0">
+    <description>DART specific physics properties</description>
+    <element name="solver" required="1">
+      <description></description>
+      <element name="solver_type" type="string" default="dantzig" required="1">
+        <description>One of the following types: pgs, dantzig. PGS stands for Projected Gauss-Seidel.</description>
+      </element>
+    </element>
+    <element name="collision_detector" type="string" default="fcl" required="0">
+      <description>Specify collision detector for DART to use. Can be dart, fcl, bullet or ode. </description>
+    </element>
+  </element>
+
+  <element name="simbody" required="0">
+    <description>Simbody specific physics properties</description>
+    <element name="min_step_size" type="double" default="0.0001" required="0">
+      <description>(Currently not used in simbody) The time duration which advances with each iteration of the dynamics engine, this has to be no bigger than max_step_size under physics block.  If left unspecified, min_step_size defaults to max_step_size.</description>
+    </element>
+    <element name="accuracy" type="double" default="1e-3" required="0">
+      <description>Roughly the relative error of the system.
+        -LOG(accuracy) is roughly the number of significant digits.</description>
+    </element>
+    <element name="max_transient_velocity" type="double"
+             default="0.01" required="0">
+      <description>Tolerable "slip" velocity allowed by the solver when static
+        friction is supposed to hold object in place.</description>
+    </element>
+    <element name="contact" required="0">
+      <description><![CDATA[
+        Relationship among dissipation, coef. restitution, etc.
+        d = dissipation coefficient (1/velocity)
+        vc = capture velocity (velocity where e=e_max)
+        vp = plastic velocity (smallest v where e=e_min) > vc
+        Assume real COR=1 when v=0.
+        e_min = given minimum COR, at v >= vp (a.k.a. plastic_coef_restitution)
+        d = slope = (1-e_min)/vp
+        OR, e_min = 1 - d*vp
+        e_max = maximum COR = 1-d*vc, reached at v=vc
+        e = 0,                       v <= vc
+          = 1 - d*v,               vc < v < vp
+          = e_min,                   v >= vp
+
+        dissipation factor = d*min(v,vp)   [compliant]
+        cor = e                            [rigid]
+
+        Combining rule e = 0,               e1==e2==0
+                         = 2*e1*e2/(e1+e2), otherwise]]>
+      </description>
+
+      <element name="stiffness" type="double" default="1e8" required="0">
+        <description>Default contact material stiffness
+                     (force/dist or torque/radian).</description>
+      </element>
+      <element name="dissipation" type="double" default="100" required="0">
+        <description>dissipation coefficient to be used in compliant contact;
+    if not given it is (1-min_cor)/plastic_impact_velocity</description>
+      </element>
+
+      <element name="plastic_coef_restitution" type="double"
+               default="0.5" required="0">
+        <description>this is the COR to be used at high velocities for rigid
+    impacts; if not given it is 1 - dissipation*plastic_impact_velocity
+        </description>
+      </element>
+
+      <element name="plastic_impact_velocity" type="double"
+               default="0.5" required="0">
+        <description>smallest impact velocity at which min COR is reached; set
+      to zero if you want the min COR always to be used</description>
+      </element>
+
+      <element name="static_friction" type="double" default="0.9" required="0">
+        <description>static friction (mu_s) as described by this plot: http://gazebosim.org/wiki/File:Stribeck_friction.png</description>
+      </element>
+      <element name="dynamic_friction" type="double" default="0.9" required="0">
+        <description>dynamic friction (mu_d) as described by this plot: http://gazebosim.org/wiki/File:Stribeck_friction.png</description>
+      </element>
+      <element name="viscous_friction" type="double" default="0.0" required="0">
+        <description>viscous friction (mu_v) with units of (1/velocity) as described by this plot: http://gazebosim.org/wiki/File:Stribeck_friction.png</description>
+      </element>
+
+      <element name="override_impact_capture_velocity" type="double"
+               default="0.001" required="0">
+        <description>for rigid impacts only, impact velocity at which
+          COR is set to zero; normally inherited from global default but can
+          be overridden here. Combining rule: use larger velocity</description>
+      </element>
+
+      <element name="override_stiction_transition_velocity" type="double"
+               default="0.001" required="0">
+        <description>This is the largest slip velocity at which
+           we'll consider a transition to stiction. Normally inherited
+           from a global default setting. For a continuous friction model
+           this is the velocity at which the max static friction force
+           is reached.  Combining rule: use larger velocity</description>
+      </element>
+
+    </element>
+  </element>
+
+  <element name="bullet" required="0">
+    <description>Bullet specific physics properties</description>
+    <element name="solver" required="1">
+      <description></description>
+      <element name="type" type="string" default="sequential_impulse" required="1">
+        <description>One of the following types: sequential_impulse only.</description>
+      </element>
+      <element name="min_step_size" type="double" default="0.0001" required="0">
+        <description>The time duration which advances with each iteration of the dynamics engine, this has to be no bigger than max_step_size under physics block.  If left unspecified, min_step_size defaults to max_step_size.</description>
+      </element>
+      <element name="iters" type="int" default="50" required="1">
+        <description>Number of iterations for each step. A higher number produces greater accuracy at a performance cost.</description>
+      </element>
+      <element name="sor" type="double" default="1.3" required="1">
+        <description>Set the successive over-relaxation parameter.</description>
+      </element>
+    </element> <!-- End Solver -->
+
+    <element name="constraints" required="1">
+      <description>Bullet constraint parameters.</description>
+      <element name="cfm" type="double" default="0" required="1">
+        <description>Constraint force mixing parameter. See the ODE page for more information.</description>
+      </element>
+      <element name="erp" type="double" default="0.2" required="1">
+        <description>Error reduction parameter. See the ODE page for more information.</description>
+      </element>
+      <element name="contact_surface_layer" type="double" default="0.001" required="1">
+        <description>The depth of the surface layer around all geometry objects. Contacts are allowed to sink into the surface layer up to the given depth before coming to rest. The default value is zero. Increasing this to some small value (e.g. 0.001) can help prevent jittering problems due to contacts being repeatedly made and broken.</description>
+      </element>
+      <element name="split_impulse" type="bool" default="true" required="1">
+        <description>Similar to ODE's max_vel implementation. See http://web.archive.org/web/20120430155635/http://bulletphysics.org/mediawiki-1.5.8/index.php/BtContactSolverInfo#Split_Impulse for more information.</description>
+      </element>
+      <element name="split_impulse_penetration_threshold" type="double" default="-0.01" required="1">
+        <description>Similar to ODE's max_vel implementation.  See http://web.archive.org/web/20120430155635/http://bulletphysics.org/mediawiki-1.5.8/index.php/BtContactSolverInfo#Split_Impulse for more information.</description>
+      </element>
+    </element> <!-- End Constraints -->
+  </element>
+
+  <element name="ode" required="0">
+    <description>ODE specific physics properties</description>
+    <element name="solver" required="1">
+      <description></description>
+      <element name="type" type="string" default="quick" required="1">
+        <description>One of the following types: world, quick</description>
+      </element>
+      <element name="min_step_size" type="double" default="0.0001" required="0">
+        <description>The time duration which advances with each iteration of the dynamics engine, this has to be no bigger than max_step_size under physics block.  If left unspecified, min_step_size defaults to max_step_size.</description>
+      </element>
+      <element name="island_threads" type="int" default="0" required="0">
+        <description>Number of threads to use for "islands" of disconnected models.</description>
+      </element>
+      <element name="iters" type="int" default="50" required="1">
+        <description>Number of iterations for each step. A higher number produces greater accuracy at a performance cost.</description>
+      </element>
+      <element name="precon_iters" type="int" default="0" required="0">
+        <description>Experimental parameter.</description>
+      </element>
+      <element name="sor" type="double" default="1.3" required="1">
+        <description>Set the successive over-relaxation parameter.</description>
+      </element>
+      <element name="thread_position_correction" type="bool" default="false" required="0">
+        <description>Flag to use threading to speed up position correction computation.</description>
+      </element>
+      <element name="use_dynamic_moi_rescaling" type="bool" default="false" required="1">
+        <description>
+          Flag to enable dynamic rescaling of moment of inertia in constrained directions.
+          See gazebo pull request 1114 for the implementation of this feature.
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
+        </description>
+      </element>
+      <element name="friction_model" type="string" default="pyramid_model" required="0">
+        <description>
+          Name of ODE friction model to use. Valid values include:
+
+          pyramid_model: (default) friction forces limited in two directions
+          in proportion to normal force.
+          box_model: friction forces limited to constant in two directions.
+          cone_model: friction force magnitude limited in proportion to normal force.
+
+          See gazebo pull request 1522 for the implementation of this feature.
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522
+          https://github.com/osrf/gazebo/commit/968dccafdfbfca09c9b3326f855612076fed7e6f
+        </description>
+      </element>
+    </element> <!-- End Solver -->
+
+    <element name="constraints" required="1">
+      <description>ODE constraint parameters.</description>
+      <element name="cfm" type="double" default="0" required="1">
+        <description>Constraint force mixing parameter. See the ODE page for more information.</description>
+      </element>
+      <element name="erp" type="double" default="0.2" required="1">
+        <description>Error reduction parameter. See the ODE page for more information.</description>
+      </element>
+      <element name="contact_max_correcting_vel" type="double" default="100.0" required="1">
+        <description>The maximum correcting velocities allowed when resolving contacts.</description>
+      </element>
+      <element name="contact_surface_layer" type="double" default="0.001" required="1">
+        <description>The depth of the surface layer around all geometry objects. Contacts are allowed to sink into the surface layer up to the given depth before coming to rest. The default value is zero. Increasing this to some small value (e.g. 0.001) can help prevent jittering problems due to contacts being repeatedly made and broken.</description>
+      </element>
+    </element> <!-- End Constraints -->
+  </element> <!-- ODE -->
+</element> <!-- Physics -->

--- a/sdf/1.12/plane_shape.sdf
+++ b/sdf/1.12/plane_shape.sdf
@@ -1,0 +1,9 @@
+<element name="plane" required="0">
+  <description>Plane shape</description>
+  <element name="normal" type="vector3" default="0 0 1" required="1">
+    <description>Normal direction for the plane. When a Plane is used as a geometry for a Visual or Collision object, then the normal is specified in the Visual or Collision frame, respectively.</description>
+  </element>
+  <element name="size" type="vector2d" default="1 1" min="0 0" required="1">
+    <description>Length of each side of the plane. Note that this property is meaningful only for visualizing the Plane, i.e., when the Plane is used as a geometry for a Visual object. The Plane has infinite size when used as a geometry for a Collision object.</description>
+  </element>
+</element>

--- a/sdf/1.12/plugin.sdf
+++ b/sdf/1.12/plugin.sdf
@@ -1,0 +1,13 @@
+<!-- Plugin -->
+<element name="plugin" required="*">
+  <description>A plugin is a dynamically loaded chunk of code. It can exist as a child of world, model, and sensor.</description>
+  <attribute name="name" type="string" default="" required="0">
+    <description>A name for the plugin.</description>
+  </attribute>
+  <attribute name="filename" type="string" default="__default__" required="1">
+    <description>Name of the shared library to load. If the filename is not a full path name, the file will be searched for in the configuration paths.</description>
+  </attribute>
+  <element copy_data="true" required="*">
+    <description>This is a special element that should not be specified in an SDFormat file. It automatically copies child elements into the SDFormat element so that a plugin can access the data.</description>
+  </element>
+</element> <!-- End Plugin -->

--- a/sdf/1.12/polyline_shape.sdf
+++ b/sdf/1.12/polyline_shape.sdf
@@ -1,0 +1,14 @@
+<element name="polyline" required="0">
+  <description>Defines an extruded polyline shape</description>
+
+  <element name="point" type="vector2d" default="0 0" required="+">
+    <description>
+      A series of points that define the path of the polyline.
+    </description>
+  </element>
+
+  <element name="height" type="double" default="1.0" required="1">
+    <description>Height of the polyline</description>
+  </element>
+
+</element>

--- a/sdf/1.12/population.sdf
+++ b/sdf/1.12/population.sdf
@@ -1,0 +1,58 @@
+<!-- Population -->
+<element name="population" required="*">
+  <description>
+    The population element defines how and where a set of models will
+    be automatically populated in Gazebo.
+  </description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>
+      A unique name for the population. This name must not match
+      another population in the world.
+    </description>
+  </attribute>
+
+  <include filename="box_shape.sdf" required="0"/>
+  <include filename="cylinder_shape.sdf" required="0"/>
+
+  <element name="model_count" type="int" default="1" required="1">
+    <description>The number of models to place.</description>
+  </element><!-- End Model_count -->
+
+  <element name="distribution" required="1">
+    <description>
+      Specifies the type of object distribution and its optional parameters.
+    </description>
+
+    <element name="type" type="string" default="random" required="1">
+      <description>
+        Define how the objects will be placed in the specified region.
+        - random: Models placed at random.
+        - uniform: Models approximately placed in a 2D grid pattern with control
+            over the number of objects.
+        - grid: Models evenly placed in a 2D grid pattern. The number of objects
+            is not explicitly specified, it is based on the number of rows and
+            columns of the grid.
+        - linear-x: Models evently placed in a row along the global x-axis.
+        - linear-y: Models evently placed in a row along the global y-axis.
+        - linear-z: Models evently placed in a row along the global z-axis.
+      </description>
+    </element><!-- End Type -->
+
+    <element name="rows" type="int" default="1" required="0">
+      <description>Number of rows in the grid.</description>
+    </element><!-- End Rows -->
+    <element name="cols" type="int" default="1" required="0">
+      <description>Number of columns in the grid.</description>
+    </element><!-- End Columns -->
+    <element name="step" type="vector3" default="0.5 0.5 0" required="0">
+      <description>Distance between elements of the grid.</description>
+    </element><!-- End Step -->
+
+  </element><!-- End Distribution -->
+
+  <include filename="pose.sdf" required="0"/>
+
+  <include filename="model.sdf" required="1"/>
+
+</element> <!-- End Population -->

--- a/sdf/1.12/pose.sdf
+++ b/sdf/1.12/pose.sdf
@@ -1,0 +1,43 @@
+<!-- Pose -->
+<element name="pose" type="pose" default="0 0 0 0 0 0" required="0">
+  <description>A pose (translation, rotation) expressed in the frame named by
+  @relative_to. The first three components (x, y, z) represent the position of
+  the element's origin (in the @relative_to frame). The rotation component
+  represents the orientation of the element as either a sequence of Euler
+  rotations (r, p, y), see http://sdformat.org/tutorials?tut=specify_pose,
+  or as a quaternion (x, y, z, w), where w is the real component.</description>
+
+  <attribute name="relative_to" type="string" default="" required="0">
+    <description>
+      If specified, this pose is expressed in the named frame. The named frame
+      must be declared within the same scope (world/model) as the element that
+      has its pose specified by this tag.
+
+      If missing, the pose is expressed in the frame of the parent XML element
+      of the element that contains the pose. For exceptions to this rule and
+      more details on the default behavior, see
+      http://sdformat.org/tutorials?tut=pose_frame_semantics.
+
+      Note that @relative_to merely affects an element's initial pose and
+      does not affect the element's dynamic movement thereafter.
+
+      New in v1.8: @relative_to may use frames of nested scopes. In this case,
+      the frame is specified using `::` as delimiter to define the scope of the
+      frame, e.g. `nested_model_A::nested_model_B::awesome_frame`.
+    </description>
+  </attribute>
+
+  <attribute name="rotation_format" type="string" default="euler_rpy" required="0">
+    <description>'euler_rpy' by default. Supported rotation formats are
+      'euler_rpy', Euler angles representation in roll, pitch, yaw. The pose is expected to have 6 values.
+      'quat_xyzw', Quaternion representation in x, y, z, w. The pose is expected to have 7 values.
+    </description>
+  </attribute>
+
+  <attribute name="degrees" type="bool" default="false" required="0">
+    <description>
+      Whether or not the euler angles are in degrees, otherwise they will be interpreted as radians by default.
+    </description>
+  </attribute>
+
+</element> <!-- End Pose -->

--- a/sdf/1.12/projector.sdf
+++ b/sdf/1.12/projector.sdf
@@ -1,0 +1,32 @@
+<!-- Projector -->
+<element name="projector" required="0">
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Name of the projector</description>
+  </attribute>
+
+  <element name="texture" type="string" default="__default__" required="1">
+    <description>Texture name</description>
+  </element>
+
+  <element name="fov" type="double" default="0.785" required="0">
+    <description>Field of view</description>
+  </element>
+
+
+  <element name="near_clip" type="double" default="0.1" required="0">
+    <description>Near clip distance</description>
+  </element>
+
+
+  <element name="far_clip" type="double" default="10.0" required="0">
+    <description>far clip distance</description>
+  </element>
+
+  <element name="visibility_flags" type="unsigned int" default="4294967295" required="0">
+    <description><![CDATA[Visibility flags of a projector. When (camera's visibility_mask & projector's visibility_flags) evaluates to non-zero, the projector will be visible to the camera.]]></description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+
+  <include filename="plugin.sdf" required="*"/>
+</element>

--- a/sdf/1.12/ray.sdf
+++ b/sdf/1.12/ray.sdf
@@ -1,0 +1,78 @@
+<element name="ray" required="0">
+  <description>These elements are specific to the ray (laser) sensor.</description>
+
+  <element name="scan" required="1">
+    <description></description>
+    <element name="horizontal" required="1">
+      <description></description>
+
+      <element name="samples" type="unsigned int" default="640" required="1">
+        <description>The number of simulated rays to generate per complete laser sweep cycle.</description>
+      </element>
+
+      <element name="resolution" type="double" default="1" required="1">
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged.</description>
+      </element>
+
+      <element name="min_angle" type="double" default="0" required="1">
+        <description></description>
+      </element>
+
+      <element name="max_angle" type="double" default="0" required="1">
+        <description>Must be greater or equal to min_angle</description>
+      </element>
+
+    </element> <!-- End Horizontal -->
+
+    <element name="vertical" required="0">
+      <description></description>
+      <element name="samples" type="unsigned int" default="1" required="1">
+        <description>The number of simulated rays to generate per complete laser sweep cycle.</description>
+      </element>
+
+      <element name="resolution" type="double" default="1" required="0">
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged.</description>
+      </element>
+
+      <element name="min_angle" type="double" default="0" required="1">
+        <description></description>
+      </element>
+
+      <element name="max_angle" type="double" default="0" required="1">
+        <description>Must be greater or equal to min_angle</description>
+      </element>
+
+    </element> <!-- End Vertical -->
+  </element> <!-- End Scan -->
+
+  <element name="range" required="1">
+    <description>specifies range properties of each simulated ray</description>
+    <element name="min" type="double" default="0" required="1">
+      <description>The minimum distance for each ray.</description>
+    </element>
+    <element name="max" type="double" default="0" required="1">
+      <description>The maximum distance for each ray.</description>
+    </element>
+    <element name="resolution" type="double" default="0" required="0">
+      <description>Linear resolution of each ray.</description>
+    </element>
+  </element> <!-- End Range -->
+
+  <element name="noise" required="0">
+    <description>The properties of the noise model that should be applied to generated scans</description>
+    <element name="type" type="string" default="gaussian" required="1">
+      <description>The type of noise.  Currently supported types are: "gaussian" (draw noise values independently for each beam from a Gaussian distribution).</description>
+    </element>
+    <element name="mean" type="double" default="0.0" required="0">
+      <description>For type "gaussian," the mean of the Gaussian distribution from which noise values are drawn.</description>
+    </element>
+    <element name="stddev" type="double" default="0.0" required="0">
+      <description>For type "gaussian," the standard deviation of the Gaussian distribution from which noise values are drawn.</description>
+    </element>
+  </element> <!-- End Noise -->
+
+  <element name="visibility_mask" type="unsigned int" default="4294967295" required="0">
+    <description><![CDATA[Visibility mask of a ray sensor. When (rays' visibility_mask & object's visibility_flags) evaluates to non-zero, the object will be visible to the ray sensor.]]></description>
+  </element>
+
+</element> <!-- End Ray -->

--- a/sdf/1.12/rfid.sdf
+++ b/sdf/1.12/rfid.sdf
@@ -1,0 +1,2 @@
+<element name="rfidtag" required="0">
+</element> <!-- End rfidtag -->

--- a/sdf/1.12/rfidtag.sdf
+++ b/sdf/1.12/rfidtag.sdf
@@ -1,0 +1,2 @@
+<element name="rfid" required="0">
+</element> <!-- End RFID -->

--- a/sdf/1.12/road.sdf
+++ b/sdf/1.12/road.sdf
@@ -1,0 +1,16 @@
+<!-- Model -->
+<element name="road" required="*">
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Name of the road</description>
+  </attribute>
+
+  <element name="width" type="double" default="1.0" required="1">
+    <description>Width of the road</description>
+  </element>
+
+  <element name="point" type="vector3" default="0 0 0" required="+">
+    <description>A series of points that define the path of the road.</description>
+  </element>
+
+  <include filename="material.sdf" required="0"/>
+</element>

--- a/sdf/1.12/root.sdf
+++ b/sdf/1.12/root.sdf
@@ -1,0 +1,21 @@
+<element name="sdf" required="1">
+  <description>SDFormat base element that can include one model, actor, light, or worlds. A user of multiple worlds could run parallel instances of simulation, or offer selection of a world at runtime.</description>
+
+  <attribute name="version" type="string" default="1.10" required="1">
+    <description>
+        Version number of the SDFormat specification, consisting of major
+        and minor versions delimited by a `.` character.
+        A major version bump is required if older versions cannot be
+        automatically converted to this version.
+        A minor version bump is required when there are breaking changes that
+        can be handled by the automatic conversion functionality encoded in the
+        `*.convert` files.
+    </description>
+  </attribute>
+
+  <include filename="world.sdf" required="*"/>
+  <include filename="model.sdf" required="0"/>
+  <include filename="actor.sdf" required="0"/>
+  <include filename="light.sdf" required="0"/>
+
+</element> <!-- End SDF -->

--- a/sdf/1.12/scene.sdf
+++ b/sdf/1.12/scene.sdf
@@ -1,0 +1,86 @@
+<!-- Scene -->
+<element name="scene" required="1">
+  <description>Specifies the look of the environment.</description>
+
+  <element name="ambient" type="color" default="0.4 0.4 0.4 1.0" required="1">
+    <description>Color of the ambient light.</description>
+  </element>
+
+  <element name="background" type="color" default=".7 .7 .7 1" required="1">
+    <description>Color of the background.</description>
+  </element>
+
+  <element name="sky" required="0">
+    <description>Properties for the sky</description>
+    <element name="time" type="double" default="10.0" required="0">
+      <description>Time of day [0..24]</description>
+    </element>
+    <element name="sunrise" type="double" default="6.0" required="0">
+      <description>Sunrise time [0..24]</description>
+    </element>
+    <element name="sunset" type="double" default="20.0" required="0">
+      <description>Sunset time [0..24]</description>
+    </element>
+
+    <element name="clouds" required="0">
+      <description>Information about clouds in the sky.</description>
+      <element name="speed" type="double" default="0.6" min="0.0" required="0">
+        <description>Speed of the clouds</description>
+      </element>
+
+      <element name="direction" type="double" default="0.0"
+               min="0.0" max="3.1456" required="0">
+        <description>Direction of the cloud movement</description>
+      </element>
+      <element name="humidity" type="double" default="0.5"
+               min="0" max="1" required="0">
+        <description>Density of clouds</description>
+      </element>
+
+      <element name="mean_size" type="double" default="0.5"
+               min="0" max="1" required="0">
+        <description>Average size of the clouds</description>
+      </element>
+
+      <element name="ambient" type="color" default=".8 .8 .8 1" required="0">
+        <description>Ambient cloud color</description>
+      </element>
+    </element>
+
+    <element name="cubemap_uri" type="string" default="" required="0">
+      <description>The URI to a cubemap texture for a skybox. A .dds file is typically used for the cubemap.</description>
+    </element>
+  </element>
+
+  <element name="shadows" type="bool" default="true" required="1">
+    <description>Enable/disable shadows</description>
+   </element>
+
+  <element name="fog" required="0">
+    <description>Controls fog</description>
+    <element name="color" type="color" default="1 1 1 1" required="0">
+      <description>Fog color</description>
+    </element>
+    <element name="type" type="string" default="none" required="0">
+      <description>Fog type: constant, linear, quadratic</description>
+    </element>
+    <element name="start" type="double" default="1.0" min="0.0" required="0">
+      <description>Distance to start of fog</description>
+    </element>
+    <element name="end" type="double" default="100.0" min="0.0" required="0">
+      <description>Distance to end of fog</description>
+    </element>
+    <element name="density" type="double" default="1.0" min="0.0" required="0">
+      <description>Density of fog</description>
+    </element>
+  </element>
+
+  <element name="grid" type="bool" default="true" required="0">
+    <description>Enable/disable the grid</description>
+  </element>
+
+  <element name="origin_visual" type="bool" default="true" required="0">
+    <description>Show/hide world origin indicator</description>
+  </element>
+
+</element> <!-- End Scene -->

--- a/sdf/1.12/schema/types.xsd
+++ b/sdf/1.12/schema/types.xsd
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema'>
+  <xsd:simpleType name="vector3">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="(\s*(-|\+)?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+)\s+){2}((-|\+)?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+))\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="quaternion">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="(\s*(-|\+)?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+)\s+){3}((-|\+)?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+))\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="vector2d">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="(\s*(-|\+)?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+)\s+)((-|\+)?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+))\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="vector2i">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\s*(-|\+)?\d+\s+(-|\+)?\d+\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="pose">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="(\s*(-|\+)?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+)\s+){5}((-|\+)?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+))\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="time">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="collapse"/>
+      <xsd:pattern value="\d+ \d+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="color">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="(\s*\+?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+)\s+){3}\+?(\d+(\.\d*)?|\.\d+|\d+\.\d+[eE][-\+]?[0-9]+)\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/sdf/1.12/sensor.sdf
+++ b/sdf/1.12/sensor.sdf
@@ -1,0 +1,82 @@
+<!-- Sensor -->
+<element name="sensor" required="0">
+  <description>The sensor tag describes the type and properties of a sensor.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>A unique name for the sensor. This name must not match another model in the model.</description>
+  </attribute>
+
+  <attribute name="type" type="string" default="__default__" required="1">
+    <description>The type name of the sensor. By default, SDFormat supports types
+                  air_pressure,
+                  air_speed,
+                  altimeter,
+                  camera,
+                  contact,
+                  boundingbox_camera, boundingbox,
+                  custom,
+                  depth_camera, depth,
+                  force_torque,
+                  gps,
+                  gpu_lidar,
+                  gpu_ray,
+                  imu,
+                  lidar,
+                  logical_camera,
+                  magnetometer,
+                  multicamera,
+                  navsat,
+                  ray,
+                  rfid,
+                  rfidtag,
+                  rgbd_camera, rgbd,
+                  segmentation_camera, segmentation,
+                  sonar,
+                  thermal_camera, thermal,
+                  wireless_receiver, and
+                  wireless_transmitter.
+      The "ray", "gpu_ray", and "gps" types are equivalent to "lidar", "gpu_lidar", and "navsat", respectively. It is preferred to use "lidar", "gpu_lidar", and "navsat" since "ray", "gpu_ray", and "gps" will be deprecated. The "ray", "gpu_ray", and "gps" types are maintained for legacy support.
+    </description>
+  </attribute>
+
+  <element name="always_on" type="bool" default="false" required="0">
+    <description>If true the sensor will always be updated according to the update rate.</description>
+  </element>
+
+  <element name="update_rate" type="double" default="0" required="0">
+    <description>The frequency at which the sensor data is generated. If left unspecified, the sensor will generate data every cycle.</description>
+  </element>
+
+  <element name="visualize" type="bool" default="false" required="0">
+    <description>If true, the sensor is visualized in the GUI</description>
+  </element>
+
+  <element name="topic" type="string" default="__default__" required="0">
+    <description>Name of the topic on which data is published. This is necessary for visualization</description>
+  </element>
+
+  <element name="enable_metrics" type="bool" default="false" required="0">
+    <description>If true, the sensor will publish performance metrics</description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+  <include filename="plugin.sdf" required="*"/>
+  <include filename="air_pressure.sdf" required="0"/>
+  <include filename="air_speed.sdf" required="0"/>
+  <include filename="altimeter.sdf" required="0"/>
+  <include filename="camera.sdf" required="0"/>
+  <include filename="contact.sdf" required="0"/>
+  <include filename="forcetorque.sdf" required="0"/>
+  <include filename="gps.sdf" required="0"/>
+  <include filename="imu.sdf" required="0"/>
+  <include filename="lidar.sdf" required="0"/>
+  <include filename="logical_camera.sdf" required="0"/>
+  <include filename="magnetometer.sdf" required="0"/>
+  <include filename="navsat.sdf" required="0"/>
+  <include filename="ray.sdf" required="0"/>
+  <include filename="rfid.sdf" required="0"/>
+  <include filename="rfidtag.sdf" required="0"/>
+  <include filename="sonar.sdf" required="0"/>
+  <include filename="transceiver.sdf" required="0"/>
+
+</element> <!-- End Sensor -->

--- a/sdf/1.12/sonar.sdf
+++ b/sdf/1.12/sonar.sdf
@@ -1,0 +1,16 @@
+<element name="sonar" required="0">
+  <description>These elements are specific to the sonar sensor.</description>
+  <element name="geometry" type="string" default="cone" required="0">
+    <description>The sonar collision shape. Currently supported geometries are: "cone" and "sphere".</description>
+  </element>
+  <element name="min" type="double" default="0" required="1">
+    <description>Minimum range</description>
+  </element>
+  <element name="max" type="double" default="1.0" required="1">
+    <description>Max range</description>
+  </element>
+
+  <element name="radius" type="double" default="0.5" required="0">
+    <description>Radius of the sonar cone at max range. This parameter is only used if geometry is "cone".</description>
+  </element>
+</element>

--- a/sdf/1.12/sphere_shape.sdf
+++ b/sdf/1.12/sphere_shape.sdf
@@ -1,0 +1,6 @@
+<element name="sphere" required="0">
+  <description>Sphere shape</description>
+  <element name="radius" type="double" default="1" required="1">
+    <description>radius of the sphere</description>
+  </element>
+</element>

--- a/sdf/1.12/spherical_coordinates.sdf
+++ b/sdf/1.12/spherical_coordinates.sdf
@@ -1,0 +1,65 @@
+<element name="spherical_coordinates" required="0">
+  <element name="surface_model" type="string" default="EARTH_WGS84" required="1">
+    <description>
+      Name of planetary surface model, used to determine the surface altitude
+      at a given latitude and longitude. The default is an ellipsoid model of
+      the earth based on the WGS-84 standard. It is used in Gazebo's GPS sensor
+      implementation.
+    </description>
+  </element>
+
+  <element name="world_frame_orientation" type="string" default="ENU" required="0">
+    <description>
+      This field identifies how Gazebo world frame is aligned in Geographical
+      sense.  The final Gazebo world frame orientation is obtained by rotating
+      a frame aligned with following notation by the field heading_deg.
+      Options are:
+        - ENU (East-North-Up)
+    </description>
+  </element>
+  <element name="latitude_deg" type="double" default="0.0" required="1">
+    <description>
+      Geodetic latitude at origin of gazebo reference frame, specified
+      in units of degrees.
+    </description>
+  </element>
+
+  <element name="longitude_deg" type="double" default="0.0" required="1">
+    <description>
+      Longitude at origin of gazebo reference frame, specified in units
+      of degrees.
+    </description>
+  </element>
+
+  <element name="elevation" type="double" default="0.0" required="1">
+    <description>
+      Elevation of origin of gazebo reference frame, specified in meters.
+    </description>
+  </element>
+
+  <element name="surface_axis_equatorial" type="double" default="0.0" required="0">
+    <description>
+      Equatorial axis of a custom surface type, specified in meters.
+      This is only required for custom surfaces.
+    </description>
+  </element>
+
+  <element name="surface_axis_polar" type="double" default="0.0" required="0">
+    <description>
+      Polar axis of a custom surface type, specified in meters.
+      This is only required for custom surfaces.
+    </description>
+  </element>
+
+  <element name="heading_deg" type="double" default="0.0" required="1">
+    <description>
+      Heading offset of gazebo reference frame, measured as angle between
+      Gazebo world frame and the world_frame_orientation type.
+      The direction of rotation follows the right-hand rule, so a positive
+      angle indicates clockwise rotation (from east to north) when viewed from top-down. Note
+      that this is not consistent with compass heading convention.
+      The angle is specified in degrees.
+    </description>
+  </element>
+
+</element>

--- a/sdf/1.12/state.sdf
+++ b/sdf/1.12/state.sdf
@@ -1,0 +1,41 @@
+<!-- State Info -->
+<element name="state" required="*">
+  <!-- Name of the world this state applies to -->
+  <attribute name="world_name" type="string" default="__default__" required="1">
+    <description>Name of the world this state applies to</description>
+  </attribute>
+
+  <element name="sim_time" type="time" default="0 0" required="0">
+    <description>Simulation time stamp of the state [seconds nanoseconds]</description>
+  </element>
+
+  <element name="wall_time" type="time" default="0 0" required="0">
+    <description>Wall time stamp of the state [seconds nanoseconds]</description>
+  </element>
+
+  <element name="real_time" type="time" default="0 0" required="0">
+    <description>Real time stamp of the state [seconds nanoseconds]</description>
+  </element>
+
+  <element name="iterations" type="unsigned int" default="0" required="1">
+    <description>Number of simulation iterations.</description>
+  </element>
+
+  <element name="insertions" required="0">
+    <description>A list containing the entire description of entities inserted.</description>
+    <include filename="model.sdf" required="+"/>
+    <include filename="light.sdf" required="+"/>
+  </element>
+
+  <element name="deletions" required="0">
+    <description>A list of names of deleted entities/</description>
+    <element name="name" type="string" default="__default__" required="+">
+      <description>The name of a deleted entity.</description>
+    </element>
+  </element>
+
+  <include filename="model_state.sdf" required="*"/>
+
+  <include filename="light_state.sdf" required="*"/>
+
+</element> <!-- End State -->

--- a/sdf/1.12/surface.sdf
+++ b/sdf/1.12/surface.sdf
@@ -1,0 +1,245 @@
+<element name="surface" required="0">
+  <description>The surface parameters</description>
+  <element name="bounce" required="0">
+    <description></description>
+    <element name="restitution_coefficient" type="double" default="0" min="0.0" max="1.0" required="0">
+      <description>Bounciness coefficient of restitution, from [0...1], where 0=no bounciness.</description>
+    </element>
+    <element name="threshold" type="double" default="100000" required="0">
+      <description>Bounce capture velocity, below which effective coefficient of restitution is 0.</description>
+    </element>
+  </element> <!-- End Bounce -->
+
+  <element name="friction" required="0">
+    <description></description>
+
+    <element name="torsional" required="0">
+      <description>Parameters for torsional friction</description>
+      <element name="coefficient" type="double" default="1.0" min="0.0" required="0">
+        <description>
+          Torsional friction coefficient, unitless maximum ratio of
+          tangential stress to normal stress.
+        </description>
+      </element>
+      <element name="use_patch_radius" type="bool" default="true" required="0">
+        <description>
+          If this flag is true,
+          torsional friction is calculated using the "patch_radius" parameter.
+          If this flag is set to false,
+          "surface_radius" (R) and contact depth (d)
+          are used to compute the patch radius as sqrt(R*d).
+        </description>
+      </element>
+      <element name="patch_radius" type="double" default="0" min="0.0" required="0">
+        <description>Radius of contact patch surface.</description>
+      </element>
+      <element name="surface_radius" type="double" default="0.0" min="0.0" required="0">
+        <description>Surface radius on the point of contact.</description>
+      </element>
+      <element name="ode" required="0">
+        <description>Torsional friction parameters for ODE</description>
+        <element name="slip" type="double" default="0.0" required="0">
+          <description>
+            Force dependent slip for torsional friction,
+            equivalent to inverse of viscous damping coefficient
+            with units of rad/s/(Nm).
+            A slip value of 0 is infinitely viscous.
+          </description>
+        </element>
+      </element> <!-- End ODE -->
+    </element> <!-- End torsional -->
+
+    <element name="ode" required="0">
+      <description>ODE friction parameters</description>
+      <element name="mu" type="double" default="1" min="0.0" required="0">
+        <description>
+          Coefficient of friction in first friction pyramid direction,
+          the unitless maximum ratio of force in first friction pyramid
+          direction to normal force.
+        </description>
+      </element>
+      <element name="mu2" type="double" default="1" min="0.0" required="0">
+        <description>
+          Coefficient of friction in second friction pyramid direction,
+          the unitless maximum ratio of force in second friction pyramid
+          direction to normal force.
+        </description>
+      </element>
+      <element name="fdir1" type="vector3" default="0 0 0" required="0">
+        <description>
+          Unit vector specifying first friction pyramid direction in
+          collision-fixed reference frame.
+          If the friction pyramid model is in use,
+          and this value is set to a unit vector for one of the
+          colliding surfaces,
+          the ODE Collide callback function will align the friction pyramid directions
+          with a reference frame fixed to that collision surface.
+          If both surfaces have this value set to a vector of zeros,
+          the friction pyramid directions will be aligned with the world frame.
+          If this value is set for both surfaces, the behavior is undefined.
+        </description>
+      </element>
+      <element name="slip1" type="double" default="0.0" required="0">
+        <description>
+          Force dependent slip in first friction pyramid direction,
+          equivalent to inverse of viscous damping coefficient
+          with units of m/s/N.
+          A slip value of 0 is infinitely viscous.
+        </description>
+      </element>
+      <element name="slip2" type="double" default="0.0" required="0">
+        <description>
+          Force dependent slip in second friction pyramid direction,
+          equivalent to inverse of viscous damping coefficient
+          with units of m/s/N.
+          A slip value of 0 is infinitely viscous.
+        </description>
+      </element>
+    </element> <!-- End ODE -->
+    <element name="bullet" required="0">
+      <element name="friction" type="double" default="1" min="0.0" required="0">
+        <description>
+          Coefficient of friction in first friction pyramid direction,
+          the unitless maximum ratio of force in first friction pyramid
+          direction to normal force.
+        </description>
+      </element>
+      <element name="friction2" type="double" default="1" min="0.0" required="0">
+        <description>
+          Coefficient of friction in second friction pyramid direction,
+          the unitless maximum ratio of force in second friction pyramid
+          direction to normal force.
+        </description>
+      </element>
+      <element name="fdir1" type="vector3" default="0 0 0" required="0">
+        <description>
+          Unit vector specifying first friction pyramid direction in
+          collision-fixed reference frame.
+          If the friction pyramid model is in use,
+          and this value is set to a unit vector for one of the
+          colliding surfaces,
+          the friction pyramid directions will be aligned
+          with a reference frame fixed to that collision surface.
+          If both surfaces have this value set to a vector of zeros,
+          the friction pyramid directions will be aligned with the world frame.
+          If this value is set for both surfaces, the behavior is undefined.
+        </description>
+      </element>
+      <element name="rolling_friction" type="double" default="1" required="0">
+        <description>Coefficient of rolling friction</description>
+      </element>
+    </element> <!-- End Bullet -->
+  </element> <!-- End Friction -->
+
+  <element name="contact" required="0">
+    <description></description>
+    <element name="collide_without_contact" type="bool" default="false" required="0">
+      <description>Flag to disable contact force generation, while still allowing collision checks and contact visualization to occur.</description>
+    </element>
+    <element name="collide_without_contact_bitmask" type="unsigned int" default="1" required="0">
+      <description>Bitmask for collision filtering when collide_without_contact is on </description>
+    </element>
+
+    <element name="collide_bitmask" type="unsigned int" default="65535" required="0">
+      <description>Bitmask for collision filtering. This will override collide_without_contact. Parsed as 16-bit unsigned integer.</description>
+    </element>
+
+    <element name="category_bitmask" type="unsigned int" default="65535" required="0">
+      <description><![CDATA[Bitmask for category of collision filtering. Collision happens if ((category1 & collision2) | (category2 & collision1)) is not zero. If not specified, the category_bitmask should be interpreted as being the same as collide_bitmask. Parsed as 16-bit unsigned integer.]]></description>
+    </element>
+
+    <element name="poissons_ratio" type="double" default="0.3" required="0">
+      <description>
+        Poisson's ratio is the unitless ratio between transverse and axial strain.
+        This value must lie between (-1, 0.5).  Defaults to 0.3 for typical steel.
+        Note typical silicone elastomers have Poisson's ratio near 0.49 ~ 0.50.
+
+        For reference, approximate values for Material:(Young's Modulus, Poisson's Ratio)
+        for some of the typical materials are:
+          Plastic:  (1e8 ~ 3e9 Pa,  0.35 ~ 0.41),
+          Wood:     (4e9 ~ 1e10 Pa, 0.22 ~ 0.50),
+          Aluminum: (7e10 Pa,       0.32 ~ 0.35),
+          Steel:    (2e11 Pa,       0.26 ~ 0.31).
+      </description>
+    </element>
+    <element name="elastic_modulus" type="double" default="-1" required="0">
+      <description>
+        Young's Modulus in SI derived unit Pascal.
+        Defaults to -1.  If value is less or equal to zero,
+        contact using elastic modulus (with Poisson's Ratio) is disabled.
+
+        For reference, approximate values for Material:(Young's Modulus, Poisson's Ratio)
+        for some of the typical materials are:
+          Plastic:  (1e8 ~ 3e9 Pa,  0.35 ~ 0.41),
+          Wood:     (4e9 ~ 1e10 Pa, 0.22 ~ 0.50),
+          Aluminum: (7e10 Pa,       0.32 ~ 0.35),
+          Steel:    (2e11 Pa,       0.26 ~ 0.31).
+      </description>
+    </element>
+
+    <element name="ode" required="0">
+      <description>ODE contact parameters</description>
+      <element name="soft_cfm" type="double" default="0" required="0">
+        <description>Soft constraint force mixing.</description>
+      </element>
+      <element name="soft_erp" type="double" default="0.2" required="0">
+        <description>Soft error reduction parameter</description>
+      </element>
+      <element name="kp" type="double" default="1000000000000.0" required="0">
+        <description>dynamically "stiffness"-equivalent coefficient for contact joints</description>
+      </element>
+      <element name="kd" type="double" default="1.0" required="0">
+        <description>dynamically "damping"-equivalent coefficient for contact joints</description>
+      </element>
+      <element name="max_vel" type="double" default="0.01" required="0">
+        <description>maximum contact correction velocity truncation term.</description>
+      </element>
+      <element name="min_depth" type="double" default="0" required="0">
+        <description>minimum allowable depth before contact correction impulse is applied</description>
+      </element>
+    </element> <!-- End ODE -->
+    <element name="bullet" required="0">
+      <description>Bullet contact parameters</description>
+      <element name="soft_cfm" type="double" default="0" required="0">
+        <description>Soft constraint force mixing.</description>
+      </element>
+      <element name="soft_erp" type="double" default="0.2" required="0">
+        <description>Soft error reduction parameter</description>
+      </element>
+      <element name="kp" type="double" default="1000000000000.0" required="0">
+        <description>dynamically "stiffness"-equivalent coefficient for contact joints</description>
+      </element>
+      <element name="kd" type="double" default="1.0" required="0">
+        <description>dynamically "damping"-equivalent coefficient for contact joints</description>
+      </element>
+      <element name="split_impulse" type="bool" default="true" required="1">
+        <description>Similar to ODE's max_vel implementation.  See http://bulletphysics.org/mediawiki-1.5.8/index.php/BtContactSolverInfo#Split_Impulse for more information.</description>
+      </element>
+      <element name="split_impulse_penetration_threshold" type="double" default="-0.01" required="1">
+        <description>Similar to ODE's max_vel implementation.  See http://bulletphysics.org/mediawiki-1.5.8/index.php/BtContactSolverInfo#Split_Impulse for more information.</description>
+      </element>
+    </element> <!-- End Bullet -->
+  </element> <!-- End Contact -->
+
+  <!-- for deformable bodies -->
+  <element name="soft_contact" required="0">
+    <element name="dart" required="0">
+      <description>soft contact pamameters based on paper:
+             http://www.cc.gatech.edu/graphics/projects/Sumit/homepage/papers/sigasia11/jain_softcontacts_siga11.pdf
+      </description>
+      <element name="bone_attachment" type="double" default="100.0" required="1">
+        <description>This is variable k_v in the soft contacts paper.  Its unit is N/m.</description>
+      </element>
+      <element name="stiffness" type="double" default="100.0" required="1">
+        <description>This is variable k_e in the soft contacts paper.  Its unit is N/m.</description>
+      </element>
+      <element name="damping" type="double" default="10.0" required="1">
+        <description>Viscous damping of point velocity in body frame.  Its unit is N/m/s.</description>
+      </element>
+      <element name="flesh_mass_fraction" type="double" default="0.05" required="1">
+        <description>Fraction of mass to be distributed among deformable nodes.</description>
+      </element>
+    </element> <!-- dart -->
+  </element> <!-- soft_contact -->
+
+</element> <!-- End Surface -->

--- a/sdf/1.12/transceiver.sdf
+++ b/sdf/1.12/transceiver.sdf
@@ -1,0 +1,34 @@
+<element name="transceiver" required="0">
+  <description>These elements are specific to a wireless transceiver.</description>
+
+  <element name="essid" type="string" default="wireless" required="0">
+    <description>Service set identifier (network name)</description>
+  </element> <!-- End Essid -->
+
+  <element name="frequency" type="double" default="2442" required="0">
+    <description>Specifies the frequency of transmission in MHz</description>
+  </element> <!-- End Frequency -->
+
+  <element name="min_frequency" type="double" default="2412" required="0">
+    <description>Only a frequency range is filtered. Here we set the lower bound (MHz).
+    </description>
+  </element> <!-- End min_frequency -->
+
+  <element name="max_frequency" type="double" default="2484" required="0">
+    <description>Only a frequency range is filtered. Here we set the upper bound (MHz).
+    </description>
+  </element> <!-- End max_frequency -->
+
+  <element name="gain" type="double" default="2.5" required="1">
+    <description>Specifies the antenna gain in dBi</description>
+  </element> <!-- End Gain -->
+
+  <element name="power" type="double" default="14.50" required="1">
+    <description>Specifies the transmission power in dBm</description>
+  </element> <!-- End Power -->
+
+  <element name="sensitivity" type="double" default="-90" required="0">
+    <description>Mininum received signal power in dBm</description>
+  </element> <!-- End Sensitivity -->
+
+</element> <!-- End Transceiver -->

--- a/sdf/1.12/visual.sdf
+++ b/sdf/1.12/visual.sdf
@@ -1,0 +1,38 @@
+<!-- Visual -->
+<element name="visual" required="*">
+  <description>The visual properties of the link. This element specifies the shape of the object (box, cylinder, etc.) for visualization purposes.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Unique name for the visual element within the scope of the parent link.</description>
+  </attribute>
+
+  <element name="cast_shadows" type="bool" default="true" required="0">
+    <description>If true the visual will cast shadows.</description>
+  </element>
+
+  <element name="laser_retro" type="double" default="0.0" required="0">
+    <description>will be implemented in the future release.</description>
+  </element>
+
+  <element name="transparency" type="double" default="0.0" required="0">
+    <description>The amount of transparency( 0=opaque, 1 = fully transparent)</description>
+  </element>
+
+  <element name="visibility_flags" type="unsigned int" default="4294967295" required="0">
+    <description><![CDATA[Visibility flags of a visual. When (camera's visibility_mask & visual's visibility_flags) evaluates to non-zero, the visual will be visible to the camera.]]></description>
+  </element>
+
+  <element name="meta" required="0">
+    <description>Optional meta information for the visual. The information contained within this element should be used to provide additional feedback to an end user.</description>
+
+    <element name="layer" type="int" default="0" required="0">
+      <description>The layer in which this visual is displayed. The layer number is useful for programs, such as Gazebo, that put visuals in different layers for enhanced visualization.</description>
+    </element>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+
+  <include filename="material.sdf" required="0"/>
+  <include filename="geometry.sdf" required="1"/>
+  <include filename="plugin.sdf" required="*"/>
+</element> <!-- End Visual -->

--- a/sdf/1.12/world.sdf
+++ b/sdf/1.12/world.sdf
@@ -1,0 +1,75 @@
+<element name="world" required="*">
+  <description>The world element encapsulates an entire world description including: models, scene, physics, and plugins.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Unique name of the world</description>
+  </attribute>
+
+  <element name="audio" required="0">
+    <description>Global audio properties.</description>
+
+    <element name="device" type="string" default="default" required="1">
+      <description>Device to use for audio playback. A value of "default" will use the system's default audio device. Otherwise, specify a an audio device file"</description>
+    </element>
+  </element>
+
+  <element name="wind" required="0">
+    <description>The wind tag specifies the type and properties of the wind.</description>
+
+    <element name="linear_velocity" type="vector3" default="0 0 0" required="0">
+      <description>Linear velocity of the wind.</description>
+    </element>
+  </element>
+
+  <element name="include" required="*">
+    <description>
+        Include resources from a URI. Included resources can only contain one 'model', 'light' or 'actor' element. The URI can point to a directory or a file. If the URI is a directory, it must conform to the model database structure (see /tutorials?tut=composition&amp;cat=specification&amp;#defining-models-in-separate-files).
+    </description>
+    <attribute name="merge" type="bool" default="false" required="0">
+      <description>Merge the included model into the top model. Only elements valid in 'world' are allowed in the included model</description>
+    </attribute>
+    <element name="uri" type="string" default="__default__" required="1">
+      <description>URI to a resource, such as a model</description>
+    </element>
+
+    <element name="name" type="string" default="" required="0">
+      <description>Override the name of the included entity.</description>
+    </element>
+
+    <element name="static" type="bool" default="false" required="0">
+      <description>Override the static value of the included entity.</description>
+    </element>
+
+    <include filename="pose.sdf" required="0"/>
+    <include filename="plugin.sdf" required="*"/>
+
+    <element name="placement_frame" type="string" default="" required="0">
+      <description>The frame inside the included entity whose pose will be set by the specified pose element. If this element is specified, the pose must be specified.</description>
+    </element>
+  </element>
+
+  <element name="gravity" type="vector3" default="0 0 -9.8" required="1">
+    <description>The gravity vector in m/s^2, expressed in a coordinate frame defined by the spherical_coordinates tag.</description>
+  </element> <!-- End Gravity -->
+
+  <element name="magnetic_field" type="vector3" default="5.5645e-6 22.8758e-6 -42.3884e-6" required="1">
+    <description>The magnetic vector in Tesla, expressed in a coordinate frame defined by the spherical_coordinates tag.</description>
+  </element> <!-- End Magnetic -->
+
+  <include filename="atmosphere.sdf" required="1"/>
+  <include filename="gui.sdf" required="0"/>
+  <include filename="physics.sdf" required="+"/>
+  <include filename="scene.sdf" required="1"/>
+  <include filename="light.sdf" required="*"/>
+
+  <include filename="frame.sdf" required="*"/>
+  <include filename="joint.sdf" required="*"/>
+  <include filename="model.sdf" required="*"/>
+  <include filename="actor.sdf" required="*"/>
+  <include filename="plugin.sdf" required="*"/>
+  <include filename="road.sdf" required="*"/>
+  <include filename="spherical_coordinates.sdf" required="0"/>
+
+  <include filename="state.sdf" required="*"/>
+  <include filename="population.sdf" required="*"/>
+</element> <!-- End World -->

--- a/sdf/CMakeLists.txt
+++ b/sdf/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(1.8)
 add_subdirectory(1.9)
 add_subdirectory(1.10)
 add_subdirectory(1.11)
+add_subdirectory(1.12)
 
 add_custom_target(schema)
 add_dependencies(schema schema1_11)

--- a/sdf/embedSdf.py
+++ b/sdf/embedSdf.py
@@ -14,6 +14,7 @@ from pathlib import Path, PurePosixPath
 # The list of supported SDF specification versions. This will let us drop
 # versions without removing the directories.
 SUPPORTED_SDF_VERSIONS = [
+    "1.12",
     "1.11",
     "1.10",
     "1.9",
@@ -28,7 +29,7 @@ SUPPORTED_SDF_VERSIONS = [
 
 # The list of supported SDF conversions. This list includes versions that
 # a user can convert an existing SDF version to.
-SUPPORTED_SDF_CONVERSIONS = ["1.11", "1.10", "1.9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3"]
+SUPPORTED_SDF_CONVERSIONS = ["1.12", "1.11", "1.10", "1.9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3"]
 
 # whitespace indentation for C++ code
 INDENTATION = "  "

--- a/src/Root_TEST.cc
+++ b/src/Root_TEST.cc
@@ -583,7 +583,7 @@ TEST(DOMRoot, CopyConstructor)
 
   auto testFrame1 = [](const sdf::Root &_root)
   {
-    EXPECT_EQ("1.11", _root.Version());
+    EXPECT_EQ("1.12", _root.Version());
 
     const sdf::World *world = _root.WorldByIndex(0);
     ASSERT_NE(nullptr, world);


### PR DESCRIPTION
# 🎉 New feature

Needed for Ionic features

## Summary

This bumps the SDFormat spec version to 1.12 on `main` so we can add new features for Ionic. There are not yet any changes between 1.11 and 1.12.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
