### PR TITLE
Param_TEST: Check return values of Param::Get/Set

### DIFF
--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -46,45 +46,45 @@ TEST(Param, Bool)
 {
   sdf::Param boolParam("key", "bool", "true", false, "description");
   bool value = true;
-  boolParam.Get<bool>(value);
+  EXPECT_TRUE(boolParam.Get<bool>(value));
   EXPECT_TRUE(value);
 
-  boolParam.Set(false);
-  boolParam.Get<bool>(value);
+  EXPECT_TRUE(boolParam.Set(false));
+  EXPECT_TRUE(boolParam.Get<bool>(value));
   EXPECT_FALSE(value);
 
   // String parameter that represents a boolean.
   sdf::Param strParam("key", "string", "true", false, "description");
 
-  strParam.Get<bool>(value);
+  EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_TRUE(value);
 
-  strParam.Set("false");
-  strParam.Get<bool>(value);
+  EXPECT_TRUE(strParam.Set("false"));
+  EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_FALSE(value);
 
-  strParam.Set("1");
-  strParam.Get<bool>(value);
+  EXPECT_TRUE(strParam.Set("1"));
+  EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_TRUE(value);
 
-  strParam.Set("0");
-  strParam.Get<bool>(value);
+  EXPECT_TRUE(strParam.Set("0"));
+  EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_FALSE(value);
 
-  strParam.Set("True");
-  strParam.Get<bool>(value);
+  EXPECT_TRUE(strParam.Set("True"));
+  EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_TRUE(value);
 
-  strParam.Set("TRUE");
-  strParam.Get<bool>(value);
+  EXPECT_TRUE(strParam.Set("TRUE"));
+  EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_TRUE(value);
 
   // Anything other than 1 or true is treated as a false value
-  strParam.Set("%");
-  strParam.Get<bool>(value);
+  EXPECT_TRUE(strParam.Set("%"));
+  EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_FALSE(value);
 
-  boolParam.Set(true);
+  EXPECT_TRUE(boolParam.Set(true));
   std::any anyValue;
   EXPECT_TRUE(boolParam.GetAny(anyValue));
   try


### PR DESCRIPTION
# 🦟 Bug fix

Adds more expectations to a unit test

## Summary

While investigating how to implement a suggestion added in a comment in https://github.com/gazebosim/sdformat/commit/d3532946bc64fef713b30fbb1ab21a33603bf9dd, I noticed that the `UNIT_Param_TEST` has many calls to `bool Param::Get` and `bool Param::Set` without checking the return value. This adds expectations on the return value of those function calls, which will aid in addressing the aforementioned comment with a behavior change PR on `main`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
