### PR TITLE
Update default camera instrinsics skew to 0, which matches spec

### DIFF
--- a/python/test/pyCamera_TEST.py
+++ b/python/test/pyCamera_TEST.py
@@ -191,7 +191,7 @@ class CameraTEST(unittest.TestCase):
       cam.set_lens_intrinsics_cy(123)
       self.assertAlmostEqual(123, cam.lens_intrinsics_cy())
 
-      self.assertAlmostEqual(1.0, cam.lens_intrinsics_skew())
+      self.assertAlmostEqual(0.0, cam.lens_intrinsics_skew())
       cam.set_lens_intrinsics_skew(2.3)
       self.assertAlmostEqual(2.3, cam.lens_intrinsics_skew())
 

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -208,7 +208,7 @@ class sdf::Camera::Implementation
   public: double lensProjectionTy{0.0};
 
   /// \brief lens instrinsics s.
-  public: double lensIntrinsicsS{1.0};
+  public: double lensIntrinsicsS{0.0};
 
   /// \brief True if this camera has custom intrinsics values
   public: bool hasIntrinsics = false;

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -214,7 +214,7 @@ TEST(DOMCamera, Construction)
   cam.SetLensProjectionTy(2);
   EXPECT_DOUBLE_EQ(2, cam.LensProjectionTy());
 
-  EXPECT_DOUBLE_EQ(1.0, cam.LensIntrinsicsSkew());
+  EXPECT_DOUBLE_EQ(0, cam.LensIntrinsicsSkew());
   cam.SetLensIntrinsicsSkew(2.3);
   EXPECT_DOUBLE_EQ(2.3, cam.LensIntrinsicsSkew());
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Default camera lens intrinsics skew is 0 in the camera sdf spec: [https://github.com/gazebosim/sdformat/blob/sdf14/sdf/1.11/camera.sdf](https://github.com/gazebosim/sdformat/blob/c9779cb7f19bac92b512e213b7fd50dbcf2c8c8d/sdf/1.11/camera.sdf#L193)
But the default value in `sdf::Camera` class was set to 1. I've fixed this value to match the spec in this PR and updated the associated tests.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
