### PR TITLE
Prepare for 13.7.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.6.0)
+project (sdformat13 VERSION 13.7.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,41 @@
 ## libsdformat 13.X
 
+### libsdformat 13.7.0 (2024-06-13)
+
+1. Add support for no gravity link
+    * [Pull request #1410](https://github.com/gazebosim/sdformat/pull/1410)
+    * [Pull request #1419](https://github.com/gazebosim/sdformat/pull/1419)
+
+1. Fix macOS workflow and backport windows fix
+    * [Pull request #1409](https://github.com/gazebosim/sdformat/pull/1409)
+
+1. Fix warning with pybind11 2.12
+    * [Pull request #1389](https://github.com/gazebosim/sdformat/pull/1389)
+
+1. Add bullet and torsional friction DOM
+    * [Pull request #1351](https://github.com/gazebosim/sdformat/pull/1351)
+    * [Pull request #1427](https://github.com/gazebosim/sdformat/pull/1427)
+
+1. Resolve URIs relative to file path
+    * [Pull request #1373](https://github.com/gazebosim/sdformat/pull/1373)
+
+1. Bazel updates for Garden build
+    * [Pull request #1239](https://github.com/gazebosim/sdformat/pull/1239)
+
+1. Fix static builds and optimize test compilation
+    * [Pull request #1343](https://github.com/gazebosim/sdformat/pull/1343)
+    * [Pull request #1347](https://github.com/gazebosim/sdformat/pull/1347)
+
+1. Install ruby commands on Windows
+    * [Pull request #1339](https://github.com/gazebosim/sdformat/pull/1339)
+    * [Pull request #1341](https://github.com/gazebosim/sdformat/pull/1341)
+
+1. Update github action workflows
+    * [Pull request #1345](https://github.com/gazebosim/sdformat/pull/1345)
+
+1. URDF->SDF handle links with no inertia or small mass
+    * [Pull request #1238](https://github.com/gazebosim/sdformat/pull/1238)
+
 ### libsdformat 13.6.0 (2023-08-30)
 
 1. Use relative path in an urdf include to avoid confusion between internal and system headers


### PR DESCRIPTION


# 🎈 Release

Preparation for 13.7.0 release.

Comparison to 13.6.0: https://github.com/gazebosim/sdformat/compare/sdformat13_13.6.0...prep_13.7.0


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

