### PR TITLE
Add mesh optimization attribute to <mesh>

### DIFF
--- a/include/sdf/Mesh.hh
+++ b/include/sdf/Mesh.hh
@@ -37,6 +37,17 @@ namespace sdf
   // Forward declarations.
   class ParserConfig;
 
+  /// \brief Mesh simplification method
+  enum class MeshSimplification
+  {
+    /// \brief No mesh simplification
+    NONE,
+    /// \brief Convex hull
+    CONVEX_HULL,
+    /// \brief Convex decomposition
+    CONVEX_DECOMPOSITION
+  };
+
   /// \brief Mesh represents a mesh shape, and is usually accessed through a
   /// Geometry.
   class SDFORMAT_VISIBLE Mesh
@@ -63,12 +74,24 @@ namespace sdf
 
     /// \brief Get the mesh's simplifcation method
     /// \return The mesh simplification method.
+    /// MeshSimplification::NONE if no mesh simplificaton is done.
+    public: MeshSimplification Simplification() const;
+
+    /// \brief Get the mesh's simplifcation method
+    /// \return The mesh simplification method.
     /// Empty string if no mesh simplificaton is done.
-    public: std::string Simplification() const;
+    public: std::string SimplificationStr() const;
 
     /// \brief Set the mesh simplification method.
     /// \param[in] _simplifcation The mesh simplification method.
-    public: void SetSimplification(const std::string &_simplifcation);
+    public: void SetSimplification(MeshSimplification _simplifcation);
+
+    /// \brief Set the mesh simplification method.
+    /// \param[in] _simplifcation The mesh simplification method.
+    /// \return True if the _simplificationStr parameter matched a known
+    /// mesh simplification method. False if the mesh simplification method
+    ///  could not be set.
+    public: bool SetSimplification(const std::string &_simplifcationStr);
 
     /// \brief Get the mesh's URI.
     /// \return The URI of the mesh data.

--- a/include/sdf/Mesh.hh
+++ b/include/sdf/Mesh.hh
@@ -37,10 +37,10 @@ namespace sdf
   // Forward declarations.
   class ParserConfig;
 
-  /// \brief Mesh simplification method
-  enum class MeshSimplification
+  /// \brief Mesh optimization method
+  enum class MeshOptimization
   {
-    /// \brief No mesh simplification
+    /// \brief No mesh optimization
     NONE,
     /// \brief Convex hull
     CONVEX_HULL,
@@ -72,26 +72,26 @@ namespace sdf
     /// an error code and message. An empty vector indicates no error.
     public: Errors Load(sdf::ElementPtr _sdf, const ParserConfig &_config);
 
-    /// \brief Get the mesh's simplifcation method
-    /// \return The mesh simplification method.
-    /// MeshSimplification::NONE if no mesh simplificaton is done.
-    public: MeshSimplification Simplification() const;
+    /// \brief Get the mesh's optimization method
+    /// \return The mesh optimization method.
+    /// MeshOptimization::NONE if no mesh simplificaton is done.
+    public: MeshOptimization Optimization() const;
 
-    /// \brief Get the mesh's simplifcation method
-    /// \return The mesh simplification method.
+    /// \brief Get the mesh's optimization method
+    /// \return The mesh optimization method.
     /// Empty string if no mesh simplificaton is done.
-    public: std::string SimplificationStr() const;
+    public: std::string OptimizationStr() const;
 
-    /// \brief Set the mesh simplification method.
-    /// \param[in] _simplifcation The mesh simplification method.
-    public: void SetSimplification(MeshSimplification _simplifcation);
+    /// \brief Set the mesh optimization method.
+    /// \param[in] _optimization The mesh optimization method.
+    public: void SetOptimization(MeshOptimization _optimization);
 
-    /// \brief Set the mesh simplification method.
-    /// \param[in] _simplifcation The mesh simplification method.
-    /// \return True if the _simplificationStr parameter matched a known
-    /// mesh simplification method. False if the mesh simplification method
+    /// \brief Set the mesh optimization method.
+    /// \param[in] _optimization The mesh optimization method.
+    /// \return True if the _optimizationStr parameter matched a known
+    /// mesh optimization method. False if the mesh optimization method
     ///  could not be set.
-    public: bool SetSimplification(const std::string &_simplifcationStr);
+    public: bool SetOptimization(const std::string &_optimizationStr);
 
     /// \brief Get the mesh's URI.
     /// \return The URI of the mesh data.

--- a/include/sdf/Mesh.hh
+++ b/include/sdf/Mesh.hh
@@ -61,6 +61,15 @@ namespace sdf
     /// an error code and message. An empty vector indicates no error.
     public: Errors Load(sdf::ElementPtr _sdf, const ParserConfig &_config);
 
+    /// \brief Get the mesh's simplifcation method
+    /// \return The mesh simplification method.
+    /// Empty string if no mesh simplificaton is done.
+    public: std::string Simplification() const;
+
+    /// \brief Set the mesh simplification method.
+    /// \param[in] _simplifcation The mesh simplification method.
+    public: void SetSimplification(const std::string &_simplifcation);
+
     /// \brief Get the mesh's URI.
     /// \return The URI of the mesh data.
     public: std::string Uri() const;

--- a/include/sdf/Mesh.hh
+++ b/include/sdf/Mesh.hh
@@ -120,7 +120,7 @@ namespace sdf
     /// \param[in] _optimization The mesh optimization method.
     /// \return True if the _optimizationStr parameter matched a known
     /// mesh optimization method. False if the mesh optimization method
-    ///  could not be set.
+    /// could not be set.
     public: bool SetOptimization(const std::string &_optimizationStr);
 
     /// \brief Get the associated ConvexDecomposition object

--- a/include/sdf/Mesh.hh
+++ b/include/sdf/Mesh.hh
@@ -48,6 +48,36 @@ namespace sdf
     CONVEX_DECOMPOSITION
   };
 
