### PR TITLE
Added Automatic Moment of Inertia Calculations for Basic Shapes Pytho…

### DIFF
--- a/python/src/sdf/pyBox.cc
+++ b/python/src/sdf/pyBox.cc
@@ -16,6 +16,7 @@
 #include "pyBox.hh"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "sdf/Box.hh"
 
@@ -42,6 +43,8 @@ void defineBox(pybind11::object module)
         pybind11::overload_cast<>(&sdf::Box::Shape, pybind11::const_),
         pybind11::return_value_policy::reference,
         "Get a mutable Gazebo Math representation of this Box.")
+    .def("calculate_inertial", &sdf::Box::CalculateInertial,
+         "Calculate and return the Inertial values for the Box.")
     .def("__copy__", [](const sdf::Box &self) {
       return sdf::Box(self);
     })

--- a/python/src/sdf/pyCapsule.cc
+++ b/python/src/sdf/pyCapsule.cc
@@ -16,6 +16,7 @@
 #include "pyCapsule.hh"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "sdf/Capsule.hh"
 
@@ -41,6 +42,8 @@ void defineCapsule(pybind11::object module)
          "Get the capsule's length in meters.")
     .def("set_length", &sdf::Capsule::SetLength,
          "Set the capsule's length in meters.")
+    .def("calculate_inertial", &sdf::Capsule::CalculateInertial,
+         "Calculate and return the Inertial values for the Capsule.")
     .def(
         "shape",
         pybind11::overload_cast<>(&sdf::Capsule::Shape, pybind11::const_),

--- a/python/src/sdf/pyCollision.cc
+++ b/python/src/sdf/pyCollision.cc
@@ -17,6 +17,7 @@
 #include "pyCollision.hh"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "sdf/Collision.hh"
 #include "sdf/Geometry.hh"
@@ -37,6 +38,12 @@ void defineCollision(pybind11::object module)
   geometryModule
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Collision>())
+    .def("set_density", &sdf::Collision::SetDensity, "Set the density of the collision.")
+    .def("density", &sdf::Collision::Density, "Get the density of the collision.")
+    .def("calculate_inertial",
+         pybind11::overload_cast<sdf::Errors &, gz::math::Inertiald &, const ParserConfig &>(
+          &sdf::Collision::CalculateInertial),
+         "Calculate and return the MassMatrix for the collision.")
     .def("name", &sdf::Collision::Name,
          "Get the name of the collision. "
          "The name of the collision must be unique within the scope of a Link.")

--- a/python/src/sdf/pyCylinder.cc
+++ b/python/src/sdf/pyCylinder.cc
@@ -16,6 +16,7 @@
 #include "pyCylinder.hh"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "sdf/Cylinder.hh"
 
@@ -33,6 +34,8 @@ void defineCylinder(pybind11::object module)
   pybind11::class_<sdf::Cylinder>(module, "Cylinder")
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Cylinder>())
+    .def("calculate_inertial", &sdf::Cylinder::CalculateInertial,
+         "Calculate and return the Inertial values for the Cylinder.")
     .def("radius", &sdf::Cylinder::Radius,
          "Get the cylinder's radius in meters.")
     .def("set_radius", &sdf::Cylinder::SetRadius,

--- a/python/src/sdf/pyEllipsoid.cc
+++ b/python/src/sdf/pyEllipsoid.cc
@@ -16,6 +16,7 @@
 #include "pyEllipsoid.hh"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "sdf/Ellipsoid.hh"
 
@@ -33,6 +34,8 @@ void defineEllipsoid(pybind11::object module)
   pybind11::class_<sdf::Ellipsoid>(module, "Ellipsoid")
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Ellipsoid>())
+    .def("calculate_inertial", &sdf::Ellipsoid::CalculateInertial,
+         "Calculate and return the Inertial values for the Ellipsoid.")
     .def("radii", &sdf::Ellipsoid::Radii,
          "Get the ellipsoid's radii in meters.")
     .def("set_radii", &sdf::Ellipsoid::SetRadii,

--- a/python/src/sdf/pyGeometry.cc
+++ b/python/src/sdf/pyGeometry.cc
@@ -17,6 +17,7 @@
 #include "pyGeometry.hh"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "sdf/ParserConfig.hh"
 
@@ -45,6 +46,8 @@ void defineGeometry(pybind11::object module)
   geometryModule
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Geometry>())
+    .def("calculate_inertial", &sdf::Geometry::CalculateInertial,
+         "Calculate and return the Mass Matrix values for the Geometry")
     .def("type", &sdf::Geometry::Type,
          "Get the type of geometry.")
     .def("set_type", &sdf::Geometry::SetType,

--- a/python/src/sdf/pyLink.cc
+++ b/python/src/sdf/pyLink.cc
@@ -41,6 +41,16 @@ void defineLink(pybind11::object module)
   pybind11::class_<sdf::Link>(module, "Link")
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Link>())
+    .def("resolve_auto_inertials", &sdf::Link::ResolveAutoInertials,
+         "Calculate & set inertial values for the link")
+    .def("auto_inertia", &sdf::Link::AutoInertia,
+         "Check if the automatic calculation for the link inertial is enabled or not.")
+    .def("set_auto_inertia", &sdf::Link::SetAutoInertia,
+         "Enable automatic inertial calculations by setting autoInertia to true")
+    .def("auto_inertia_saved", &sdf::Link::AutoInertiaSaved,
+         "Check if the inertial values for this link were saved.")
+    .def("set_auto_inertia_saved", &sdf::Link::SetAutoInertiaSaved,
+         "Set the autoInertiaSaved() values")
     .def("name", &sdf::Link::Name,
          "Get the name of the link.")
     .def("set_name", &sdf::Link::SetName,

--- a/python/src/sdf/pyModel.cc
+++ b/python/src/sdf/pyModel.cc
@@ -46,6 +46,8 @@ void defineModel(pybind11::object module)
          },
          "Check that the FrameAttachedToGraph and PoseRelativeToGraph "
          "are valid.")
