### PR TITLE
Add mesh simplification attribute to <mesh>

### DIFF
--- a/include/sdf/Mesh.hh
+++ b/include/sdf/Mesh.hh
@@ -37,6 +37,17 @@ namespace sdf
   // Forward declarations.
   class ParserConfig;
 
+  /// \brief Mesh simplification method
+  enum class MeshSimplification
+  {
+    /// \brief No mesh simplification
+    NONE,
+    /// \brief Convex hull
+    CONVEX_HULL,
+    /// \brief Convex decomposition
+    CONVEX_DECOMPOSITION
+  };
+
   /// \brief Mesh represents a mesh shape, and is usually accessed through a
   /// Geometry.
   class SDFORMAT_VISIBLE Mesh
@@ -63,12 +74,24 @@ namespace sdf
 
     /// \brief Get the mesh's simplifcation method
     /// \return The mesh simplification method.
+    /// MeshSimplification::NONE if no mesh simplificaton is done.
+    public: MeshSimplification Simplification() const;
+
+    /// \brief Get the mesh's simplifcation method
+    /// \return The mesh simplification method.
     /// Empty string if no mesh simplificaton is done.
-    public: std::string Simplification() const;
+    public: std::string SimplificationStr() const;
 
     /// \brief Set the mesh simplification method.
     /// \param[in] _simplifcation The mesh simplification method.
-    public: void SetSimplification(const std::string &_simplifcation);
+    public: void SetSimplification(MeshSimplification _simplifcation);
+
+    /// \brief Set the mesh simplification method.
+    /// \param[in] _simplifcation The mesh simplification method.
+    /// \return True if the _simplificationStr parameter matched a known
+    /// mesh simplification method. False if the mesh simplification method
+    ///  could not be set.
+    public: bool SetSimplification(const std::string &_simplifcationStr);
 
     /// \brief Get the mesh's URI.
     /// \return The URI of the mesh data.

--- a/include/sdf/Mesh.hh
+++ b/include/sdf/Mesh.hh
@@ -61,6 +61,15 @@ namespace sdf
     /// an error code and message. An empty vector indicates no error.
     public: Errors Load(sdf::ElementPtr _sdf, const ParserConfig &_config);
 
+    /// \brief Get the mesh's simplifcation method
+    /// \return The mesh simplification method.
+    /// Empty string if no mesh simplificaton is done.
+    public: std::string Simplification() const;
+
+    /// \brief Set the mesh simplification method.
+    /// \param[in] _simplifcation The mesh simplification method.
+    public: void SetSimplification(const std::string &_simplifcation);
+
     /// \brief Get the mesh's URI.
     /// \return The URI of the mesh data.
     public: std::string Uri() const;

--- a/sdf/1.11/mesh_shape.sdf
+++ b/sdf/1.11/mesh_shape.sdf
@@ -1,5 +1,12 @@
 <element name="mesh" required="0">
   <description>Mesh shape</description>
+
+  <attribute name="simplification" type="string" default="" required="0">
+    <description>
+      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull", "convex_decomposition". Default value is an empty string which means no mesh simplification.
+    </description>
+  </attribute>
+
   <element name="uri" type="string" default="__default__" required="1">
     <description>Mesh uri</description>
   </element>

--- a/sdf/1.11/mesh_shape.sdf
+++ b/sdf/1.11/mesh_shape.sdf
@@ -3,7 +3,7 @@
 
   <attribute name="simplification" type="string" default="" required="0">
     <description>
-      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull", "convex_decomposition". Default value is an empty string which means no mesh simplification.
+      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull" - a single convex hull that encapsulates the mesh, "convex_decomposition" - decompose the mesh into multiple convex hull meshes. Default value is an empty string which means no mesh simplification.
     </description>
   </attribute>
 

--- a/src/Mesh.cc
+++ b/src/Mesh.cc
@@ -30,6 +30,9 @@ using namespace sdf;
 // Private data class
 class sdf::Mesh::Implementation
 {
+  /// \brief Mesh simplification method
+  public: std::string simplification;
+
   /// \brief The mesh's URI.
   public: std::string uri = "";
 
@@ -87,6 +90,13 @@ Errors Mesh::Load(ElementPtr _sdf, const ParserConfig &_config)
     return errors;
   }
 