+  /// \brief Convex decomposition
+  class SDFORMAT_VISIBLE ConvexDecomposition
+  {
+    /// \brief Default constructor
+    public: ConvexDecomposition();
+
+    /// \brief Load the contact based on a element pointer. This is *not* the
+    /// usual entry point. Typical usage of the SDF DOM is through the Root
+    /// object.
+    /// \param[in] _sdf The SDF Element pointer
+    /// \return Errors, which is a vector of Error objects. Each Error includes
+    /// an error code and message. An empty vector indicates no error.
+    public: Errors Load(ElementPtr _sdf);
+
+    /// \brief Get a pointer to the SDF element that was used during
+    /// load.
+    /// \return SDF element pointer. The value will be nullptr if Load has
+    /// not been called.
+    public: sdf::ElementPtr Element() const;
+
+    /// \brief Get the maximum number of convex hulls that can be generated.
+    public: unsigned int MaxConvexHulls() const;
+
+    /// \brief Set the maximum number of convex hulls that can be generated.
+    public: void SetMaxConvexHulls(unsigned int _maxConvexHulls);
+
+    /// \brief Private data pointer.
+    GZ_UTILS_IMPL_PTR(dataPtr)
+  };
+
   /// \brief Mesh represents a mesh shape, and is usually accessed through a
   /// Geometry.
   class SDFORMAT_VISIBLE Mesh
@@ -92,6 +122,16 @@ namespace sdf
     /// mesh optimization method. False if the mesh optimization method
     ///  could not be set.
     public: bool SetOptimization(const std::string &_optimizationStr);
+
+    /// \brief Get the associated ConvexDecomposition object
+    /// \returns Pointer to the associated ConvexDecomposition object,
+    /// nullptr if the Mesh doesn't contain a ConvexDecomposition element.
+    public: const sdf::ConvexDecomposition *ConvexDecomposition() const;
+
+    /// \brief Set the associated ConvexDecomposition object.
+    /// \param[in] _convexDecomposition The ConvexDecomposition object.
+    public: void SetConvexDecomposition(
+        const sdf::ConvexDecomposition &_convexDecomposition);
 
     /// \brief Get the mesh's URI.
     /// \return The URI of the mesh data.

--- a/sdf/1.11/mesh_shape.sdf
+++ b/sdf/1.11/mesh_shape.sdf
@@ -1,11 +1,18 @@
 <element name="mesh" required="0">
   <description>Mesh shape</description>
 
-  <attribute name="simplification" type="string" default="" required="0">
+  <attribute name="optimization" type="string" default="" required="0">
     <description>
-      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull" - a single convex hull that encapsulates the mesh, "convex_decomposition" - decompose the mesh into multiple convex hull meshes. Default value is an empty string which means no mesh simplification.
+      Set whether to optimize the mesh using one of the specified methods. Values include: "convex_hull" - a single convex hull that encapsulates the mesh, "convex_decomposition" - decompose the mesh into multiple convex hull meshes. Default value is an empty string which means no mesh optimization.
     </description>
   </attribute>
+
+  <element name="convex_decomposition" required="0">
+    <description>Convex decomposition parameters. Applicable if the mesh optimization attribute is set to convex_decomposition</description>
+    <element name="max_convex_hulls" type="unsigned int" default="16" required="0">
+      <description>Maximum number of convex hulls to decompose into. If the input mesh has multiple submeshes, this limit is applied when decomposing each submesh</description>
+    </element>
+  </element>
 
   <element name="uri" type="string" default="__default__" required="1">
     <description>Mesh uri</description>

--- a/sdf/1.11/mesh_shape.sdf
+++ b/sdf/1.11/mesh_shape.sdf
@@ -1,5 +1,12 @@
 <element name="mesh" required="0">
   <description>Mesh shape</description>
+
+  <attribute name="simplification" type="string" default="" required="0">
+    <description>
+      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull", "convex_decomposition". Default value is an empty string which means no mesh simplification.
+    </description>
+  </attribute>
+
   <element name="uri" type="string" default="__default__" required="1">
     <description>Mesh uri</description>
   </element>

--- a/sdf/1.11/mesh_shape.sdf
+++ b/sdf/1.11/mesh_shape.sdf
@@ -3,7 +3,7 @@
 
   <attribute name="simplification" type="string" default="" required="0">
     <description>
-      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull", "convex_decomposition". Default value is an empty string which means no mesh simplification.
+      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull" - a single convex hull that encapsulates the mesh, "convex_decomposition" - decompose the mesh into multiple convex hull meshes. Default value is an empty string which means no mesh simplification.
     </description>
   </attribute>
 

--- a/sdf/1.12/mesh_shape.sdf
+++ b/sdf/1.12/mesh_shape.sdf
@@ -1,5 +1,12 @@
 <element name="mesh" required="0">
   <description>Mesh shape</description>
+
+  <attribute name="simplification" type="string" default="" required="0">
+    <description>
+      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull" - a single convex hull that encapsulates the mesh, "convex_decomposition" - decompose the mesh into multiple convex hull meshes. Default value is an empty string which means no mesh simplification.
+    </description>
+  </attribute>
+
   <element name="uri" type="string" default="__default__" required="1">
     <description>Mesh uri</description>
   </element>

