### PR TITLE
Update max_convex_hulls description 

### DIFF
--- a/sdf/1.11/mesh_shape.sdf
+++ b/sdf/1.11/mesh_shape.sdf
@@ -10,7 +10,7 @@
   <element name="convex_decomposition" required="0">
     <description>Convex decomposition parameters. Applicable if the mesh optimization attribute is set to convex_decomposition</description>
     <element name="max_convex_hulls" type="unsigned int" default="16" required="0">
-      <description>Maximum number of convex hulls to decompose into. If the input mesh has multiple submeshes, this limit is applied when decomposing each submesh</description>
+      <description>Maximum number of convex hulls to decompose into. This sets the maximum number of submeshes that the final decomposed mesh will contain.</description>
     </element>
   </element>
 

--- a/sdf/1.12/mesh_shape.sdf
+++ b/sdf/1.12/mesh_shape.sdf
@@ -12,7 +12,6 @@
     <element name="max_convex_hulls" type="unsigned int" default="16" required="0">
       <description>Maximum number of convex hulls to decompose into. This sets the maximum number of submeshes that the final decomposed mesh will contain.</description>
     </element>
-    </element>
   </element>
 
   <element name="uri" type="string" default="__default__" required="1">

--- a/sdf/1.12/mesh_shape.sdf
+++ b/sdf/1.12/mesh_shape.sdf
@@ -10,7 +10,8 @@
   <element name="convex_decomposition" required="0">
     <description>Convex decomposition parameters. Applicable if the mesh optimization attribute is set to convex_decomposition</description>
     <element name="max_convex_hulls" type="unsigned int" default="16" required="0">
-      <description>Maximum number of convex hulls to decompose into. If the input mesh has multiple submeshes, this limit is applied when decomposing each submesh</description>
+      <description>Maximum number of convex hulls to decompose into. This sets the maximum number of submeshes that the final decomposed mesh will contain.</description>
+    </element>
     </element>
   </element>
 


### PR DESCRIPTION

# 🦟 Bug fix


## Summary
Update `<max_convex_hulls>` description based on the recommendation in https://github.com/gazebosim/gz-physics/pull/606#pullrequestreview-1956282332. 

This parameter now determines the max number of submeshes that will be in the final decomposed mesh.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
