### PR TITLE
Prepare for 14.1.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat14 VERSION 14.1.0)
+project (sdformat14 VERSION 14.1.1)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 ## libsdformat 14.X
 
+### libsdformat 14.1.1 (2024-03-28)
+
+1. Use relative install paths in CMake
+    * [Pull request #1387](https://github.com/gazebosim/sdformat/pull/1387)
+
 ### libsdformat 14.1.0 (2024-03-14)
+
 1. Resolve URIs relative to file path
     * [Pull request #1373](https://github.com/gazebosim/sdformat/pull/1373)
 
@@ -22,7 +28,7 @@
 1. Bazel updates for Garden build
     * [Pull request #1239](https://github.com/gazebosim/sdformat/pull/1239)
 
-1. Fix static builds and optimize test compilation 
+1. Fix static builds and optimize test compilation
     * [Pull request #1343](https://github.com/gazebosim/sdformat/pull/1343)
     * [Pull request #1347](https://github.com/gazebosim/sdformat/pull/1347)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### libsdformat 14.1.1 (2024-03-28)
 
+1. Fix warning with pybind11 2.12
+    * [Pull request #1389](https://github.com/gazebosim/sdformat/pull/1389)
+
 1. Use relative install paths in CMake
     * [Pull request #1387](https://github.com/gazebosim/sdformat/pull/1387)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 14.1.1 release.

Comparison to 14.1.0: https://github.com/gazebosim/sdformat/compare/sdformat14_14.1.0...sdf14

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.