--- a/sdf/1.12/mesh_shape.sdf
+++ b/sdf/1.12/mesh_shape.sdf
@@ -1,11 +1,18 @@
 <element name="mesh" required="0">
   <description>Mesh shape</description>
 
-  <attribute name="simplification" type="string" default="" required="0">
+  <attribute name="optimization" type="string" default="" required="0">
     <description>
-      Set whether to simplify the mesh using one of the specified methods. Values include: "convex_hull" - a single convex hull that encapsulates the mesh, "convex_decomposition" - decompose the mesh into multiple convex hull meshes. Default value is an empty string which means no mesh simplification.
+      Set whether to optimize the mesh using one of the specified methods. Values include: "convex_hull" - a single convex hull that encapsulates the mesh, "convex_decomposition" - decompose the mesh into multiple convex hull meshes. Default value is an empty string which means no mesh optimization.
     </description>
   </attribute>
+
+  <element name="convex_decomposition" required="0">
+    <description>Convex decomposition parameters. Applicable if the mesh optimization attribute is set to convex_decomposition</description>
+    <element name="max_convex_hulls" type="unsigned int" default="16" required="0">
+      <description>Maximum number of convex hulls to decompose into. If the input mesh has multiple submeshes, this limit is applied when decomposing each submesh</description>
+    </element>
+  </element>
 
   <element name="uri" type="string" default="__default__" required="1">
     <description>Mesh uri</description>

--- a/src/Mesh.cc
+++ b/src/Mesh.cc
@@ -30,6 +30,9 @@ using namespace sdf;
 // Private data class
 class sdf::Mesh::Implementation
 {
+  /// \brief Mesh simplification method
+  public: std::string simplification;
+
   /// \brief The mesh's URI.
   public: std::string uri = "";
 
@@ -87,6 +90,13 @@ Errors Mesh::Load(ElementPtr _sdf, const ParserConfig &_config)
     return errors;
   }
 
