### PR TITLE
Added kinematic methods to Python Link wrapper

### DIFF
--- a/python/src/sdf/pyLink.cc
+++ b/python/src/sdf/pyLink.cc
@@ -162,6 +162,12 @@ void defineLink(pybind11::object module)
     .def("set_enable_wind",
          &sdf::Link::SetEnableWind,
          "Set whether this link should be subject to wind.")
+    .def("kinematic",
+         &sdf::Link::Kinematic,
+         "Check if this link is kinematic only")
+    .def("set_kinematic",
+         &sdf::Link::SetKinematic,
+         "Set whether this link is kinematic only.")
     .def("add_collision",
          &sdf::Link::AddCollision,
          "Add a collision to the link.")

--- a/python/test/pyLink_TEST.py
+++ b/python/test/pyLink_TEST.py
@@ -61,6 +61,10 @@ class LinkTEST(unittest.TestCase):
         link.set_enable_wind(True)
         self.assertTrue(link.enable_wind())
 
+        self.assertFalse(link.kinematic())
+        link.set_kinematic(True)
+        self.assertTrue(link.kinematic())
+
         self.assertEqual(0, link.sensor_count())
         self.assertEqual(None, link.sensor_by_index(0))
         self.assertEqual(None, link.sensor_by_index(1))


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Added `kinematic` and `setkinematic` methods to Link Python wrappers. Not included here https://github.com/gazebosim/sdformat/pull/1390/files

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
