### PR TITLE
sdf 1.12: rename state subelements with _state suffix

### DIFF
--- a/sdf/1.12/1_11.convert
+++ b/sdf/1.12/1_11.convert
@@ -1,2 +1,46 @@
 <convert name="sdf">
+
+  <convert name="world">
+    <!-- Rename state elements -->
+    <convert name="state">
+
+      <move>
+        <from element="light"/>
+        <to element="light_state"/>
+      </move>
+
+      <move>
+        <from element="model"/>
+        <to element="model_state"/>
+      </move>
+
+      <convert name="model">
+        <move>
+          <from element="link"/>
+          <to element="link_state"/>
+        </move>
+        <move>
+          <from element="model"/>
+          <to element="model_state"/>
+        </move>
+        <convert name="model">
+          <move>
+            <from element="link"/>
+            <to element="link_state"/>
+          </move>
+          <move>
+            <from element="model"/>
+            <to element="model_state"/>
+          </move>
+          <convert name="model">
+            <move>
+              <from element="link"/>
+              <to element="link_state"/>
+            </move>
+          </convert>
+        </convert>
+      </convert>
+
+    </convert>
+  </convert>
 </convert> <!-- End SDF -->

--- a/sdf/1.12/light_state.sdf
+++ b/sdf/1.12/light_state.sdf
@@ -1,5 +1,5 @@
 <!-- State information for a light -->
-<element name="light" required="*">
+<element name="light_state" required="*">
   <description>Light state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">

--- a/sdf/1.12/link_state.sdf
+++ b/sdf/1.12/link_state.sdf
@@ -1,5 +1,5 @@
 <!-- State information for a link -->
-<element name="link" required="*">
+<element name="link_state" required="*">
   <description>Link state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">
@@ -27,7 +27,7 @@
     </description>
   </element>
 
-  <element name="collision" required="*">
+  <element name="collision_state" required="*">
     <description>Collision state</description>
 
     <attribute name="name" type="string" default="__default__" required="1">

--- a/sdf/1.12/model_state.sdf
+++ b/sdf/1.12/model_state.sdf
@@ -1,12 +1,12 @@
 <!-- State information for a model -->
-<element name="model" required="*">
+<element name="model_state" required="*">
   <description>Model state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">
     <description>Name of the model</description>
   </attribute>
 
-  <element name="joint" required="*">
+  <element name="joint_state" required="*">
     <description>Joint angle</description>
 
     <attribute name="name" type="string" default="__default__" required="1">
@@ -22,7 +22,7 @@
     </element>
   </element>
 
-  <element name="model" ref="model_state" required="*">
+  <element name="model_state" ref="model_state" required="*">
     <description>A nested model state element</description>
     <attribute name="name" type="string" default="__default__" required="1">
       <description>Name of the model. </description>

--- a/test/integration/frame.cc
+++ b/test/integration/frame.cc
@@ -206,11 +206,11 @@ TEST(Frame, NoFrame)
 }
 
 ////////////////////////////////////////
-// Test parsing nested model states
+// Test parsing states with //pose/@relative_to
 TEST(Frame, StateFrame)
 {
   std::ostringstream sdfStr;
-  sdfStr << "<sdf version ='" << SDF_VERSION << "'>"
+  sdfStr << "<sdf version ='1.11'>"
     << "<world name='default'>"
     << "<state world_name='default'>"
     << "<model name='my_model'>"
@@ -239,8 +239,8 @@ TEST(Frame, StateFrame)
   EXPECT_TRUE(worldElem->HasElement("state"));
   sdf::ElementPtr stateElem = worldElem->GetElement("state");
 
-  EXPECT_TRUE(stateElem->HasElement("model"));
-  sdf::ElementPtr modelStateElem = stateElem->GetElement("model");
+  EXPECT_TRUE(stateElem->HasElement("model_state"));
+  sdf::ElementPtr modelStateElem = stateElem->GetElement("model_state");
 
   // model
   EXPECT_TRUE(modelStateElem->HasAttribute("name"));
@@ -271,8 +271,8 @@ TEST(Frame, StateFrame)
   }
 
   // link