+    .def("resolve_auto_inertials", &sdf::Model::ResolveAutoInertials,
+         "Calculate and set the inertials for all the links belonging to the model object")
     .def("name", &sdf::Model::Name,
          "Get the name of model.")
     .def("set_name", &sdf::Model::SetName,

--- a/python/src/sdf/pyParserConfig.cc
+++ b/python/src/sdf/pyParserConfig.cc
@@ -46,6 +46,12 @@ void defineParserConfig(pybind11::object module)
     .def("find_file_callback",
          &sdf::ParserConfig::FindFileCallback,
          "Get the find file callback function")
+    .def("calculate_inertial_configuration",
+         &sdf::ParserConfig::CalculateInertialConfiguration,
+         "Get the current configuration for the CalculateInertial() function")
+    .def("set_calculate_inertial_configuration",
+         &sdf::ParserConfig::SetCalculateInertialConfiguration,
+         "Set the configuration for the CalculateInertial() function")
     .def("set_find_callback",
          &sdf::ParserConfig::SetFindCallback,
          "Set the callback to use when libsdformat can't find a file.")
@@ -96,6 +102,10 @@ void defineParserConfig(pybind11::object module)
     .value("WARN", sdf::EnforcementPolicy::WARN)
     .value("LOG", sdf::EnforcementPolicy::LOG);
 
+  pybind11::enum_<sdf::ConfigureResolveAutoInertials>(
+    module, "ConfigureResolveAutoInertials")
+    .value("SKIP_CALCULATION_IN_LOAD", sdf::ConfigureResolveAutoInertials::SKIP_CALCULATION_IN_LOAD)
+    .value("SAVE_CALCULATION", sdf::ConfigureResolveAutoInertials::SAVE_CALCULATION);
 }
 }  // namespace python
 }  // namespace SDF_VERSION_NAMESPACE

