### PR TITLE
Change behavior of Param::Get<bool>

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -20,6 +20,16 @@ but with improved human-readability..
     + Details about the 1.11 to 1.12 transition are explained below in this same
       document
 
+### Modifications
+
+1. **Behavior change of `Param::Get<bool>`**
+    + Previously when a Param was set from a string, the `Get<bool>` method
+      would always return `true`, and the value would be `true` if the lowercase
+      string value matched `"1"` or `"true"` and `false` otherwise. Now,
+      the `Get<bool>` method returns `true` only if the lowercase value string
+      matches `"0"`, `"1"`, `"true"`, or `"false"` and returns `false`
+      otherwise.
+
 ## libsdformat 13.x to 14.x
 
 ### Additions

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -740,22 +740,6 @@ namespace sdf
       {
         _value = std::get<T>(pv);
       }
-      else if (typeStr == "bool" && this->dataPtr->typeName == "string")
-      {
-        // this section for handling bool types is to keep backward behavior
-        // TODO(anyone) remove for Fortress. For more details:
-        // https://github.com/gazebosim/sdformat/pull/638
-        valueStr = lowercase(valueStr);
-
-        std::stringstream tmp;
-        if (valueStr == "true" || valueStr == "1")
-          tmp << "1";
-        else
-          tmp << "0";
-
-        tmp >> _value;
-        return true;
-      }
 
       return success;
     }

--- a/python/test/pyParam_TEST.py
+++ b/python/test/pyParam_TEST.py
@@ -46,7 +46,7 @@ class ParamTEST(unittest.TestCase):
         str_param.set_string("TRUE")
         self.assertTrue(str_param.get_bool()[0])
 
-        # Anything other than 1 or true is treated as a False value
+        # Anything other than "0", "1" , "false", or "true" raises an exception
         str_param.set_string("%")
         with self.assertRaises(SDFErrorsException):
             str_param.get_bool()

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -79,8 +79,8 @@ TEST(Param, Bool)
   EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_TRUE(value);
 
-  // Anything other than 0, 1, true, or false (any capitalization) will
-  // causes Get<bool> to fail.
+  // Anything other than "0", "1", "true", or "false" (any capitalization) will
+  // cause Get<bool> to fail.
   EXPECT_TRUE(strParam.Set("%"));
   EXPECT_FALSE(strParam.Get<bool>(value));
 

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -79,10 +79,10 @@ TEST(Param, Bool)
   EXPECT_TRUE(strParam.Get<bool>(value));
   EXPECT_TRUE(value);
 
-  // Anything other than 1 or true is treated as a false value
+  // Anything other than 0, 1, true, or false (any capitalization) will
+  // causes Get<bool> to fail.
   EXPECT_TRUE(strParam.Set("%"));
-  EXPECT_TRUE(strParam.Get<bool>(value));
-  EXPECT_FALSE(value);
+  EXPECT_FALSE(strParam.Get<bool>(value));
 
   EXPECT_TRUE(boolParam.Set(true));
   std::any anyValue;


### PR DESCRIPTION
# 🦟 Bug fix

Implements a behavior change from a TODO comment in the Fortress era

## Summary

A comment was added in https://github.com/gazebosim/sdformat/pull/638/commits/d3532946bc64fef713b30fbb1ab21a33603bf9dd to #638 suggesting a behavior change in `Param::Get<bool>` that should be done for Fortress. I just noticed it recently and have implemented the behavior change and updated a test and the migration guide.

### Description of behavior change:

Previously when a Param was set from a string, the
`Get<bool>` method would always return `true`, and
the value would be `true` if the lowercase value string
matched `"1"` or `"true"`. Otherwise the value would
be `false`.

Now, the `Get<bool>` method returns `true` only if the
lowercase value string matches one of `"0"`, `"1"`,
`"true"`, or `"false"`. Otherwise `Get<bool>` returns
`false` and the value is not written.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