-  EXPECT_TRUE(modelStateElem->HasElement("link"));
-  sdf::ElementPtr linkStateElem = modelStateElem->GetElement("link");
+  EXPECT_TRUE(modelStateElem->HasElement("link_state"));
+  sdf::ElementPtr linkStateElem = modelStateElem->GetElement("link_state");
   EXPECT_TRUE(linkStateElem->HasAttribute("name"));
   EXPECT_EQ(linkStateElem->Get<std::string>("name"), "my_link");
 
@@ -286,8 +286,8 @@ TEST(Frame, StateFrame)
               gz::math::Pose3d(111, 3, 0, 0, 0, 0));
   }
 
-  EXPECT_TRUE(stateElem->HasElement("light"));
-  sdf::ElementPtr lightStateElem = stateElem->GetElement("light");
+  EXPECT_TRUE(stateElem->HasElement("light_state"));
+  sdf::ElementPtr lightStateElem = stateElem->GetElement("light_state");
 
   // light
   EXPECT_TRUE(lightStateElem->HasAttribute("name"));

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -244,6 +244,102 @@ TEST(NestedModel, State)
 }
 
 ////////////////////////////////////////
+// Test parsing nested model states
+TEST(NestedModel, StateSiblingsConversion1_12)
+{
+  const std::string testFile =
+  sdf::testing::TestFile("sdf", "state_nested_model_world.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+
+  // load the state sdf
+  EXPECT_TRUE(root.Element()->HasElement("world"));
+  sdf::ElementPtr worldElem = root.Element()->GetElement("world");
+
+  // Confirm that regular model elements were not migrated
+  EXPECT_FALSE(worldElem->HasElement("model_state"));
+
+  // Confirm that model and link elements in state were converted to
+  // model_state and link_state
+  EXPECT_TRUE(worldElem->HasElement("state"));
+  sdf::ElementPtr stateElem = worldElem->GetElement("state");
+  EXPECT_TRUE(stateElem->HasElement("model_state"))
+    << stateElem->ToString("");
+  EXPECT_FALSE(stateElem->HasElement("model"))
+    << stateElem->ToString("");
+
+  // model sdf
+  sdf::ElementPtr modelStateElem = stateElem->GetElement("model_state");
+  EXPECT_TRUE(modelStateElem->HasAttribute("name"));
+  EXPECT_EQ(modelStateElem->Get<std::string>("name"), "top_level_model");
+  EXPECT_TRUE(modelStateElem->HasElement("link_state"))
+    << modelStateElem->ToString("");
+  EXPECT_TRUE(modelStateElem->HasElement("model_state"))
+    << modelStateElem->ToString("");
+  EXPECT_FALSE(modelStateElem->HasElement("link"))
+    << modelStateElem->ToString("");
+  EXPECT_FALSE(modelStateElem->HasElement("model"))
+    << modelStateElem->ToString("");
+}
+
+////////////////////////////////////////
+// Test parsing nested model states
+TEST(NestedModel, StateInsertionsConversion1_12)
+{
+  const std::string testFile =
+  sdf::testing::TestFile("sdf", "state_nested_model_world_insertion.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+
+  // load the state sdf
+  EXPECT_TRUE(root.Element()->HasElement("world"));
+  sdf::ElementPtr worldElem = root.Element()->GetElement("world");
+
+  // Confirm that regular model elements were not migrated
+  EXPECT_FALSE(worldElem->HasElement("model_state"));
+
+  // Confirm that model and link elements in state were converted to
+  // model_state and link_state
+  EXPECT_TRUE(worldElem->HasElement("state"));
+  sdf::ElementPtr stateElem = worldElem->GetElement("state");
+  EXPECT_TRUE(stateElem->HasElement("model_state"))
+    << stateElem->ToString("");
+  EXPECT_FALSE(stateElem->HasElement("model"))
+    << stateElem->ToString("");
+
+  // model sdf
+  sdf::ElementPtr modelStateElem = stateElem->GetElement("model_state");
+  EXPECT_TRUE(modelStateElem->HasAttribute("name"));
+  EXPECT_EQ(modelStateElem->Get<std::string>("name"), "top_level_model");
+  EXPECT_TRUE(modelStateElem->HasElement("link_state"))
+    << modelStateElem->ToString("");
+  EXPECT_TRUE(modelStateElem->HasElement("model_state"))
+    << modelStateElem->ToString("");
+  EXPECT_FALSE(modelStateElem->HasElement("link"))
+    << modelStateElem->ToString("");
+  EXPECT_FALSE(modelStateElem->HasElement("model"))
+    << modelStateElem->ToString("");
+
+  // insertions
+  EXPECT_TRUE(stateElem->HasElement("insertions"));
+  sdf::ElementPtr insertionsElem = stateElem->GetElement("insertions");
+  // confirm that //insertions/model and link tags were not converted
+  EXPECT_FALSE(insertionsElem->HasElement("model_state"));
+  EXPECT_TRUE(insertionsElem->HasElement("model"));
+  sdf::ElementPtr insertedModelElem = insertionsElem->GetElement("model");
+  EXPECT_TRUE(insertedModelElem->HasAttribute("name"));
+  EXPECT_EQ(insertedModelElem->Get<std::string>("name"), "unit_box");
+  EXPECT_FALSE(insertedModelElem->HasElement("link_state"));
+  EXPECT_TRUE(insertedModelElem->HasElement("link"));
+}
+
+////////////////////////////////////////
 // Test parsing models with joints nested via <include>
 // Confirm that joint axis rotation is handled differently for 1.4 and 1.5+
 TEST(NestedModel, NestedInclude)

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -111,7 +111,7 @@ TEST(NestedModel, NestedModel)
 TEST(NestedModel, State)
 {
   std::ostringstream sdfStr;
-  sdfStr << "<sdf version ='" << SDF_VERSION << "'>"
+  sdfStr << "<sdf version ='1.11'>"
     << "<world name='default'>"
     << "<state world_name='default'>"
     << "<model name='model_00'>"
@@ -154,9 +154,9 @@ TEST(NestedModel, State)
   sdf::ElementPtr worldElem = sdfParsed->Root()->GetElement("world");
   EXPECT_TRUE(worldElem->HasElement("state"));
   sdf::ElementPtr stateElem = worldElem->GetElement("state");
-  EXPECT_TRUE(stateElem->HasElement("model"));
+  EXPECT_TRUE(stateElem->HasElement("model_state"));
 
-  sdf::ElementPtr modelStateElem = stateElem->GetElement("model");
+  sdf::ElementPtr modelStateElem = stateElem->GetElement("model_state");
 
   // model sdf
   EXPECT_TRUE(modelStateElem->HasAttribute("name"));
@@ -167,8 +167,8 @@ TEST(NestedModel, State)
   EXPECT_TRUE(!modelStateElem->HasElement("joint"));
 
   // link sdf
-  EXPECT_TRUE(modelStateElem->HasElement("link"));
-  sdf::ElementPtr linkStateElem = modelStateElem->GetElement("link");
+  EXPECT_TRUE(modelStateElem->HasElement("link_state"));
+  sdf::ElementPtr linkStateElem = modelStateElem->GetElement("link_state");
   EXPECT_TRUE(linkStateElem->HasAttribute("name"));
   EXPECT_EQ(linkStateElem->Get<std::string>("name"), "link_00");
   EXPECT_TRUE(linkStateElem->HasElement("pose"));
@@ -185,9 +185,9 @@ TEST(NestedModel, State)
     gz::math::Pose3d(0, 0.006121, 0, 0, 0, 0));
 
   // nested model sdf
-  EXPECT_TRUE(modelStateElem->HasElement("model"));
+  EXPECT_TRUE(modelStateElem->HasElement("model_state"));
   sdf::ElementPtr nestedModelStateElem =
-    modelStateElem->GetElement("model");
+    modelStateElem->GetElement("model_state");
   EXPECT_TRUE(nestedModelStateElem->HasAttribute("name"));
   EXPECT_EQ(nestedModelStateElem->Get<std::string>("name"), "model_01");
   EXPECT_TRUE(nestedModelStateElem->HasElement("pose"));
@@ -196,9 +196,9 @@ TEST(NestedModel, State)
   EXPECT_TRUE(!nestedModelStateElem->HasElement("joint"));
 
   // nested model's link sdf
-  EXPECT_TRUE(nestedModelStateElem->HasElement("link"));
+  EXPECT_TRUE(nestedModelStateElem->HasElement("link_state"));
   sdf::ElementPtr nestedLinkStateElem =
-    nestedModelStateElem->GetElement("link");
+    nestedModelStateElem->GetElement("link_state");
   EXPECT_TRUE(nestedLinkStateElem->HasAttribute("name"));
   EXPECT_EQ(nestedLinkStateElem->Get<std::string>("name"), "link_01");
   EXPECT_TRUE(nestedLinkStateElem->HasElement("pose"));
@@ -215,8 +215,8 @@ TEST(NestedModel, State)
     gz::math::Pose3d(0, 0.000674, 0, 0, 0, 0));
 
   // double nested model sdf
-  EXPECT_TRUE(nestedModelStateElem->HasElement("model"));
-  nestedModelStateElem = nestedModelStateElem->GetElement("model");
+  EXPECT_TRUE(nestedModelStateElem->HasElement("model_state"));
+  nestedModelStateElem = nestedModelStateElem->GetElement("model_state");
   EXPECT_TRUE(nestedModelStateElem->HasAttribute("name"));
   EXPECT_EQ(nestedModelStateElem->Get<std::string>("name"), "model_02");
   EXPECT_TRUE(nestedModelStateElem->HasElement("pose"));
@@ -225,8 +225,8 @@ TEST(NestedModel, State)
   EXPECT_TRUE(!nestedModelStateElem->HasElement("joint"));
 
   // double nested model's link sdf
-  EXPECT_TRUE(nestedModelStateElem->HasElement("link"));
-  nestedLinkStateElem = nestedModelStateElem->GetElement("link");
+  EXPECT_TRUE(nestedModelStateElem->HasElement("link_state"));
+  nestedLinkStateElem = nestedModelStateElem->GetElement("link_state");
   EXPECT_TRUE(nestedLinkStateElem->HasAttribute("name"));
   EXPECT_EQ(nestedLinkStateElem->Get<std::string>("name"), "link_02");
   EXPECT_TRUE(nestedLinkStateElem->HasElement("pose"));

--- a/test/sdf/state_nested_model_world.sdf
+++ b/test/sdf/state_nested_model_world.sdf
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <world name="default">
+    <model name="top_level_model">
+      <link name="parent"/>
+      <link name="child"/>
+      <model name="nested_model01">
+        <link name="nested_link01"/>
+        <link name="nested_link02"/>
+        <model name="nested_nested_model01">
+          <link name="nested_nested_link01"/>
+          <link name="nested_nested_link02"/>
+        </model>
+        <model name="nested_nested_model02">
+          <link name="nested_nested_link01"/>
+          <link name="nested_nested_link02"/>
+        </model>
+      </model>
+      <model name="nested_model02">
+        <link name="nested_link01"/>
+        <link name="nested_link02"/>
+      </model>
+      <joint name="top_level_joint" type="revolute">
+        <parent>parent</parent>
+        <child>child</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+        </axis>
+      </joint>
+    </model>
+    <gravity>0 0 -9.8</gravity>
+    <state world_name="default">
+      <sim_time>0 689000000</sim_time>
+      <real_time>0 732670244</real_time>
+      <wall_time>1709252095 646182343</wall_time>
+      <iterations>689</iterations>
+      <model name="top_level_model">
+        <link name="child">
+          <pose>0 0 -2.329 0 -0 0 </pose>
+        </link>
+        <link name="parent">
+          <pose>0 0 -2.329 0 -0 0 </pose>
+        </link>
+        <model name="nested_model01">
+          <link name="nested_link01">
+            <pose>0 0 -2.329 0 -0 0 </pose>
+          </link>
+          <link name="nested_link02">
+            <pose>0 0 -2.329 0 -0 0 </pose>
+          </link>
+          <model name="nested_nested_model01">
+            <link name="nested_nested_link01">
+              <pose>0 0 -2.329 0 -0 0 </pose>
+            </link>
+            <link name="nested_nested_link02">
+              <pose>0 0 -2.329 0 -0 0 </pose>
+            </link>
+          </model>
+          <model name="nested_nested_model02">
+            <link name="nested_nested_link01">
+              <pose>0 0 -2.329 0 -0 0 </pose>
+            </link>
+            <link name="nested_nested_link02">
+              <pose>0 0 -2.329 0 -0 0 </pose>
+            </link>
+          </model>
+        </model>
+        <model name="nested_model02">
+          <link name="nested_link01">
+            <pose>0 0 -2.329 0 -0 0 </pose>
+          </link>
+          <link name="nested_link02">
+            <pose>0 0 -2.329 0 -0 0 </pose>
+          </link>
+        </model>
+      </model>
+    </state>
+  </world>
+</sdf>

--- a/test/sdf/state_nested_model_world_insertion.sdf
+++ b/test/sdf/state_nested_model_world_insertion.sdf
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <world name="default">
+    <model name="top_level_model">
+      <link name="parent"/>
+      <link name="child"/>
+      <model name="nested_model01">
+        <link name="nested_link01"/>
+        <link name="nested_link02"/>
+        <model name="nested_nested_model01">
+          <link name="nested_nested_link01"/>
+          <link name="nested_nested_link02"/>
+        </model>
+        <model name="nested_nested_model02">
+          <link name="nested_nested_link01"/>
+          <link name="nested_nested_link02"/>
+        </model>
+      </model>
+      <model name="nested_model02">
+        <link name="nested_link01"/>
+        <link name="nested_link02"/>
+      </model>
+      <joint name="top_level_joint" type="revolute">
+        <parent>parent</parent>
+        <child>child</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+        </axis>
+      </joint>
+    </model>
+    <gravity>0 0 -9.8</gravity>
+    <state world_name="default">
+      <sim_time>0 689000000</sim_time>
+      <real_time>0 732670244</real_time>
+      <wall_time>1709252095 646182343</wall_time>
+      <iterations>689</iterations>
+      <insertions>
+        <model name='unit_box'>
+          <pose>-0.541687 -2.44761 0.5 0 -0 0</pose>
+          <link name='link'/>
+        </model>
+      </insertions>
+      <model name="top_level_model">
+        <link name="child">
+          <pose>0 0 -2.329 0 -0 0 </pose>
+        </link>
+        <link name="parent">
+          <pose>0 0 -2.329 0 -0 0 </pose>
+        </link>
+        <model name="nested_model01">
+          <link name="nested_link01">
+            <pose>0 0 -2.329 0 -0 0 </pose>
+          </link>
+          <link name="nested_link02">
+            <pose>0 0 -2.329 0 -0 0 </pose>
+          </link>
+          <model name="nested_nested_model01">
+            <link name="nested_nested_link01">
+              <pose>0 0 -2.329 0 -0 0 </pose>
+            </link>
+            <link name="nested_nested_link02">
+              <pose>0 0 -2.329 0 -0 0 </pose>
+            </link>
+          </model>
+          <model name="nested_nested_model02">
+            <link name="nested_nested_link01">
+              <pose>0 0 -2.329 0 -0 0 </pose>
+            </link>
+            <link name="nested_nested_link02">
+              <pose>0 0 -2.329 0 -0 0 </pose>
+            </link>
+          </model>
+        </model>
+        <model name="nested_model02">
+          <link name="nested_link01">
+            <pose>0 0 -2.329 0 -0 0 </pose>
+          </link>
+          <link name="nested_link02">
+            <pose>0 0 -2.329 0 -0 0 </pose>
+          </link>
+        </model>
+      </model>
+      <model name="unit_box">
+        <link name="link">
+          <pose>-0.5417 -2.448 0.5 0 -0 0 </pose>
+        </link>
+      </model>
+    </state>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/sdformat/issues/632

## Summary

There is some overlap in the names used for elements in the `//world/state` specification and elsewhere, for example the [model_state.sdf](https://github.com/gazebosim/sdformat/blob/sdformat14_14.0.0/sdf/1.11/model_state.sdf#L2) file [included in state.sdf](https://github.com/gazebosim/sdformat/blob/sdformat14_14.0.0/sdf/1.11/state.sdf#L37) defines an element named [model](https://github.com/gazebosim/sdformat/blob/sdformat14_14.0.0/sdf/1.11/model_state.sdf#L2). This has caused challenges with aliasing in XSD (see https://github.com/gazebosim/sdformat/issues/632 and https://github.com/gazebosim/sdformat/pull/643), and it would be simpler if some of these elements had different names (for example by appending a `_state` suffix). This pull request is a work-in-progress to append this suffix to the relevant state tags in SDFormat 1.12 with automatic conversion of state elements defined in earlier versions of the spec. I have the conversion partially working, but have run into an issue with the `Converter` class, which does not act on all sibling elements, but only to the first child element for a given `<move>` conversion.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
