### PR TITLE
Prepare for 12.8.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat12 VERSION 12.7.2)
+project (sdformat12 VERSION 12.8.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,20 @@
 ## libsdformat 12.X
 
+### libsdformat 12.8.0 (2024-06-06)
+
+1. Add support for no gravity link
+    * [Pull request #1410](https://github.com/gazebosim/sdformat/pull/1410)
+
+1. Add bullet and torsional friction DOM
+    * [Pull request #1351](https://github.com/gazebosim/sdformat/pull/1351)
+
+1. Fix static builds and optimize test compilation
+    * [Pull request #1343](https://github.com/gazebosim/sdformat/pull/1343)
+    * [Pull request #1347](https://github.com/gazebosim/sdformat/pull/1347)
+
+1. Update github action workflows
+    * [Pull request #1345](https://github.com/gazebosim/sdformat/pull/1345)
+
 ### libsdformat 12.7.2 (2023-09-01)
 
 1. Fixed 1.9/light.sdf


### PR DESCRIPTION


<!-- For maintainers only -->

# 🎈 Release

Preparation for 12.8.0 release.

Comparison to 12.7.2: https://github.com/gazebosim/sdformat/compare/sdformat12_12.7.2...prep_12.8.0

<!-- Add links to PRs that require this release (if needed) -->
Needed by:
* https://github.com/gazebosim/gz-physics/pull/633
* https://github.com/gazebosim/gz-sim/pull/2398

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
