### PR TITLE
Add custom attribute to custom element in test

### DIFF
--- a/test/integration/custom_elems_attrs.sdf
+++ b/test/integration/custom_elems_attrs.sdf
@@ -10,7 +10,7 @@
         <child>L2</child>
       </joint>
 
-      <mysim:transmission name="simple_trans">
+      <mysim:transmission name="simple_trans" mysim:attr="custom_attribute">
         <mysim:type>transmission_interface/SimpleTransmission</mysim:type>
         <mysim:joint name="J1">
           <mysim:hardwareInterface>EffortJointInterface</mysim:hardwareInterface>

--- a/test/integration/sdf_custom.cc
+++ b/test/integration/sdf_custom.cc
@@ -125,7 +125,7 @@ TEST(SDFParser, ReloadCustomElements)
   ASSERT_NE(nullptr, customElem2);
 
   const std::string customElemStr =
-R"(<mysim:transmission name='simple_trans'>
+R"(<mysim:transmission name='simple_trans' mysim:attr='custom_attribute'>
   <mysim:type>transmission_interface/SimpleTransmission</mysim:type>
   <mysim:joint name='J1'>
     <mysim:hardwareInterface>EffortJointInterface</mysim:hardwareInterface>


### PR DESCRIPTION
# 🦟 Bug fix

Confirms that #54 has been fixed

## Summary

Issue #54 was opened before we had documented support for custom elements and attributes and mentions that custom attributes are not supported within a custom element. This was fixed at some point (not sure when), and I have confirmed this by adding a custom attribute inside a custom element in the `test/integration/custom_elems_attrs.sdf` file and updated the associated expectations in the `INTEGRATION_sdf_custom` test.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
