### PR TITLE
Prepare for 14.2.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat14 VERSION 14.1.1)
+project (sdformat14 VERSION 14.2.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,21 @@
 ## libsdformat 14.X
 
+### libsdformat 14.2.0 (2024-04-23)
+
+1. Fix trivial warning on 24.04 for JointAxis_TEST.cc
+    * [Pull request #1402](https://github.com/gazebosim/sdformat/pull/1402)
+
+1. Add package.xml, fix `gz sdf` tests on Windows
+    * [Pull request #1374](https://github.com/gazebosim/sdformat/pull/1374)
+
+1. Backport mesh optimization feature
+    * [Pull request #1398](https://github.com/gazebosim/sdformat/pull/1398)
+    * [Pull request #1386](https://github.com/gazebosim/sdformat/pull/1386)
+    * [Pull request #1382](https://github.com/gazebosim/sdformat/pull/1382)
+
+1. Param_TEST: Check return values of Param::Get/Set
+    * [Pull request #1394](https://github.com/gazebosim/sdformat/pull/1394)
+
 ### libsdformat 14.1.1 (2024-03-28)
 
 1. Fix warning with pybind11 2.12

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat14</name>
-  <version>14.1.1</version>
+  <version>14.2.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION


# 🎈 Release

Preparation for 14.2.0 release.

Comparison to 14.1.1: https://github.com/gazebosim/sdformat/compare/sdformat14_14.1.1...prep_14.2.0


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
