### PR TITLE
Add note in migration guide on camera lens intrinsics skew value change

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -22,6 +22,9 @@ but with improved human-readability..
 
 ### Modifications
 
+1. The default camera lens intrinsics skew value in the Camera DOM class changed
+   from `1` to `0` to match the SDF specification.
+
 1. World class only renames frames with name collisions if original file version
    is 1.6 or earlier. Name collisions in newer files will cause `DUPLICATE_NAME`
    errors, which now matches the behavior of the Model class.


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Add entry in migration guide to mention the camera lens intrinsics skew value change in #1423 


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