+  // Simplify
+  if (_sdf->HasAttribute("simplification"))
+  {
+    this->dataPtr->simplification = _sdf->Get<std::string>("simplification",
+        this->dataPtr->simplification).first;
+  }
+
   if (_sdf->HasElement("uri"))
   {
     std::unordered_set<std::string> paths;
@@ -138,6 +148,18 @@ Errors Mesh::Load(ElementPtr _sdf, const ParserConfig &_config)
 sdf::ElementPtr Mesh::Element() const
 {
   return this->dataPtr->sdf;
+}
+
+//////////////////////////////////////////////////
+std::string Mesh::Simplification() const
+{
+  return this->dataPtr->simplification;
+}
+
+//////////////////////////////////////////////////
+void Mesh::SetSimplification(const std::string &_simplification)
+{
+  this->dataPtr->simplification = _simplification;
 }
 
 //////////////////////////////////////////////////
@@ -243,6 +265,10 @@ sdf::ElementPtr Mesh::ToElement(sdf::Errors &_errors) const
 {
   sdf::ElementPtr elem(new sdf::Element);
   sdf::initFile("mesh_shape.sdf", elem);
+
+  // Simplification
+  elem->GetAttribute("simplification")->Set<std::string>(
+      this->dataPtr->simplification);
 
   // Uri
   sdf::ElementPtr uriElem = elem->GetElement("uri", _errors);

--- a/src/Mesh.cc
+++ b/src/Mesh.cc
@@ -14,8 +14,10 @@
  * limitations under the License.
  *
 */
+#include <array>
 #include <filesystem>
 #include <optional>
+#include <string_view>
 
 #include <gz/math/Inertial.hh>
 #include "sdf/CustomInertiaCalcProperties.hh"
@@ -27,11 +29,21 @@
 
 using namespace sdf;
 
+/// Mesh Simplification method strings. These should match the data in
+/// `enum class MeshSimplification` located in Mesh.hh, and the size
+/// template parameter should match the number of elements as well.
+constexpr std::array<const std::string_view, 3> kMeshSimplificationStrs =
+{
+  "",
+  "convex_hull",
+  "convex_decomposition"
+};
+
 // Private data class
 class sdf::Mesh::Implementation
 {
   /// \brief Mesh simplification method
-  public: std::string simplification;
+  public: MeshSimplification simplification = MeshSimplification::NONE;
 
   /// \brief The mesh's URI.
   public: std::string uri = "";
@@ -93,8 +105,7 @@ Errors Mesh::Load(ElementPtr _sdf, const ParserConfig &_config)
   // Simplify
   if (_sdf->HasAttribute("simplification"))
   {
-    this->dataPtr->simplification = _sdf->Get<std::string>("simplification",
-        this->dataPtr->simplification).first;
+    this->SetSimplification(_sdf->Get<std::string>("simplification", "").first);
   }
 
   if (_sdf->HasElement("uri"))
@@ -151,13 +162,36 @@ sdf::ElementPtr Mesh::Element() const
 }
 
 //////////////////////////////////////////////////
-std::string Mesh::Simplification() const
+MeshSimplification Mesh::Simplification() const
 {
   return this->dataPtr->simplification;
 }
 
 //////////////////////////////////////////////////
-void Mesh::SetSimplification(const std::string &_simplification)
+std::string Mesh::SimplificationStr() const
+{
+  size_t index = static_cast<int>(this->dataPtr->simplification);
+  if (index < kMeshSimplificationStrs.size())
+    return std::string(kMeshSimplificationStrs[index]);
+  return "";
+}
+
+//////////////////////////////////////////////////
+bool Mesh::SetSimplification(const std::string &_simplificationStr)
+{
+  for (size_t i = 0; i < kMeshSimplificationStrs.size(); ++i)
+  {
+    if (_simplificationStr == kMeshSimplificationStrs[i])
+    {
+      this->dataPtr->simplification = static_cast<MeshSimplification>(i);
+      return true;
+    }
+  }
+  return false;
+}
+
+//////////////////////////////////////////////////
+void Mesh::SetSimplification(MeshSimplification _simplification)
 {
   this->dataPtr->simplification = _simplification;
 }
@@ -268,7 +302,7 @@ sdf::ElementPtr Mesh::ToElement(sdf::Errors &_errors) const
 
   // Simplification
   elem->GetAttribute("simplification")->Set<std::string>(
-      this->dataPtr->simplification);
+      this->SimplificationStr());
 
   // Uri
   sdf::ElementPtr uriElem = elem->GetElement("uri", _errors);

--- a/src/Mesh.cc
+++ b/src/Mesh.cc
@@ -29,10 +29,10 @@
 
 using namespace sdf;
 
-/// Mesh Simplification method strings. These should match the data in
-/// `enum class MeshSimplification` located in Mesh.hh, and the size
+/// Mesh Optimization method strings. These should match the data in
+/// `enum class MeshOptimization` located in Mesh.hh, and the size
 /// template parameter should match the number of elements as well.
-constexpr std::array<const std::string_view, 3> kMeshSimplificationStrs =
+constexpr std::array<const std::string_view, 3> kMeshOptimizationStrs =
 {
   "",
   "convex_hull",
@@ -42,8 +42,8 @@ constexpr std::array<const std::string_view, 3> kMeshSimplificationStrs =
 // Private data class
 class sdf::Mesh::Implementation
 {
-  /// \brief Mesh simplification method
-  public: MeshSimplification simplification = MeshSimplification::NONE;
+  /// \brief Mesh optimization method
+  public: MeshOptimization optimization = MeshOptimization::NONE;
 
   /// \brief The mesh's URI.
   public: std::string uri = "";
@@ -103,9 +103,9 @@ Errors Mesh::Load(ElementPtr _sdf, const ParserConfig &_config)
   }
 
   // Simplify
-  if (_sdf->HasAttribute("simplification"))
+  if (_sdf->HasAttribute("optimization"))
   {
-    this->SetSimplification(_sdf->Get<std::string>("simplification", "").first);
+    this->SetOptimization(_sdf->Get<std::string>("optimization", "").first);
   }
 
   if (_sdf->HasElement("uri"))
@@ -162,28 +162,28 @@ sdf::ElementPtr Mesh::Element() const
 }
 
 //////////////////////////////////////////////////
-MeshSimplification Mesh::Simplification() const
+MeshOptimization Mesh::Optimization() const
 {
-  return this->dataPtr->simplification;
+  return this->dataPtr->optimization;
 }
 
 //////////////////////////////////////////////////
-std::string Mesh::SimplificationStr() const
+std::string Mesh::OptimizationStr() const
 {
-  size_t index = static_cast<int>(this->dataPtr->simplification);
-  if (index < kMeshSimplificationStrs.size())
-    return std::string(kMeshSimplificationStrs[index]);
+  size_t index = static_cast<int>(this->dataPtr->optimization);
+  if (index < kMeshOptimizationStrs.size())
+    return std::string(kMeshOptimizationStrs[index]);
   return "";
 }
 
 //////////////////////////////////////////////////
-bool Mesh::SetSimplification(const std::string &_simplificationStr)
+bool Mesh::SetOptimization(const std::string &_optimizationStr)
 {
-  for (size_t i = 0; i < kMeshSimplificationStrs.size(); ++i)
+  for (size_t i = 0; i < kMeshOptimizationStrs.size(); ++i)
   {
-    if (_simplificationStr == kMeshSimplificationStrs[i])
+    if (_optimizationStr == kMeshOptimizationStrs[i])
     {
-      this->dataPtr->simplification = static_cast<MeshSimplification>(i);
+      this->dataPtr->optimization = static_cast<MeshOptimization>(i);
       return true;
     }
   }
@@ -191,9 +191,9 @@ bool Mesh::SetSimplification(const std::string &_simplificationStr)
 }
 
 //////////////////////////////////////////////////
-void Mesh::SetSimplification(MeshSimplification _simplification)
+void Mesh::SetOptimization(MeshOptimization _optimization)
 {
-  this->dataPtr->simplification = _simplification;
+  this->dataPtr->optimization = _optimization;
 }
 
 //////////////////////////////////////////////////
@@ -300,9 +300,9 @@ sdf::ElementPtr Mesh::ToElement(sdf::Errors &_errors) const
   sdf::ElementPtr elem(new sdf::Element);
   sdf::initFile("mesh_shape.sdf", elem);
 
-  // Simplification
-  elem->GetAttribute("simplification")->Set<std::string>(
-      this->SimplificationStr());
+  // Optimization
+  elem->GetAttribute("optimization")->Set<std::string>(
+      this->OptimizationStr());
 
   // Uri
   sdf::ElementPtr uriElem = elem->GetElement("uri", _errors);

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -34,8 +34,8 @@ TEST(DOMMesh, Construction)
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
 
-  EXPECT_EQ(std::string(), mesh.SimplificationStr());
-  EXPECT_EQ(sdf::MeshSimplification::NONE, mesh.Simplification());
+  EXPECT_EQ(std::string(), mesh.OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::NONE, mesh.Optimization());
   EXPECT_EQ(std::string(), mesh.FilePath());
   EXPECT_EQ(std::string(), mesh.Uri());
   EXPECT_EQ(std::string(), mesh.Submesh());
@@ -47,7 +47,7 @@ TEST(DOMMesh, Construction)
 TEST(DOMMesh, MoveConstructor)
 {
   sdf::Mesh mesh;
-  mesh.SetSimplification("convex_hull");
+  mesh.SetOptimization("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -55,8 +55,8 @@ TEST(DOMMesh, MoveConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(std::move(mesh));
-  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
-  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::CONVEX_HULL, mesh2.Optimization());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -68,7 +68,7 @@ TEST(DOMMesh, MoveConstructor)
 TEST(DOMMesh, CopyConstructor)
 {
   sdf::Mesh mesh;
-  mesh.SetSimplification("convex_hull");
+  mesh.SetOptimization("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -76,8 +76,8 @@ TEST(DOMMesh, CopyConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(mesh);
-  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
-  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::CONVEX_HULL, mesh2.Optimization());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -89,7 +89,7 @@ TEST(DOMMesh, CopyConstructor)
 TEST(DOMMesh, CopyAssignmentOperator)
 {
   sdf::Mesh mesh;
-  mesh.SetSimplification("convex_hull");
+  mesh.SetOptimization("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -98,8 +98,8 @@ TEST(DOMMesh, CopyAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = mesh;
-  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
-  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::CONVEX_HULL, mesh2.Optimization());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -111,7 +111,7 @@ TEST(DOMMesh, CopyAssignmentOperator)
 TEST(DOMMesh, MoveAssignmentOperator)
 {
   sdf::Mesh mesh;
-  mesh.SetSimplification("convex_hull");
+  mesh.SetOptimization("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -120,8 +120,8 @@ TEST(DOMMesh, MoveAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = std::move(mesh);
-  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
-  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::CONVEX_HULL, mesh2.Optimization());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -154,14 +154,14 @@ TEST(DOMMesh, Set)
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
 
-  EXPECT_EQ(std::string(), mesh.SimplificationStr());
-  mesh.SetSimplification("convex_hull");
-  EXPECT_EQ("convex_hull", mesh.SimplificationStr());
-  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh.Simplification());
-  mesh.SetSimplification(sdf::MeshSimplification::CONVEX_DECOMPOSITION);
-  EXPECT_EQ("convex_decomposition", mesh.SimplificationStr());
-  EXPECT_EQ(sdf::MeshSimplification::CONVEX_DECOMPOSITION,
-            mesh.Simplification());
+  EXPECT_EQ(std::string(), mesh.OptimizationStr());
+  mesh.SetOptimization("convex_hull");
+  EXPECT_EQ("convex_hull", mesh.OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::CONVEX_HULL, mesh.Optimization());
+  mesh.SetOptimization(sdf::MeshOptimization::CONVEX_DECOMPOSITION);
+  EXPECT_EQ("convex_decomposition", mesh.OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::CONVEX_DECOMPOSITION,
+            mesh.Optimization());
 
   EXPECT_EQ(std::string(), mesh.Uri());
   mesh.SetUri("http://myuri.com");
@@ -319,7 +319,7 @@ TEST(DOMMesh, ToElement)
 {
   sdf::Mesh mesh;
 
-  mesh.SetSimplification("convex_hull");
+  mesh.SetOptimization("convex_hull");
   mesh.SetUri("mesh-uri");
   mesh.SetScale(gz::math::Vector3d(1, 2, 3));
   mesh.SetSubmesh("submesh");
@@ -331,8 +331,8 @@ TEST(DOMMesh, ToElement)
   sdf::Mesh mesh2;
   mesh2.Load(elem);
 
-  EXPECT_EQ(mesh.SimplificationStr(), mesh2.SimplificationStr());
-  EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
+  EXPECT_EQ(mesh.OptimizationStr(), mesh2.OptimizationStr());
+  EXPECT_EQ(mesh.Optimization(), mesh2.Optimization());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());
   EXPECT_EQ(mesh.Submesh(), mesh2.Submesh());
@@ -358,7 +358,7 @@ TEST(DOMMesh, ToElementErrorOutput)
   sdf::Mesh mesh;
   sdf::Errors errors;
 
-  mesh.SetSimplification("convex_hull");
+  mesh.SetOptimization("convex_hull");
   mesh.SetUri("mesh-uri");
   mesh.SetScale(gz::math::Vector3d(1, 2, 3));
   mesh.SetSubmesh("submesh");
@@ -372,8 +372,8 @@ TEST(DOMMesh, ToElementErrorOutput)
   errors = mesh2.Load(elem);
   EXPECT_TRUE(errors.empty());
 
-  EXPECT_EQ(mesh.SimplificationStr(), mesh2.SimplificationStr());
-  EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
+  EXPECT_EQ(mesh.OptimizationStr(), mesh2.OptimizationStr());
+  EXPECT_EQ(mesh.Optimization(), mesh2.Optimization());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());
   EXPECT_EQ(mesh.Submesh(), mesh2.Submesh());

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -34,7 +34,8 @@ TEST(DOMMesh, Construction)
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
 
-  EXPECT_EQ(std::string(), mesh.Simplification());
+  EXPECT_EQ(std::string(), mesh.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::NONE, mesh.Simplification());
   EXPECT_EQ(std::string(), mesh.FilePath());
   EXPECT_EQ(std::string(), mesh.Uri());
   EXPECT_EQ(std::string(), mesh.Submesh());
@@ -54,7 +55,8 @@ TEST(DOMMesh, MoveConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(std::move(mesh));
-  EXPECT_EQ("convex_hull", mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -74,7 +76,8 @@ TEST(DOMMesh, CopyConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(mesh);
-  EXPECT_EQ("convex_hull", mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -95,7 +98,8 @@ TEST(DOMMesh, CopyAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = mesh;
-  EXPECT_EQ("convex_hull", mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -116,7 +120,8 @@ TEST(DOMMesh, MoveAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = std::move(mesh);
-  EXPECT_EQ("convex_hull", mesh2.Simplification());
+  EXPECT_EQ("convex_hull", mesh2.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -149,9 +154,14 @@ TEST(DOMMesh, Set)
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
 
-  EXPECT_EQ(std::string(), mesh.Simplification());
+  EXPECT_EQ(std::string(), mesh.SimplificationStr());
   mesh.SetSimplification("convex_hull");
-  EXPECT_EQ("convex_hull", mesh.Simplification());
+  EXPECT_EQ("convex_hull", mesh.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL, mesh.Simplification());
+  mesh.SetSimplification(sdf::MeshSimplification::CONVEX_DECOMPOSITION);
+  EXPECT_EQ("convex_decomposition", mesh.SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_DECOMPOSITION,
+            mesh.Simplification());
 
   EXPECT_EQ(std::string(), mesh.Uri());
   mesh.SetUri("http://myuri.com");
@@ -321,6 +331,7 @@ TEST(DOMMesh, ToElement)
   sdf::Mesh mesh2;
   mesh2.Load(elem);
 
+  EXPECT_EQ(mesh.SimplificationStr(), mesh2.SimplificationStr());
   EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());
@@ -361,6 +372,7 @@ TEST(DOMMesh, ToElementErrorOutput)
   errors = mesh2.Load(elem);
   EXPECT_TRUE(errors.empty());
 
+  EXPECT_EQ(mesh.SimplificationStr(), mesh2.SimplificationStr());
   EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -48,7 +48,7 @@ TEST(DOMMesh, Construction)
 TEST(DOMMesh, MoveConstructor)
 {
   sdf::Mesh mesh;
-  mesh.SetOptimization("convex_decomposition");
+  EXPECT_TRUE(mesh.SetOptimization("convex_decomposition"));
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -56,6 +56,7 @@ TEST(DOMMesh, MoveConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::ConvexDecomposition convexDecomp;
+  EXPECT_EQ(nullptr, convexDecomp.Element());
   convexDecomp.SetMaxConvexHulls(10u);
   mesh.SetConvexDecomposition(convexDecomp);
 
@@ -77,7 +78,7 @@ TEST(DOMMesh, MoveConstructor)
 TEST(DOMMesh, CopyConstructor)
 {
   sdf::Mesh mesh;
-  mesh.SetOptimization("convex_hull");
+  EXPECT_TRUE(mesh.SetOptimization("convex_hull"));
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -99,7 +100,7 @@ TEST(DOMMesh, CopyConstructor)
 TEST(DOMMesh, CopyAssignmentOperator)
 {
   sdf::Mesh mesh;
-  mesh.SetOptimization("convex_hull");
+  EXPECT_TRUE(mesh.SetOptimization("convex_hull"));
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -122,7 +123,7 @@ TEST(DOMMesh, CopyAssignmentOperator)
 TEST(DOMMesh, MoveAssignmentOperator)
 {
   sdf::Mesh mesh;
-  mesh.SetOptimization("convex_hull");
+  EXPECT_TRUE(mesh.SetOptimization("convex_hull"));
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -167,13 +168,14 @@ TEST(DOMMesh, Set)
   EXPECT_EQ(nullptr, mesh.Element());
 
   EXPECT_EQ(std::string(), mesh.OptimizationStr());
-  mesh.SetOptimization("convex_hull");
+  EXPECT_TRUE(mesh.SetOptimization("convex_hull"));
   EXPECT_EQ("convex_hull", mesh.OptimizationStr());
   EXPECT_EQ(sdf::MeshOptimization::CONVEX_HULL, mesh.Optimization());
   mesh.SetOptimization(sdf::MeshOptimization::CONVEX_DECOMPOSITION);
   EXPECT_EQ("convex_decomposition", mesh.OptimizationStr());
   EXPECT_EQ(sdf::MeshOptimization::CONVEX_DECOMPOSITION,
             mesh.Optimization());
+  EXPECT_FALSE(mesh.SetOptimization("invalid"));
 
   sdf::ConvexDecomposition convexDecomp;
   convexDecomp.SetMaxConvexHulls(10u);
@@ -337,7 +339,7 @@ TEST(DOMMesh, ToElement)
 {
   sdf::Mesh mesh;
 
-  mesh.SetOptimization("convex_decomposition");
+  EXPECT_TRUE(mesh.SetOptimization("convex_decomposition"));
   mesh.SetUri("mesh-uri");
   mesh.SetScale(gz::math::Vector3d(1, 2, 3));
   mesh.SetSubmesh("submesh");
@@ -382,7 +384,7 @@ TEST(DOMMesh, ToElementErrorOutput)
   sdf::Mesh mesh;
   sdf::Errors errors;
 
-  mesh.SetOptimization("convex_hull");
+  EXPECT_TRUE(mesh.SetOptimization("convex_hull"));
   mesh.SetUri("mesh-uri");
   mesh.SetScale(gz::math::Vector3d(1, 2, 3));
   mesh.SetSubmesh("submesh");

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -175,7 +175,14 @@ TEST(DOMMesh, Set)
   EXPECT_EQ("convex_decomposition", mesh.OptimizationStr());
   EXPECT_EQ(sdf::MeshOptimization::CONVEX_DECOMPOSITION,
             mesh.Optimization());
+  // check invalid inputs
   EXPECT_FALSE(mesh.SetOptimization("invalid"));
+  {
+    auto invalidMeshOpt = static_cast<sdf::MeshOptimization>(99);
+    mesh.SetOptimization(invalidMeshOpt);
+    EXPECT_EQ(invalidMeshOpt, mesh.Optimization());
+    EXPECT_EQ("", mesh.OptimizationStr());
+  }
 
   sdf::ConvexDecomposition convexDecomp;
   convexDecomp.SetMaxConvexHulls(10u);
@@ -208,6 +215,7 @@ TEST(DOMMesh, Set)
 TEST(DOMMesh, Load)
 {
   sdf::Mesh mesh;
+  sdf::ConvexDecomposition convexDecomp;
   sdf::Errors errors;
 
   // Null element name
@@ -216,6 +224,11 @@ TEST(DOMMesh, Load)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_MISSING, errors[0].Code());
   EXPECT_EQ(nullptr, mesh.Element());
 
+  errors = convexDecomp.Load(nullptr);
+  ASSERT_EQ(1u, errors.size());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_MISSING, errors[0].Code());
+  EXPECT_EQ(nullptr, convexDecomp.Element());
+
   // Bad element name
   sdf::ElementPtr sdf(new sdf::Element());
   sdf->SetName("bad");
@@ -223,6 +236,11 @@ TEST(DOMMesh, Load)
   ASSERT_EQ(1u, errors.size());
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
   EXPECT_NE(nullptr, mesh.Element());
+
+  errors = convexDecomp.Load(sdf);
+  ASSERT_EQ(1u, errors.size());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
+  EXPECT_NE(nullptr, convexDecomp.Element());
 
   // Missing <uri> element
   sdf->SetName("mesh");

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -34,6 +34,7 @@ TEST(DOMMesh, Construction)
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
 
+  EXPECT_EQ(std::string(), mesh.Simplification());
   EXPECT_EQ(std::string(), mesh.FilePath());
   EXPECT_EQ(std::string(), mesh.Uri());
   EXPECT_EQ(std::string(), mesh.Submesh());
@@ -45,6 +46,7 @@ TEST(DOMMesh, Construction)
 TEST(DOMMesh, MoveConstructor)
 {
   sdf::Mesh mesh;
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -52,6 +54,7 @@ TEST(DOMMesh, MoveConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(std::move(mesh));
+  EXPECT_EQ("convex_hull", mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -63,6 +66,7 @@ TEST(DOMMesh, MoveConstructor)
 TEST(DOMMesh, CopyConstructor)
 {
   sdf::Mesh mesh;
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -70,6 +74,7 @@ TEST(DOMMesh, CopyConstructor)
   mesh.SetFilePath("/pear");
 
   sdf::Mesh mesh2(mesh);
+  EXPECT_EQ("convex_hull", mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -81,6 +86,7 @@ TEST(DOMMesh, CopyConstructor)
 TEST(DOMMesh, CopyAssignmentOperator)
 {
   sdf::Mesh mesh;
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -89,6 +95,7 @@ TEST(DOMMesh, CopyAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = mesh;
+  EXPECT_EQ("convex_hull", mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -100,6 +107,7 @@ TEST(DOMMesh, CopyAssignmentOperator)
 TEST(DOMMesh, MoveAssignmentOperator)
 {
   sdf::Mesh mesh;
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("banana");
   mesh.SetSubmesh("watermelon");
   mesh.SetCenterSubmesh(true);
@@ -108,6 +116,7 @@ TEST(DOMMesh, MoveAssignmentOperator)
 
   sdf::Mesh mesh2;
   mesh2 = std::move(mesh);
+  EXPECT_EQ("convex_hull", mesh2.Simplification());
   EXPECT_EQ("banana", mesh2.Uri());
   EXPECT_EQ("watermelon", mesh2.Submesh());
   EXPECT_EQ(gz::math::Vector3d(0.5, 0.6, 0.7), mesh2.Scale());
@@ -139,6 +148,10 @@ TEST(DOMMesh, Set)
 {
   sdf::Mesh mesh;
   EXPECT_EQ(nullptr, mesh.Element());
+
+  EXPECT_EQ(std::string(), mesh.Simplification());
+  mesh.SetSimplification("convex_hull");
+  EXPECT_EQ("convex_hull", mesh.Simplification());
 
   EXPECT_EQ(std::string(), mesh.Uri());
   mesh.SetUri("http://myuri.com");
@@ -296,6 +309,7 @@ TEST(DOMMesh, ToElement)
 {
   sdf::Mesh mesh;
 
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("mesh-uri");
   mesh.SetScale(gz::math::Vector3d(1, 2, 3));
   mesh.SetSubmesh("submesh");
@@ -307,6 +321,7 @@ TEST(DOMMesh, ToElement)
   sdf::Mesh mesh2;
   mesh2.Load(elem);
 
+  EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());
   EXPECT_EQ(mesh.Submesh(), mesh2.Submesh());
@@ -332,6 +347,7 @@ TEST(DOMMesh, ToElementErrorOutput)
   sdf::Mesh mesh;
   sdf::Errors errors;
 
+  mesh.SetSimplification("convex_hull");
   mesh.SetUri("mesh-uri");
   mesh.SetScale(gz::math::Vector3d(1, 2, 3));
   mesh.SetSubmesh("submesh");
@@ -345,6 +361,7 @@ TEST(DOMMesh, ToElementErrorOutput)
   errors = mesh2.Load(elem);
   EXPECT_TRUE(errors.empty());
 
+  EXPECT_EQ(mesh.Simplification(), mesh2.Simplification());
   EXPECT_EQ(mesh.Uri(), mesh2.Uri());
   EXPECT_EQ(mesh.Scale(), mesh2.Scale());
   EXPECT_EQ(mesh.Submesh(), mesh2.Submesh());

--- a/test/integration/geometry_dom.cc
+++ b/test/integration/geometry_dom.cc
@@ -179,6 +179,8 @@ TEST(DOMGeometry, Shapes)
   EXPECT_EQ(sdf::GeometryType::MESH, meshCol->Geom()->Type());
   const sdf::Mesh *meshColGeom = meshCol->Geom()->MeshShape();
   ASSERT_NE(nullptr, meshColGeom);
+  EXPECT_EQ("convex_hull", meshColGeom->Simplification());
+
   EXPECT_EQ("https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/"
       "mesh.dae", meshColGeom->Uri());
   EXPECT_TRUE(gz::math::Vector3d(0.1, 0.2, 0.3) ==

--- a/test/integration/geometry_dom.cc
+++ b/test/integration/geometry_dom.cc
@@ -179,9 +179,9 @@ TEST(DOMGeometry, Shapes)
   EXPECT_EQ(sdf::GeometryType::MESH, meshCol->Geom()->Type());
   const sdf::Mesh *meshColGeom = meshCol->Geom()->MeshShape();
   ASSERT_NE(nullptr, meshColGeom);
-  EXPECT_EQ("convex_hull", meshColGeom->SimplificationStr());
-  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL,
-            meshColGeom->Simplification());
+  EXPECT_EQ("convex_hull", meshColGeom->OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::CONVEX_HULL,
+            meshColGeom->Optimization());
 
   EXPECT_EQ("https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/"
       "mesh.dae", meshColGeom->Uri());

--- a/test/integration/geometry_dom.cc
+++ b/test/integration/geometry_dom.cc
@@ -179,9 +179,11 @@ TEST(DOMGeometry, Shapes)
   EXPECT_EQ(sdf::GeometryType::MESH, meshCol->Geom()->Type());
   const sdf::Mesh *meshColGeom = meshCol->Geom()->MeshShape();
   ASSERT_NE(nullptr, meshColGeom);
-  EXPECT_EQ("convex_hull", meshColGeom->OptimizationStr());
-  EXPECT_EQ(sdf::MeshOptimization::CONVEX_HULL,
+  EXPECT_EQ("convex_decomposition", meshColGeom->OptimizationStr());
+  EXPECT_EQ(sdf::MeshOptimization::CONVEX_DECOMPOSITION,
             meshColGeom->Optimization());
+  ASSERT_NE(nullptr, meshColGeom->ConvexDecomposition());
+  EXPECT_EQ(4u, meshColGeom->ConvexDecomposition()->MaxConvexHulls());
 
   EXPECT_EQ("https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/"
       "mesh.dae", meshColGeom->Uri());

--- a/test/integration/geometry_dom.cc
+++ b/test/integration/geometry_dom.cc
@@ -179,7 +179,9 @@ TEST(DOMGeometry, Shapes)
   EXPECT_EQ(sdf::GeometryType::MESH, meshCol->Geom()->Type());
   const sdf::Mesh *meshColGeom = meshCol->Geom()->MeshShape();
   ASSERT_NE(nullptr, meshColGeom);
-  EXPECT_EQ("convex_hull", meshColGeom->Simplification());
+  EXPECT_EQ("convex_hull", meshColGeom->SimplificationStr());
+  EXPECT_EQ(sdf::MeshSimplification::CONVEX_HULL,
+            meshColGeom->Simplification());
 
   EXPECT_EQ("https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/"
       "mesh.dae", meshColGeom->Uri());

--- a/test/sdf/shapes.sdf
+++ b/test/sdf/shapes.sdf
@@ -120,7 +120,10 @@
 
       <collision name="mesh_col">
         <geometry>
-          <mesh simplification="convex_hull">
+          <mesh optimization="convex_decomposition">
+            <convex_decomposition>
+              <max_convex_hulls>4</max_convex_hulls>
+            </convex_decomposition>
             <uri>https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/mesh.dae</uri>
             <submesh>
               <name>my_submesh</name>

--- a/test/sdf/shapes.sdf
+++ b/test/sdf/shapes.sdf
@@ -120,7 +120,7 @@
 
       <collision name="mesh_col">
         <geometry>
-          <mesh>
+          <mesh simplification="convex_hull">
             <uri>https://fuel.gazebosim.org/1.0/an_org/models/a_model/mesh/mesh.dae</uri>
             <submesh>
               <name>my_submesh</name>


### PR DESCRIPTION
# 🎉 New feature

Replaces #1380

Implemented proposal in https://github.com/gazebosim/sdformat/issues/68

## Summary

Adds a new optional attribute called ~`simplification`~ `optimization` to the `<mesh>` sdf element. This allows users specify a method for simplifying the mesh, e.g.

```xml
<collision name="my_collision">
  <geometry>
    <mesh optimization="convex_decomposition">
      <uri>path_to_complex_mesh</uri>
    </mesh>
  </geometry>
</collision>
```

Also updated the Mesh DOM class to include this new attribute.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