--- a/python/src/sdf/pyRoot.cc
+++ b/python/src/sdf/pyRoot.cc
@@ -38,6 +38,8 @@ void defineRoot(pybind11::object module)
 {
   pybind11::class_<sdf::Root>(module, "Root")
     .def(pybind11::init<>())
+    .def("resolve_auto_inertials", &sdf::Root::ResolveAutoInertials,
+         "Calculate & set the inertial properties")
     .def("load",
          [](Root &self, const std::string &_filename)
          {
@@ -46,7 +48,7 @@ void defineRoot(pybind11::object module)
          "Parse the given SDF file, and generate objects based on types "
          "specified in the SDF file.")
     .def("load",
-         [](Root &self, const std::string &_filename, 
+         [](Root &self, const std::string &_filename,
             const ParserConfig &_config)
          {
            ThrowIfErrors(self.Load(_filename, _config));

--- a/python/src/sdf/pySphere.cc
+++ b/python/src/sdf/pySphere.cc
@@ -16,6 +16,7 @@
 #include "pySphere.hh"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "sdf/Sphere.hh"
 
@@ -33,6 +34,8 @@ void defineSphere(pybind11::object module)
   pybind11::class_<sdf::Sphere>(module, "Sphere")
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::Sphere>())
+    .def("calculate_inertial", &sdf::Sphere::CalculateInertial,
+         "Calculate and return the Inertial values for the Sphere.")
     .def("radius", &sdf::Sphere::Radius,
          "Get the sphere's radius in meters.")
     .def("set_radius", &sdf::Sphere::SetRadius,

--- a/python/src/sdf/pyWorld.cc
+++ b/python/src/sdf/pyWorld.cc
@@ -48,6 +48,8 @@ void defineWorld(pybind11::object module)
   geometryModule
     .def(pybind11::init<>())
     .def(pybind11::init<sdf::World>())
+    .def("resolve_auto_inertials", &sdf::World::ResolveAutoInertials,
+         "Calculate and set the inertials for all the models in the world object")
     .def("validate_graphs", &sdf::World::ValidateGraphs,
          "Check that the FrameAttachedToGraph and PoseRelativeToGraph "
          "are valid.")

--- a/python/test/pyCapsule_TEST.py
+++ b/python/test/pyCapsule_TEST.py
@@ -16,6 +16,7 @@ import copy
 
 import math
 
+from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
 from gz_test_deps.sdformat import Capsule
 
 import unittest
@@ -56,7 +57,7 @@ class CapsuleTEST(unittest.TestCase):
 
 
   def test_copy_construction(self):
-    capsule = Capsule();
+    capsule = Capsule()
     capsule.set_radius(0.2)
     capsule.set_length(3.0)
 
@@ -65,29 +66,29 @@ class CapsuleTEST(unittest.TestCase):
     self.assertEqual(3.0, capsule2.length())
 
   def test_copy_construction(self):
-    capsule = Capsule();
+    capsule = Capsule()
     capsule.set_radius(0.2)
     capsule.set_length(3.0)
 
-    capsule2 = copy.deepcopy(capsule);
+    capsule2 = copy.deepcopy(capsule)
     self.assertEqual(0.2, capsule2.radius())
     self.assertEqual(3.0, capsule2.length())
 
 
   def test_assignment_after_move(self):
-    capsule1 = Capsule();
+    capsule1 = Capsule()
     capsule1.set_radius(0.2)
     capsule1.set_length(3.0)
 
-    capsule2 = Capsule();
+    capsule2 = Capsule()
     capsule2.set_radius(2)
     capsule2.set_length(30.0)
 
     # This is similar to what std::swap does except it uses std::move for each
     # assignment
     tmp = capsule1
-    capsule1 = copy.deepcopy(capsule2);
-    capsule2 = tmp;
+    capsule1 = copy.deepcopy(capsule2)
+    capsule2 = tmp
 
     self.assertEqual(2, capsule1.radius())
     self.assertEqual(30, capsule1.length())
@@ -97,7 +98,7 @@ class CapsuleTEST(unittest.TestCase):
 
 
   def test_shape(self):
-    capsule = Capsule();
+    capsule = Capsule()
     self.assertEqual(0.5, capsule.radius())
     self.assertEqual(1.0, capsule.length())
 
@@ -106,6 +107,43 @@ class CapsuleTEST(unittest.TestCase):
     self.assertEqual(0.123, capsule.radius())
     self.assertEqual(0.456, capsule.length())
 
+  def test_calculate_inertial(self):
+    capsule = Capsule()
+
+    # density of aluminium
+    density = 2710
+    l = 2.0
+    r = 0.1
+
+    capsule.set_length(l)
+    capsule.set_radius(r)
+
+    expectedMass = capsule.shape().volume() * density
+    cylinderVolume = math.pi * r * r * l
+    sphereVolume = math.pi * 4. / 3. * r * r * r
+    volume = cylinderVolume + sphereVolume
+    cylinderMass = expectedMass * cylinderVolume / volume
+    sphereMass = expectedMass * sphereVolume / volume
+
+    ixxIyy = (1 / 12.0) * cylinderMass * (3 * r * r + l * l) + sphereMass * (
+      0.4 * r * r + 0.375 * r * l + 0.25 * l * l)
+    izz = r*r * (0.5 * cylinderMass + 0.4 * sphereMass)
+
+    expectedMassMat = MassMatrix3d(expectedMass, Vector3d(ixxIyy, ixxIyy, izz), Vector3d.ZERO)
+
+    expectedInertial = Inertiald()
+    expectedInertial.set_mass_matrix(expectedMassMat)
+    expectedInertial.set_pose(Pose3d.ZERO)
+
+    capsuleInertial = capsule.calculate_inertial(density)
+    self.assertEqual(capsule.shape().material().density(), density)
+    self.assertNotEqual(None, capsuleInertial)
+    self.assertEqual(expectedInertial, capsuleInertial)
+    self.assertEqual(expectedInertial.mass_matrix().diagonal_moments(),
+      capsuleInertial.mass_matrix().diagonal_moments())
+    self.assertEqual(expectedInertial.mass_matrix().mass(),
+      capsuleInertial.mass_matrix().mass())
+    self.assertEqual(expectedInertial.pose(), capsuleInertial.pose())
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/pyCollision_TEST.py
+++ b/python/test/pyCollision_TEST.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Pose3d
+from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
 from gz_test_deps.sdformat import (Box, Collision, Contact, Cylinder, Error,
-                                   Geometry, Plane, Surface, Sphere,
+                                   Geometry, ParserConfig, Plane, Root, Surface, Sphere,
                                    SDFErrorsException)
 import gz_test_deps.sdformat as sdf
 import unittest
@@ -26,6 +26,7 @@ class CollisionTEST(unittest.TestCase):
     def test_default_construction(self):
         collision = Collision()
         self.assertTrue(not collision.name())
+        self.assertEqual(collision.density(), 1000.0)
 
         collision.set_name("test_collison")
         self.assertEqual(collision.name(), "test_collison")
@@ -39,6 +40,9 @@ class CollisionTEST(unittest.TestCase):
         # expect errors when trying to resolve pose
         with self.assertRaises(SDFErrorsException):
             semanticPose.resolve()
+
+        collision.set_density(1240.0)
+        self.assertAlmostEqual(collision.density(), 1240.0)
 
         collision.set_raw_pose(Pose3d(-10, -20, -30, math.pi, math.pi, math.pi))
         self.assertEqual(Pose3d(-10, -20, -30, math.pi, math.pi, math.pi),
@@ -129,6 +133,138 @@ class CollisionTEST(unittest.TestCase):
         self.assertNotEqual(None, collision.surface().contact())
         self.assertEqual(collision.surface().contact().collide_bitmask(), 0x2)
 
+
+    def test_incorrect_box_collision_calculate_inertial(self):
+        collision = Collision()
+        self.assertAlmostEqual(1000.0, collision.density())
+
+        # sdf::ElementPtr sdf(new sdf::Element())
+        # collision.Load(sdf)
+
+        collisionInertial = Inertiald()
+        sdfParserConfig = ParserConfig()
+        geom = Geometry()
+        box = Box()
+
+        # Invalid Inertial test
+        box.set_size(Vector3d(-1, 1, 0))
+        geom.set_type(sdf.GeometryType.BOX)
+        geom.set_box_shape(box)
+        collision.set_geometry(geom)
+
+        errors = []
+
+        collision.calculate_inertial(errors, collisionInertial, sdfParserConfig)
+        self.assertFalse(len(errors))
+
+
+    def test_correct_box_collision_calculate_inertial(self):
+        sdf = "<?xml version=\"1.0\"?>" + \
+        " <sdf version=\"1.11\">" + \
+        "   <model name='shapes'>" + \
+        "     <link name='link'>" + \
+        "       <inertial auto='true' />" + \
+        "       <collision name='box_col'>" + \
+        "         <density>1240.0</density>" + \
+        "         <geometry>" + \
+        "           <box>" + \
+        "             <size>2 2 2</size>" + \
+        "           </box>" + \
+        "         </geometry>" + \
+        "       </collision>" + \
+        "     </link>" + \
+        "   </model>" + \
+        " </sdf>"
+
+        root = Root()
+        sdfParserConfig = ParserConfig()
+        errors = root.load_sdf_string(sdf, sdfParserConfig)
+        self.assertEqual(None, errors)
+
+        model = root.model()
+        link = model.link_by_index(0)
+        collision = link.collision_by_index(0)
+
+        inertialErr = []
+        root.resolve_auto_inertials(inertialErr, sdfParserConfig)
+
+        l = 2.0
+        w = 2.0
+        h = 2.0
+
+        expectedMass = l * w * h * collision.density()
+        ixx = (1.0 / 12.0) * expectedMass * (w * w + h * h)
+        iyy = (1.0 / 12.0) * expectedMass * (l * l + h * h)
+        izz = (1.0 / 12.0) * expectedMass * (l * l + w * w)
+
+        expectedMassMat = MassMatrix3d(expectedMass, Vector3d(ixx, iyy, izz), Vector3d.ZERO)
+
+        expectedInertial = Inertiald()
+        expectedInertial.set_mass_matrix(expectedMassMat)
+        expectedInertial.set_pose(Pose3d.ZERO)
+
+        self.assertEqual(len(inertialErr), 0)
+        self.assertAlmostEqual(1240.0, collision.density())
+        self.assertAlmostEqual(expectedMass, link.inertial().mass_matrix().mass())
+        self.assertEqual(expectedInertial.mass_matrix(), link.inertial().mass_matrix())
+        self.assertEqual(expectedInertial.pose(), link.inertial().pose())
+
+    def test_calculate_inertial_pose_not_relative_to_link(self):
+
+        sdf = "<?xml version=\"1.0\"?>" + \
+        " <sdf version=\"1.11\">" + \
+        "   <model name='shapes'>" + \
+        "     <frame name='arbitrary_frame'>" + \
+        "       <pose>0 0 1 0 0 0</pose>" + \
+        "     </frame>" + \
+        "     <link name='link'>" + \
+        "       <inertial auto='true' />" + \
+        "       <collision name='box_col'>" + \
+        "         <pose relative_to='arbitrary_frame'>0 0 -1 0 0 0</pose>" + \
+        "         <density>1240.0</density>" + \
+        "         <geometry>" + \
+        "           <box>" + \
+        "             <size>2 2 2</size>" + \
+        "           </box>" + \
+        "         </geometry>" + \
+        "       </collision>" + \
+        "     </link>" + \
+        "   </model>" + \
+        " </sdf>"
+
+        root = Root()
+        sdfParserConfig = ParserConfig()
+        errors = root.load_sdf_string(sdf, sdfParserConfig)
+        self.assertEqual(errors, None)
+        # self.assertNotEqual(None, root.Element())
+
+        model = root.model()
+        link = model.link_by_index(0)
+        collision = link.collision_by_index(0)
+
+        inertialErr = []
+        root.resolve_auto_inertials(inertialErr, sdfParserConfig)
+
+        l = 2.0
+        w = 2.0
+        h = 2.0
+
+        expectedMass = l * w * h * collision.density()
+        ixx = (1.0 / 12.0) * expectedMass * (w * w + h * h)
+        iyy = (1.0 / 12.0) * expectedMass * (l * l + h * h)
+        izz = (1.0 / 12.0) * expectedMass * (l * l + w * w)
+
+        expectedMassMat = MassMatrix3d(expectedMass, Vector3d(ixx, iyy, izz), Vector3d.ZERO)
+
+        expectedInertial = Inertiald()
+        expectedInertial.set_mass_matrix(expectedMassMat)
+        expectedInertial.set_pose(Pose3d.ZERO)
+
+        self.assertEqual(len(inertialErr), 0)
+        self.assertAlmostEqual(1240.0, collision.density())
+        self.assertAlmostEqual(expectedMass, link.inertial().mass_matrix().mass())
+        self.assertEqual(expectedInertial.mass_matrix(), link.inertial().mass_matrix())
+        self.assertEqual(expectedInertial.pose(), link.inertial().pose())
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/pyGeometry_TEST.py
+++ b/python/test/pyGeometry_TEST.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import (Geometry, Box, Capsule, Cylinder, Ellipsoid,
-                                   Mesh, Plane, Sphere)
-from gz_test_deps.math import Vector3d, Vector2d
+from gz_test_deps.sdformat import (Element, Error, Geometry, Box, Capsule, Cylinder, Ellipsoid,
+                                   Mesh, ParserConfig, Plane, Sphere)
+from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d, Vector2d
 import gz_test_deps.sdformat as sdf
+import math
 import unittest
 
 
@@ -184,6 +185,173 @@ class GeometryTEST(unittest.TestCase):
     self.assertEqual(Vector3d.UNIT_X, geom.plane_shape().normal())
     self.assertEqual(Vector2d(9, 8), geom.plane_shape().size())
 
+
+  def test_calculate_inertial(self):
+    geom = Geometry()
+
+    # Density of Aluminimum
+    density = 2170.0
+    expectedMass = 0
+    expectedMassMat = MassMatrix3d()
+    expectedInertial = Inertiald()
+    sdfParserConfig = ParserConfig()
+    errors = []
+
+    # Not supported geom type
+    geom.set_type(sdf.GeometryType.EMPTY)
+    element = Element()
+    notSupportedInertial = geom.calculate_inertial(errors,
+      sdfParserConfig, density, element)
+    self.assertEqual(notSupportedInertial, None)
+
+    box = Box()
+    l = 2.0
+    w = 2.0
+    h = 2.0
+    box.set_size(Vector3d(l, w, h))
+
+    expectedMass = box.shape().volume() * density
+    ixx = (1.0 / 12.0) * expectedMass * (w * w + h * h)
+    iyy = (1.0 / 12.0) * expectedMass * (l * l + h * h)
+    izz = (1.0 / 12.0) * expectedMass * (l * l + w * w)
+
+    expectedMassMat.set_mass(expectedMass)
+    expectedMassMat.set_diagonal_moments(Vector3d(ixx, iyy, izz))
+    expectedMassMat.set_off_diagonal_moments(Vector3d.ZERO)
+
+    expectedInertial.set_mass_matrix(expectedMassMat)
+    expectedInertial.set_pose(Pose3d.ZERO)
+
+    geom.set_type(sdf.GeometryType.BOX)
+    geom.set_box_shape(box)
+    boxInertial = geom.calculate_inertial(errors,
+      sdfParserConfig, density, element)
+
+    self.assertNotEqual(None, boxInertial)
+    self.assertEqual(expectedInertial, boxInertial)
+    self.assertEqual(expectedInertial.mass_matrix(), expectedMassMat)
+    self.assertEqual(expectedInertial.pose(), boxInertial.pose())
+
+    # Capsule
+    capsule = Capsule()
+    l = 2.0
+    r = 0.1
+    capsule.set_length(l)
+    capsule.set_radius(r)
+
+    expectedMass = capsule.shape().volume() * density
+    cylinderVolume = math.pi * r * r * l
+    sphereVolume = math.pi * 4. / 3. * r * r * r
+    volume = cylinderVolume + sphereVolume
+    cylinderMass = expectedMass * cylinderVolume / volume
+    sphereMass = expectedMass * sphereVolume / volume
+    ixxIyy = (1 / 12.0) * cylinderMass * (3 * r *r + l * l) + sphereMass * (
+      0.4 * r * r + 0.375 * r * l + 0.25 * l * l)
+    izz = r * r * (0.5 * cylinderMass + 0.4 * sphereMass)
+
+    expectedMassMat.set_mass(expectedMass)
+    expectedMassMat.set_diagonal_moments(Vector3d(ixxIyy, ixxIyy, izz))
+    expectedMassMat.set_off_diagonal_moments(Vector3d.ZERO)
+
+    expectedInertial.set_mass_matrix(expectedMassMat)
+    expectedInertial.set_pose(Pose3d.ZERO)
+
+    geom.set_type(sdf.GeometryType.CAPSULE)
+    geom.set_capsule_shape(capsule)
+    capsuleInertial = geom.calculate_inertial(errors,
+      sdfParserConfig, density, element)
+
+    self.assertNotEqual(None, capsuleInertial)
+    self.assertEqual(expectedInertial, capsuleInertial)
+    self.assertEqual(expectedInertial.mass_matrix(), expectedMassMat)
+    self.assertEqual(expectedInertial.pose(), capsuleInertial.pose())
+
+    # Cylinder
+    cylinder = Cylinder()
+    l = 2.0
+    r = 0.1
+
+    cylinder.set_length(l)
+    cylinder.set_radius(r)
+
+    expectedMass = cylinder.shape().volume() * density
+    ixxIyy = (1/12.0) * expectedMass * (3*r*r + l*l)
+    izz = 0.5 * expectedMass * r * r
+
+    expectedMassMat.set_mass(expectedMass)
+    expectedMassMat.set_diagonal_moments(Vector3d(ixxIyy, ixxIyy, izz))
+    expectedMassMat.set_off_diagonal_moments(Vector3d.ZERO)
+
+    expectedInertial.set_mass_matrix(expectedMassMat)
+    expectedInertial.set_pose(Pose3d.ZERO)
+
+    geom.set_type(sdf.GeometryType.CYLINDER)
+    geom.set_cylinder_shape(cylinder)
+    cylinderInertial = geom.calculate_inertial(errors,
+      sdfParserConfig, density, element)
+
+    self.assertNotEqual(None, cylinderInertial)
+    self.assertEqual(expectedInertial, cylinderInertial)
+    self.assertEqual(expectedInertial.mass_matrix(), expectedMassMat)
+    self.assertEqual(expectedInertial.pose(), cylinderInertial.pose())
+
+    # Ellipsoid
+    ellipsoid = Ellipsoid()
+
+    a = 1.0
+    b = 10.0
+    c = 100.0
+
+    ellipsoid.set_radii(Vector3d(a, b, c))
+
+    expectedMass = ellipsoid.shape().volume() * density
+    ixx = (expectedMass / 5.0) * (b*b + c*c)
+    iyy = (expectedMass / 5.0) * (a*a + c*c)
+    izz = (expectedMass / 5.0) * (a*a + b*b)
+
+    expectedMassMat.set_mass(expectedMass)
+    expectedMassMat.set_diagonal_moments(Vector3d(ixx, iyy, izz))
+    expectedMassMat.set_off_diagonal_moments(Vector3d.ZERO)
+
+    expectedInertial.set_mass_matrix(expectedMassMat)
+    expectedInertial.set_pose(Pose3d.ZERO)
+
+    geom.set_type(sdf.GeometryType.ELLIPSOID)
+    geom.set_ellipsoid_shape(ellipsoid)
+    ellipsoidInertial = geom.calculate_inertial(errors,
+      sdfParserConfig, density, element)
+
+    self.assertNotEqual(None, ellipsoidInertial)
+    self.assertEqual(expectedInertial, ellipsoidInertial)
+    self.assertEqual(expectedInertial.mass_matrix(), expectedMassMat)
+    self.assertEqual(expectedInertial.pose(), ellipsoidInertial.pose())
+
+    # Sphere
+    sphere = Sphere()
+    r = 0.1
+
+    sphere.set_radius(r)
+
+    expectedMass = sphere.shape().volume() * density
+    ixxIyyIzz = 0.4 * expectedMass * r * r
+
+    expectedMassMat.set_mass(expectedMass)
+    expectedMassMat.set_diagonal_moments(
+      Vector3d(ixxIyyIzz, ixxIyyIzz, ixxIyyIzz))
+    expectedMassMat.set_off_diagonal_moments(Vector3d.ZERO)
+
+    expectedInertial.set_mass_matrix(expectedMassMat)
+    expectedInertial.set_pose(Pose3d.ZERO)
+
+    geom.set_type(sdf.GeometryType.SPHERE)
+    geom.set_sphere_shape(sphere)
+    sphereInertial = geom.calculate_inertial(errors,
+      sdfParserConfig, density, element)
+
+    self.assertNotEqual(None, sphereInertial)
+    self.assertEqual(expectedInertial, sphereInertial)
+    self.assertEqual(expectedInertial.mass_matrix(), expectedMassMat)
+    self.assertEqual(expectedInertial.pose(), sphereInertial.pose())
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/pyLink_TEST.py
+++ b/python/test/pyLink_TEST.py
@@ -14,8 +14,8 @@
 
 import copy
 from gz_test_deps.math import Pose3d, Inertiald, MassMatrix3d, Vector3d
-from gz_test_deps.sdformat import (Collision, Light, Link, Projector, Sensor,
-                                   Visual, SDFErrorsException)
+from gz_test_deps.sdformat import (Collision, Light, Link, ParserConfig, Projector, Sensor,
+                                   Visual, Root, SDFErrorsException)
 import unittest
 import math
 
@@ -60,6 +60,14 @@ class LinkTEST(unittest.TestCase):
         self.assertFalse(link.enable_wind())
         link.set_enable_wind(True)
         self.assertTrue(link.enable_wind())
+
+        self.assertFalse(link.auto_inertia_saved())
+        link.set_auto_inertia_saved(True)
+        self.assertTrue(link.auto_inertia_saved())
+
+        self.assertFalse(link.auto_inertia())
+        link.set_auto_inertia(True)
+        self.assertTrue(link.auto_inertia())
 
         self.assertEqual(0, link.sensor_count())
         self.assertEqual(None, link.sensor_by_index(0))
@@ -313,8 +321,8 @@ class LinkTEST(unittest.TestCase):
         pr = link.projector_by_index(0)
         self.assertNotEqual(None, pr)
         self.assertEqual("projector1", pr.name())
-        pr.set_name("projector2");
-        self.assertEqual("projector2", link.projector_by_index(0).name());
+        pr.set_name("projector2")
+        self.assertEqual("projector2", link.projector_by_index(0).name())
 
     def test_mutable_by_name(self):
         link = Link()
@@ -376,7 +384,7 @@ class LinkTEST(unittest.TestCase):
         self.assertFalse(link.sensor_name_exists("sensor1"))
         self.assertTrue(link.sensor_name_exists("sensor2"))
 
-        # // Modify the particle emitter
+        # # Modify the particle emitter
         # sdf::ParticleEmitter *p = link.ParticleEmitterByName("pe1")
         # self.assertNotEqual(None, p)
         # self.assertEqual("pe1", p.name())
@@ -385,12 +393,154 @@ class LinkTEST(unittest.TestCase):
         # self.assertTrue(link.particle_emitter_name_exists("pe2"))
 
         # Modify the projector
-        pr = link.projector_by_name("projector1");
-        self.assertNotEqual(None, pr);
-        self.assertEqual("projector1", pr.name());
-        pr.set_name("projector2");
-        self.assertFalse(link.projector_name_exists("projector1"));
-        self.assertTrue(link.projector_name_exists("projector2"));
+        pr = link.projector_by_name("projector1")
+        self.assertNotEqual(None, pr)
+        self.assertEqual("projector1", pr.name())
+        pr.set_name("projector2")
+        self.assertFalse(link.projector_name_exists("projector1"))
+        self.assertTrue(link.projector_name_exists("projector2"))
+
+    def test_resolveauto_inertialsWithNoCollisionsInLink(self):
+        sdf = "<?xml version=\"1.0\"?>" + \
+        " <sdf version=\"1.11\">" + \
+        "   <model name='shapes'>" + \
+        "     <link name='link'>" + \
+        "       <inertial auto='True' />" + \
+        "     </link>" + \
+        "   </model>" + \
+        " </sdf>"
+
+        root = Root()
+        sdfParserConfig = ParserConfig()
+        with self.assertRaises(SDFErrorsException):
+            errors = root.load_sdf_string(sdf, sdfParserConfig)
+
+        model = root.model()
+        link = model.link_by_index(0)
+        errors = []
+        root.resolve_auto_inertials(errors, sdfParserConfig)
+        self.assertEqual(len(errors), 0)
+
+        # Default Inertial values set during load
+        self.assertEqual(1.0, link.inertial().mass_matrix().mass())
+        self.assertEqual(Vector3d.ONE,
+            link.inertial().mass_matrix().diagonal_moments())
+
+    def test_resolveauto_inertialsWithMultipleCollisions(self):
+        sdf = "<?xml version=\"1.0\"?>" + \
+        "<sdf version=\"1.11\">" + \
+        "  <model name='compound_model'>" + \
+        "   <pose>0 0 1.0 0 0 0</pose>" + \
+        "   <link name='compound_link'>" + \
+        "     <inertial auto='True' />" + \
+        "     <collision name='box_collision'>" + \
+        "      <pose>0 0 -0.5 0 0 0</pose>" + \
+        "      <density>2.0</density>" + \
+        "      <geometry>" + \
+        "        <box>" + \
+        "          <size>1 1 1</size>" + \
+        "        </box>" + \
+        "        </geometry>" + \
+        "      </collision>" + \
+        "      <collision name='cylinder_compound_collision'>" + \
+        "        <pose>0 0 0.5 0 0 0</pose>" + \
+        "        <density>4</density>" + \
+        "        <geometry>" + \
+        "          <cylinder>" + \
+        "            <radius>0.5</radius>" + \
+        "            <length>1.0</length>" + \
+        "          </cylinder>" + \
+        "        </geometry>" + \
+        "      </collision>" + \
+        "    </link>" + \
+        "   </model>" + \
+        "  </sdf>"
+
+        root = Root()
+        sdfParserConfig = ParserConfig()
+        errors = root.load_sdf_string(sdf, sdfParserConfig)
+        self.assertEqual(errors, None)
+
+        model = root.model()
+        link = model.link_by_index(0)
+        errors = []
+        root.resolve_auto_inertials(errors, sdfParserConfig)
+        self.assertEqual(len(errors), 0)
+
+        # Mass of cube(volume * density) + mass of cylinder(volume * density)
+        expectedMass = 1.0 * 2.0 + math.pi * 0.5 * 0.5 * 1 * 4.0
+
+        self.assertAlmostEqual(expectedMass, link.inertial().mass_matrix().mass())
+        self.assertEqual(Vector3d(2.013513, 2.013513, 0.72603),
+            link.inertial().mass_matrix().diagonal_moments())
+
+    def test_inertial_values_given_with_auto_set_to_true(self):
+        sdf = "<?xml version=\"1.0\"?>" + \
+        "<sdf version=\"1.11\">" + \
+        "  <model name='compound_model'>" + \
+        "   <link name='compound_link'>" + \
+        "     <inertial auto='True'>" + \
+        "       <mass>4.0</mass>" + \
+        "       <pose>1 1 1 2 2 2</pose>" + \
+        "       <inertia>" + \
+        "         <ixx>1</ixx>" + \
+        "         <iyy>1</iyy>" + \
+        "         <izz>1</izz>" + \
+        "       </inertia>" + \
+        "     </inertial>" + \
+        "     <collision name='box_collision'>" + \
+        "      <density>2.0</density>" + \
+        "      <geometry>" + \
+        "        <box>" + \
+        "          <size>1 1 1</size>" + \
+        "        </box>" + \
+        "        </geometry>" + \
+        "      </collision>" + \
+        "    </link>" + \
+        "   </model>" + \
+        "  </sdf>"
+
+        root = Root()
+        sdfParserConfig = ParserConfig()
+        errors = root.load_sdf_string(sdf, sdfParserConfig)
+        self.assertEqual(errors, None)
+
+        model = root.model()
+        link = model.link_by_index(0)
+        errors = []
+        root.resolve_auto_inertials(errors, sdfParserConfig)
+        self.assertEqual(len(errors), 0)
+
+        self.assertNotEqual(4.0, link.inertial().mass_matrix().mass())
+        self.assertEqual(Pose3d.ZERO, link.inertial().pose())
+        self.assertEqual(Vector3d(0.33333, 0.33333, 0.33333),
+            link.inertial().mass_matrix().diagonal_moments())
+
+    def test_resolveauto_inertialsCalledWithAutoFalse(self):
+        sdf = "<?xml version=\"1.0\"?>" + \
+        " <sdf version=\"1.11\">" + \
+        "   <model name='shapes'>" + \
+        "     <link name='link'>" + \
+        "       <inertial auto='false' />" + \
+        "     </link>" + \
+        "   </model>" + \
+        " </sdf>"
+
+        root = Root()
+        sdfParserConfig = ParserConfig()
+        errors = root.load_sdf_string(sdf, sdfParserConfig)
+        self.assertEqual(errors, None)
+
+        model = root.model()
+        link = model.link_by_index(0)
+        errors = []
+        root.resolve_auto_inertials(errors, sdfParserConfig)
+        self.assertEqual(len(errors), 0)
+
+        # Default Inertial values set during load
+        self.assertEqual(1.0, link.inertial().mass_matrix().mass())
+        self.assertEqual(Vector3d.ONE,
+            link.inertial().mass_matrix().diagonal_moments())
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/pyParserConfig_TEST.py
+++ b/python/test/pyParserConfig_TEST.py
@@ -26,7 +26,7 @@ class ParserConfigColor(unittest.TestCase):
         self.assertFalse(config.uri_path_map())
         self.assertFalse(config.find_file_callback())
 
-        testDir = source_file();
+        testDir = source_file()
         config.add_uri_path("file://", testDir)
 
         self.assertTrue(config.uri_path_map())
@@ -35,7 +35,7 @@ class ParserConfigColor(unittest.TestCase):
         self.assertEqual(it[0], testDir)
 
         def testFunc(argument):
-            return "test/dir2";
+            return "test/dir2"
 
         config.set_find_callback(testFunc)
         self.assertTrue(config.find_file_callback())
@@ -102,7 +102,7 @@ class ParserConfigColor(unittest.TestCase):
         # so we'll use the source path
         testDir1 = source_file()
 
-        config1 = ParserConfig();
+        config1 = ParserConfig()
         config1.add_uri_path("file://", testDir1)
 
         it = config1.uri_path_map().get("file://")

--- a/python/test/pySphere_TEST.py
+++ b/python/test/pySphere_TEST.py
@@ -15,66 +15,101 @@
 import copy
 import math
 from gz_test_deps.sdformat import Sphere
+from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
 import unittest
 
 class SphereTEST(unittest.TestCase):
 
   def test_default_construction(self):
-    sphere = Sphere();
-    self.assertEqual(1.0, sphere.radius());
-    sphere.set_radius(0.5);
-    self.assertEqual(0.5, sphere.radius());
+    sphere = Sphere()
+    self.assertEqual(1.0, sphere.radius())
+    sphere.set_radius(0.5)
+    self.assertEqual(0.5, sphere.radius())
 
 
   def test_assignment(self):
-    sphere = Sphere();
-    sphere.set_radius(0.2);
+    sphere = Sphere()
+    sphere.set_radius(0.2)
 
-    sphere2 = sphere;
-    self.assertEqual(0.2, sphere2.radius());
+    sphere2 = sphere
+    self.assertEqual(0.2, sphere2.radius())
 
 
   def test_copy_construction(self):
-    sphere = Sphere();
-    sphere.set_radius(0.2);
+    sphere = Sphere()
+    sphere.set_radius(0.2)
 
-    sphere2 = Sphere(sphere);
-    self.assertEqual(0.2, sphere2.radius());
+    sphere2 = Sphere(sphere)
+    self.assertEqual(0.2, sphere2.radius())
 
-    self.assertEqual(4.0/3.0*math.pi*math.pow(0.2, 3), sphere2.shape().volume());
-    self.assertEqual(0.2, sphere2.shape().radius());
+    self.assertEqual(4.0/3.0*math.pi*math.pow(0.2, 3), sphere2.shape().volume())
+    self.assertEqual(0.2, sphere2.shape().radius())
 
 
   def test_deepcopy_construction(self):
-    sphere = Sphere();
-    sphere.set_radius(0.2);
+    sphere = Sphere()
+    sphere.set_radius(0.2)
 
-    sphere2 = copy.deepcopy(sphere);
-    self.assertEqual(0.2, sphere2.radius());
+    sphere2 = copy.deepcopy(sphere)
+    self.assertEqual(0.2, sphere2.radius())
 
 
   def test_deepcopy_after_assignment(self):
-    sphere1 = Sphere();
-    sphere1.set_radius(0.1);
+    sphere1 = Sphere()
+    sphere1.set_radius(0.1)
 
-    sphere2 = Sphere();
-    sphere2.set_radius(0.2);
+    sphere2 = Sphere()
+    sphere2.set_radius(0.2)
 
     # This is similar to what swap does
-    tmp = copy.deepcopy(sphere1);
-    sphere1 = sphere2;
-    sphere2 = tmp;
+    tmp = copy.deepcopy(sphere1)
+    sphere1 = sphere2
+    sphere2 = tmp
 
-    self.assertEqual(0.2, sphere1.radius());
-    self.assertEqual(0.1, sphere2.radius());
+    self.assertEqual(0.2, sphere1.radius())
+    self.assertEqual(0.1, sphere2.radius())
 
 
   def test_shape(self):
-    sphere = Sphere();
-    self.assertEqual(1.0, sphere.radius());
+    sphere = Sphere()
+    self.assertEqual(1.0, sphere.radius())
 
-    sphere.shape().set_radius(0.123);
-    self.assertEqual(0.123, sphere.radius());
+    sphere.shape().set_radius(0.123)
+    self.assertEqual(0.123, sphere.radius())
+
+  def test_calculate_inertial(self):
+    sphere = Sphere()
+
+    # density of aluminium
+    density = 2170
+
+    sphere.set_radius(-2)
+    invalidSphereInertial = sphere.calculate_inertial(density)
+    self.assertEqual(None, invalidSphereInertial)
+
+    r = 0.1
+
+    sphere.set_radius(r)
+
+    expectedMass = sphere.shape().volume() * density
+    ixxIyyIzz = 0.4 * expectedMass * r * r
+
+    expectedMassMat = MassMatrix3d(
+      expectedMass, Vector3d(ixxIyyIzz, ixxIyyIzz, ixxIyyIzz), Vector3d.ZERO)
+
+    expectedInertial = Inertiald()
+    expectedInertial.set_mass_matrix(expectedMassMat)
+    expectedInertial.set_pose(Pose3d.ZERO)
+
+    sphereInertial = sphere.calculate_inertial(density)
+    self.assertEqual(sphere.shape().material().density(), density)
+    self.assertNotEqual(None, sphereInertial)
+    self.assertEqual(expectedInertial, sphereInertial)
+    self.assertEqual(expectedInertial.mass_matrix().diagonal_moments(),
+      sphereInertial.mass_matrix().diagonal_moments())
+    self.assertEqual(expectedInertial.mass_matrix().mass(),
+      sphereInertial.mass_matrix().mass())
+    self.assertEqual(expectedInertial.pose(), sphereInertial.pose())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# 🎉 New feature

Related with https://github.com/gazebosim/sdformat/issues/1417 only for this PR https://github.com/gazebosim/sdformat/pull/1299/files

## Summary
Added Automatic Moment of Inertia Calculations for Basic Shapes Python wrappers

## Test it

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.