### PR TITLE
Fix warning with pybind11 2.12

### DIFF
--- a/python/src/sdf/_gz_sdformat_pybind11.cc
+++ b/python/src/sdf/_gz_sdformat_pybind11.cc
@@ -150,7 +150,11 @@ PYBIND11_MODULE(BINDINGS_MODULE_NAME, m) {
       sdfErrorsException.attr("errors") = pybind11::cast(e.Errors());
       // This has to be called last since it's the call that sets
       // PyErr_SetString.
+#if PYBIND11_VERSION_HEX >= 0x020C0000
+      pybind11::set_error(sdfErrorsException, e.what());
+#else
       sdfErrorsException(e.what());
+#endif
     }
   });
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a compiler warning caused by pybind11 2.12

## Summary

Version 2.12 of pybind11 was recently merged to homebrew-core:

* https://github.com/Homebrew/homebrew-core/pull/167370

This release includes https://github.com/pybind/pybind11/pull/4772, which causes a compiler warning in sdformat:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdf14-homebrew-amd64&build=37)](https://build.osrfoundation.org/view/gz-harmonic/job/sdformat-ci-sdf14-homebrew-amd64/37/) https://build.osrfoundation.org/view/gz-harmonic/job/sdformat-ci-sdf14-homebrew-amd64/37/clang/

~~~
python/src/sdf/_gz_sdformat_pybind11.cc:153:25: warning: 'operator()' is deprecated: Please use py::set_error() instead (https://github.com/pybind/pybind11/pull/4772) [-Wdeprecated-declarations]
      sdfErrorsException(e.what());
                        ^
/usr/local/include/pybind11/pybind11.h:2623:5: note: 'operator()' has been explicitly marked deprecated here
    PYBIND11_DEPRECATED("Please use py::set_error() instead "
    ^
/usr/local/include/pybind11/detail/common.h:202:43: note: expanded from macro 'PYBIND11_DEPRECATED'
#    define PYBIND11_DEPRECATED(reason) [[deprecated(reason)]]
                                          ^
1 warning generated.
~~~

This adds a version check and a fix for newer versions of pybind11.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
