### PR TITLE
Enable 24.04 CI, remove distutils dependency

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -7,7 +7,6 @@ libtinyxml2-dev
 liburdfdom-dev
 libxml2-utils
 python3-dev
-python3-distutils
 python3-gz-math8
 python3-psutil
 python3-pybind11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,12 @@ jobs:
           codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0003 NEW)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 find_package(sdformat15 REQUIRED)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,16 +7,8 @@ endif()
 
 
 if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
-  if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-    execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-  from distutils import sysconfig as sc
-  print(sc.get_python_lib(plat_specific=True))"
-      OUTPUT_VARIABLE Python3_SITEARCH
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-  else()
-    # Get install variable from Python3 module
-    # Python3_SITEARCH is available from 3.12 on, workaround if needed:
+  if(NOT Python3_SITEARCH)
+    # Get variable from Python3 module
     find_package(Python3 COMPONENTS Interpreter)
   endif()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,11 +1,3 @@
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # pybind11 logic for setting up a debug build when both a debug and release
-  # python interpreter are present in the system seems to be pretty much broken.
-  # This works around the issue.
-  set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
-endif()
-
-
 if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
   if(NOT Python3_SITEARCH)
     # Get variable from Python3 module


### PR DESCRIPTION
# 🎉 New feature

Attempting to enable CI on 24.04

## Summary

The `python3-distutils` package is not available on 24.04, but we only use it in a codepath for old versions of cmake. Since we are already requiring cmake 3.22.1 in gz-cmake4, we can require that version in sdformat15 as well and remove code for old versions of cmake.

## Test it

Observe CI results

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
