### PR TITLE
Parse kinematic property in link

### DIFF
--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -419,7 +419,7 @@ namespace sdf
     public: bool Kinematic() const;
 
     /// \brief Set whether this link is kinematic only.
-    /// \param[in] _enable True to make the link kinematic only,
+    /// \param[in] _kinematic True to make the link kinematic only,
     public: void SetKinematic(bool _kinematic);
 
     /// \brief Check if the automatic calculation for the link inertial

--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -414,6 +414,14 @@ namespace sdf
     /// \sa Model::SetEnableWind(bool)
     public: void SetEnableWind(bool _enableWind);
 
+    /// \brief Check if this link is kinematic only
+    /// \return true if the link is kinematic only, false otherwise.
+    public: bool Kinematic() const;
+
+    /// \brief Set whether this link is kinematic only.
+    /// \param[in] _enable True to make the link kinematic only,
+    public: void SetKinematic(bool _kinematic);
+
     /// \brief Check if the automatic calculation for the link inertial
     /// is enabled or not.
     /// \return True if automatic calculation is enabled. This can be done

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -87,6 +87,9 @@ class sdf::Link::Implementation
   /// \brief True if this link should be subject to wind, false otherwise.
   public: bool enableWind = false;
 
+  /// \brief True if this link is kinematic only
+  public: bool kinematic = false;
+
   /// \brief True if automatic caluclation for the link inertial is enabled
   public: bool autoInertia = false;
 
@@ -312,6 +315,9 @@ Errors Link::Load(ElementPtr _sdf, const ParserConfig &_config)
 
   this->dataPtr->enableWind = _sdf->Get<bool>("enable_wind",
       this->dataPtr->enableWind).first;
+
+  this->dataPtr->kinematic = _sdf->Get<bool>("kinematic",
+      this->dataPtr->kinematic).first;
 
   return errors;
 }
@@ -842,6 +848,18 @@ void Link::SetEnableWind(const bool _enableWind)
 }
 
 /////////////////////////////////////////////////
+bool Link::Kinematic() const
+{
+  return this->dataPtr->kinematic;
+}
+
+/////////////////////////////////////////////////
+void Link::SetKinematic(bool _kinematic)
+{
+  this->dataPtr->kinematic = _kinematic;
+}
+
+/////////////////////////////////////////////////
 bool Link::AutoInertia() const
 {
   return this->dataPtr->autoInertia;
@@ -1021,6 +1039,9 @@ sdf::ElementPtr Link::ToElement() const
 
   // wind mode
   elem->GetElement("enable_wind")->Set(this->EnableWind());
+
+  // kinematic
+  elem->GetElement("kinematic")->Set(this->Kinematic());
 
   // Collisions
   for (const sdf::Collision &collision : this->dataPtr->collisions)

--- a/src/Link_TEST.cc
+++ b/src/Link_TEST.cc
@@ -72,6 +72,10 @@ TEST(DOMLink, Construction)
   link.SetEnableWind(true);
   EXPECT_TRUE(link.EnableWind());
 
+  EXPECT_FALSE(link.Kinematic());
+  link.SetKinematic(true);
+  EXPECT_TRUE(link.Kinematic());
+
   EXPECT_FALSE(link.AutoInertiaSaved());
   link.SetAutoInertiaSaved(true);
   EXPECT_TRUE(link.AutoInertiaSaved());
@@ -902,6 +906,7 @@ TEST(DOMLink, ToElement)
   EXPECT_TRUE(link.SetInertial(inertial));
   link.SetRawPose(gz::math::Pose3d(1, 2, 3, 0.1, 0.2, 0.3));
   link.SetEnableWind(true);
+  link.SetKinematic(true);
 
   for (int j = 0; j <= 1; ++j)
   {
@@ -998,6 +1003,7 @@ TEST(DOMLink, ToElement)
   EXPECT_EQ(link.Density(), link2.Density());
   EXPECT_EQ(link.RawPose(), link2.RawPose());
   EXPECT_EQ(link.EnableWind(), link2.EnableWind());
+  EXPECT_EQ(link.Kinematic(), link2.Kinematic());
   EXPECT_EQ(link.CollisionCount(), link2.CollisionCount());
   for (uint64_t i = 0; i < link2.CollisionCount(); ++i)
     EXPECT_NE(nullptr, link2.CollisionByIndex(i));

--- a/test/integration/link_dom.cc
+++ b/test/integration/link_dom.cc
@@ -147,6 +147,7 @@ TEST(DOMLink, InertialDoublePendulum)
       upperLink->RawPose());
   EXPECT_EQ("", upperLink->PoseRelativeTo());
   EXPECT_TRUE(upperLink->EnableWind());
+  EXPECT_TRUE(upperLink->Kinematic());
 
   const gz::math::Inertiald inertialUpper = upperLink->Inertial();
   EXPECT_DOUBLE_EQ(1.0, inertialUpper.MassMatrix().Mass());

--- a/test/sdf/double_pendulum.sdf
+++ b/test/sdf/double_pendulum.sdf
@@ -57,6 +57,7 @@
     <!-- upper link, length 1, IC -90 degrees -->
     <link name="upper_link">
       <enable_wind>true</enable_wind>
+      <kinematic>true</kinematic>
       <pose>0 0 2.1 -1.5708 0 0</pose>
       <self_collide>0</self_collide>
       <inertial>


### PR DESCRIPTION

# 🎉 New feature

## Summary

Parses `<kinematic>` SDF element in `<link>` and stores the bool value in Link DOM.



## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