+  // Simplify
+  if (_sdf->HasAttribute("simplification"))
+  {
+    this->dataPtr->simplification = _sdf->Get<std::string>("simplification",
+        this->dataPtr->simplification).first;
+  }
+
   if (_sdf->HasElement("uri"))
   {
     std::unordered_set<std::string> paths;
@@ -138,6 +148,18 @@ Errors Mesh::Load(ElementPtr _sdf, const ParserConfig &_config)
 sdf::ElementPtr Mesh::Element() const
 {
   return this->dataPtr->sdf;
+}
+
+//////////////////////////////////////////////////
+std::string Mesh::Simplification() const
+{
+  return this->dataPtr->simplification;
+}
+
+//////////////////////////////////////////////////
+void Mesh::SetSimplification(const std::string &_simplification)
+{
+  this->dataPtr->simplification = _simplification;
 }
 
 //////////////////////////////////////////////////
@@ -243,6 +265,10 @@ sdf::ElementPtr Mesh::ToElement(sdf::Errors &_errors) const
 {
   sdf::ElementPtr elem(new sdf::Element);
   sdf::initFile("mesh_shape.sdf", elem);
+
+  // Simplification
+  elem->GetAttribute("simplification")->Set<std::string>(
+      this->dataPtr->simplification);
 
   // Uri
   sdf::ElementPtr uriElem = elem->GetElement("uri", _errors);

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -34,7 +34,8 @@ TEST(DOMMesh, Construction)
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
 
-  EXPECT_EQ(std::string(), mesh.Simplification());
+  EXPECT_EQ(std::string(), mesh.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::NONE, mesh.Simplification());
   EXPECT_EQ(std::string(), mesh.FilePath());
   EXPECT_EQ(std::string(), mesh.Uri());
   EXPECT_EQ(std::string(), mesh.Submesh());
@@ -54,7 +55,8 @@ TEST(DOMMesh, MoveConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(std::move(mesh));
-  EXPECT_EQ("convex_hull", mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -74,7 +76,8 @@ TEST(DOMMesh, CopyConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(mesh);
-  EXPECT_EQ("convex_hull", mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -95,7 +98,8 @@ TEST(DOMMesh, CopyAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = mesh;
-  EXPECT_EQ("convex_hull", mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -116,7 +120,8 @@ TEST(DOMMesh, MoveAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = std::move(mesh);
-  EXPECT_EQ("convex_hull", mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -149,9 +154,14 @@ TEST(DOMMesh, Set)
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
 
-  EXPECT_EQ(std::string(), mesh.Simplification());
+  EXPECT_EQ(std::string(), mesh.SimplificationStr());
   mesh.SetSimplification("convex_hull");
-  EXPECT_EQ("convex_hull", mesh.Simplification());
+  EXPECT_EQ("convex_hull", mesh.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh.Simplification());
+  mesh.SetSimplification(sdf::MeshSimplification::CONVEX_DECOMPOSITION);
+  EXPECT_EQ("convex_decomposition", mesh.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_DECOMPOSITION,
+            mesh.Simplification());
 
   EXPECT_EQ(std::string(), mesh.Uri());
   mesh.SetUri("http://myuri.com");
@@ -321,6 +331,7 @@ TEST(DOMMesh, ToElement)
   sdf::Mesh mesh2;
   mesh2.Load(elem);
 
+  EXPECT_EQ(mesh.SimplificationStr(), mesh2.SimplificationStr());
   EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());
@@ -361,6 +372,7 @@ TEST(DOMMesh, ToElementErrorOutput)
   errors = mesh2.Load(elem);
   EXPECT_TRUE(errors.empty());
 
+  EXPECT_EQ(mesh.SimplificationStr(), mesh2.SimplificationStr());
   EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -34,6 +34,7 @@ TEST(DOMMesh, Construction)
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
 
+  EXPECT_EQ(std::string(), mesh.Simplification());
   EXPECT_EQ(std::string(), mesh.FilePath());
   EXPECT_EQ(std::string(), mesh.Uri());
   EXPECT_EQ(std::string(), mesh.Submesh());
@@ -45,6 +46,7 @@ TEST(DOMMesh, Construction)
 TEST(DOMMesh, MoveConstructor)
 {
   sdf::Mesh mesh;
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -52,6 +54,7 @@ TEST(DOMMesh, MoveConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(std::move(mesh));
+  EXPECT_EQ("convex_hull", mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -63,6 +66,7 @@ TEST(DOMMesh, MoveConstructor)
 TEST(DOMMesh, CopyConstructor)
 {
   sdf::Mesh mesh;
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -70,6 +74,7 @@ TEST(DOMMesh, CopyConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(mesh);
+  EXPECT_EQ("convex_hull", mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -81,6 +86,7 @@ TEST(DOMMesh, CopyConstructor)
 TEST(DOMMesh, CopyAssignmentOperator)
 {
   sdf::Mesh mesh;
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -89,6 +95,7 @@ TEST(DOMMesh, CopyAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = mesh;
+  EXPECT_EQ("convex_hull", mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -100,6 +107,7 @@ TEST(DOMMesh, CopyAssignmentOperator)
 TEST(DOMMesh, MoveAssignmentOperator)
 {
   sdf::Mesh mesh;
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -108,6 +116,7 @@ TEST(DOMMesh, MoveAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = std::move(mesh);
+  EXPECT_EQ("convex_hull", mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -139,6 +148,10 @@ TEST(DOMMesh, Set)
 {
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
+
+  EXPECT_EQ(std::string(), mesh.Simplification());
+  mesh.SetSimplification("convex_hull");
+  EXPECT_EQ("convex_hull", mesh.Simplification());
 
   EXPECT_EQ(std::string(), mesh.Uri());
   mesh.SetUri("http://myuri.com");
@@ -296,6 +309,7 @@ TEST(DOMMesh, ToElement)
 {
   sdf::Mesh mesh;
 
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("mesh-uri");
   mesh.SetScale(gz::math::Vector3d(1, 2, 3));
   mesh.SetSubmesh("submesh");
@@ -307,6 +321,7 @@ TEST(DOMMesh, ToElement)
   sdf::Mesh mesh2;
   mesh2.Load(elem);
 
+  EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());
   EXPECT_EQ(mesh.Submesh(), mesh2.Submesh());
@@ -332,6 +347,7 @@ TEST(DOMMesh, ToElementErrorOutput)
   sdf::Mesh mesh;
   sdf::Errors errors;
 
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("mesh-uri");
   mesh.SetScale(gz::math::Vector3d(1, 2, 3));
   mesh.SetSubmesh("submesh");
@@ -345,6 +361,7 @@ TEST(DOMMesh, ToElementErrorOutput)
   errors = mesh2.Load(elem);
   EXPECT_TRUE(errors.empty());
 
+  EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());
   EXPECT_EQ(mesh.Submesh(), mesh2.Submesh());

--- a/test/integration/geometry_dom.cc
+++ b/test/integration/geometry_dom.cc
@@ -179,6 +179,8 @@ TEST(DOMGeometry, Shapes)
   EXPECT_EQ(sdf::GeometryType::MESH, meshCol->Geom()->Type());
   const sdf::Mesh *meshColGeom = meshCol->Geom()->MeshShape();
   ASSERT_NE(nullptr, meshColGeom);
+  EXPECT_EQ("convex_hull", meshColGeom->Simplification());
+
   EXPECT_EQ("https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/"
       "mesh.dae", meshColGeom->Uri());
   EXPECT_TRUE(gz::math::Vector3d(0.1, 0.2, 0.3) ==

--- a/test/integration/geometry_dom.cc
+++ b/test/integration/geometry_dom.cc
@@ -179,7 +179,9 @@ TEST(DOMGeometry, Shapes)
   EXPECT_EQ(sdf::GeometryType::MESH, meshCol->Geom()->Type());
   const sdf::Mesh *meshColGeom = meshCol->Geom()->MeshShape();
   ASSERT_NE(nullptr, meshColGeom);
-  EXPECT_EQ("convex_hull", meshColGeom->Simplification());
+  EXPECT_EQ("convex_hull", meshColGeom->SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL,
+            meshColGeom->Simplification());
 
   EXPECT_EQ("https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/"
       "mesh.dae", meshColGeom->Uri());

--- a/test/sdf/shapes.sdf
+++ b/test/sdf/shapes.sdf
@@ -120,7 +120,7 @@
 
       <collision name="mesh_col">
         <geometry>
-          <mesh>
+          <mesh simplification="convex_hull">
             <uri>https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/mesh.dae</uri>
             <submesh>
               <name>my_submesh</name>


### PR DESCRIPTION


# 🎉 New feature

Implemented proposal in https://github.com/gazebosim/sdformat/issues/68

## Summary

Adds a new optional attribute called `simplification` to the `<mesh>` sdf element. This allows users specify a method for simplifying the mesh, e.g.

```xml
<collision name="my_collision">
  <geometry>
    <mesh simplification="convex_decomposition">
      <uri>path_to_complex_mesh</uri>
    </mesh>
  </geometry>
</collision>
```

Also updated the Mesh DOM class to include this new attribute.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

