### PR TITLE
Fix trivial warning on 24.04 for JointAxis_TEST.cc

### DIFF
--- a/src/JointAxis_TEST.cc
+++ b/src/JointAxis_TEST.cc
@@ -296,21 +296,21 @@ TEST(DOMJointAxis, ToElement)
   ASSERT_TRUE(errors.empty());
   EXPECT_EQ("axis2", mimicAxisName);
 
-  double multiplier = 0.0;
+  double multiplier;
   multiplier = mimicElem->Get<double>(
-      errors, "multiplier", multiplier).first;
+      errors, "multiplier", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(5.0, multiplier);
 
-  double offset = 0.0;
+  double offset;
   offset = mimicElem->Get<double>(
-      errors, "offset", offset).first;
+      errors, "offset", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(1.0, offset);
 
-  double reference = 0.0;
+  double reference;
   reference = mimicElem->Get<double>(
-      errors, "reference", reference).first;
+      errors, "reference", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(2.0, reference);
 

--- a/src/JointAxis_TEST.cc
+++ b/src/JointAxis_TEST.cc
@@ -286,13 +286,13 @@ TEST(DOMJointAxis, ToElement)
   ASSERT_NE(nullptr, mimicElem);
   std::string mimicJointName;
   mimicJointName = mimicElem->Get<std::string>(
-      errors, "joint", mimicJointName).first;
+      errors, "joint", "").first;
   ASSERT_TRUE(errors.empty());
   EXPECT_EQ("test_joint", mimicJointName);
 
   std::string mimicAxisName;
   mimicAxisName = mimicElem->Get<std::string>(
-      errors, "axis", mimicAxisName).first;
+      errors, "axis", "").first;
   ASSERT_TRUE(errors.empty());
   EXPECT_EQ("axis2", mimicAxisName);
 

--- a/src/JointAxis_TEST.cc
+++ b/src/JointAxis_TEST.cc
@@ -296,19 +296,19 @@ TEST(DOMJointAxis, ToElement)
   ASSERT_TRUE(errors.empty());
   EXPECT_EQ("axis2", mimicAxisName);
 
-  double multiplier;
+  double multiplier = 0.0;
   multiplier = mimicElem->Get<double>(
       errors, "multiplier", multiplier).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(5.0, multiplier);
 
-  double offset;
+  double offset = 0.0;
   offset = mimicElem->Get<double>(
       errors, "offset", offset).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(1.0, offset);
 
-  double reference;
+  double reference = 0.0;
   reference = mimicElem->Get<double>(
       errors, "reference", reference).first;
   ASSERT_TRUE(errors.empty());

--- a/src/JointAxis_TEST.cc
+++ b/src/JointAxis_TEST.cc
@@ -226,58 +226,58 @@ TEST(DOMJointAxis, ToElement)
   sdf::ElementPtr dynElem = elem->GetElement("dynamics", errors);
   ASSERT_TRUE(errors.empty());
 
-  double damping = 0;
-  damping = dynElem->Get<double>(errors, "damping", damping).first;
+  double damping;
+  damping = dynElem->Get<double>(errors, "damping", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(0.2, damping);
 
-  double friction = 0;
-  friction = dynElem->Get<double>(errors, "friction", friction).first;
+  double friction;
+  friction = dynElem->Get<double>(errors, "friction", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(1.3, friction);
 
-  double springReference = 0;
+  double springReference;
   springReference = dynElem->Get<double>(
-      errors, "spring_reference", springReference).first;
+      errors, "spring_reference", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(2.4, springReference);
 
-  double springStiffness = 0;
+  double springStiffness;
   springStiffness = dynElem->Get<double>(
-      errors, "spring_stiffness", springStiffness).first;
+      errors, "spring_stiffness", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(-1.2, springStiffness);
 
   // Check //axis/limit
   sdf::ElementPtr limitElem = elem->GetElement("limit", errors);
-  double lower = 0;
-  lower = limitElem->Get<double>(errors, "lower", lower).first;
+  double lower;
+  lower = limitElem->Get<double>(errors, "lower", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(-10.8, lower);
 
-  double upper = 0;
-  upper = limitElem->Get<double>(errors, "upper", upper).first;
+  double upper;
+  upper = limitElem->Get<double>(errors, "upper", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(123.4, upper);
 
-  double effort = 0;
-  effort = limitElem->Get<double>(errors, "effort", effort).first;
+  double effort;
+  effort = limitElem->Get<double>(errors, "effort", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(3.2, effort);
 
-  double maxVel = 0;
-  maxVel = limitElem->Get<double>(errors, "velocity", maxVel).first;
+  double maxVel;
+  maxVel = limitElem->Get<double>(errors, "velocity", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(54.2, maxVel);
 
-  double stiffness = 0;
-  stiffness = limitElem->Get<double>(errors, "stiffness", stiffness).first;
+  double stiffness;
+  stiffness = limitElem->Get<double>(errors, "stiffness", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(1e2, stiffness);
 
-  double dissipation = 0;
+  double dissipation;
   dissipation = limitElem->Get<double>(
-      errors, "dissipation", dissipation).first;
+      errors, "dissipation", 0.0).first;
   ASSERT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(1.5, dissipation);
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
A build of the `sdf14` on the upcoming Ubuntu Noble return 3 warnings on the `JointAxis_TEST.cc`:

```
‘multiplier’ may be used uninitialized
``` 

Adding a default value when constructing seems enough.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers