### PR TITLE
Remove Cone shape from particle emitters

### DIFF
--- a/include/sdf/ParticleEmitter.hh
+++ b/include/sdf/ParticleEmitter.hh
@@ -51,10 +51,7 @@ namespace sdf
     CYLINDER = 2,
 
     /// \brief An ellipsoid emitter.
-    ELLIPSOID = 3,
-
-    /// \brief An cone emitter.
-    CONE = 4,
+    ELLIPSOID = 3
   };
 
   /// \brief A description of a particle emitter, which can be attached

--- a/python/src/sdf/pyParticleEmitter.cc
+++ b/python/src/sdf/pyParticleEmitter.cc
@@ -154,7 +154,6 @@ void defineParticleEmitter(pybind11::object module)
     pybind11::enum_<sdf::ParticleEmitterType>(particleEmitterModule, "ParticleEmitterType")
       .value("POINT", sdf::ParticleEmitterType::POINT)
       .value("BOX", sdf::ParticleEmitterType::BOX)
-      .value("CONE", sdf::ParticleEmitterType::CONE)
       .value("CYLINDER", sdf::ParticleEmitterType::CYLINDER)
       .value("ELLIPSOID", sdf::ParticleEmitterType::ELLIPSOID);
 }

--- a/python/test/pyParticleEmitter_TEST.py
+++ b/python/test/pyParticleEmitter_TEST.py
@@ -34,8 +34,6 @@ class ParticleEmitterTEST(unittest.TestCase):
         self.assertTrue(emitter.set_type("box"))
         self.assertEqual("box", emitter.type_str())
         self.assertEqual(ParticleEmitter.ParticleEmitterType.BOX, emitter.type())
-        emitter.set_type(ParticleEmitter.ParticleEmitterType.CONE)
-        self.assertEqual("cone", emitter.type_str())
         emitter.set_type(ParticleEmitter.ParticleEmitterType.CYLINDER)
         self.assertEqual("cylinder", emitter.type_str())
 

--- a/sdf/1.11/particle_emitter.sdf
+++ b/sdf/1.11/particle_emitter.sdf
@@ -26,8 +26,6 @@
     depending on the emmiter type:
       - point: The area is ignored.
       - box: The area is interpreted as width X height X depth.
-      - cone: The area is interpreted as the bounding box of the
-                  cone. The cone is oriented along the Z-axis.
       - cylinder: The area is interpreted as the bounding box of the
                   cylinder. The cylinder is oriented along the Z-axis.
       - ellipsoid: The area is interpreted as the bounding box of an

--- a/sdf/1.11/particle_emitter.sdf
+++ b/sdf/1.11/particle_emitter.sdf
@@ -7,7 +7,7 @@
   </attribute>
 
   <attribute name="type" type="string" default="point" required="1">
-    <description>The type of a particle emitter. One of "box", "cylinder", "cone", "ellipsoid", or "point".</description>
+    <description>The type of a particle emitter. One of "box", "cylinder", "ellipsoid", or "point".</description>
   </attribute>
 
   <element name="emitting" type="bool" default="true" required="0">

--- a/sdf/1.12/particle_emitter.sdf
+++ b/sdf/1.12/particle_emitter.sdf
@@ -7,7 +7,7 @@
   </attribute>
 
   <attribute name="type" type="string" default="point" required="1">
-    <description>The type of a particle emitter. One of "box", "cone", "cylinder", "ellipsoid", or "point".</description>
+    <description>The type of a particle emitter. One of "box", "cylinder", "ellipsoid", or "point".</description>
   </attribute>
 
   <element name="emitting" type="bool" default="true" required="0">
@@ -26,8 +26,6 @@
     depending on the emmiter type:
       - point: The area is ignored.
       - box: The area is interpreted as width X height X depth.
-      - cone: The area is interpreted as the bounding box of the
-                  cone. The cone is oriented along the Z-axis.
       - cylinder: The area is interpreted as the bounding box of the
                   cylinder. The cylinder is oriented along the Z-axis.
       - ellipsoid: The area is interpreted as the bounding box of an

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -34,13 +34,12 @@ using namespace sdf;
 /// Particle emitter type strings. These should match the data in
 /// `enum class ParticleEmitterType` located in ParticleEmitter.hh, and the size
 /// template parameter should match the number of elements as well.
-constexpr std::array<const std::string_view, 5> kEmitterTypeStrs =
+constexpr std::array<const std::string_view, 4> kEmitterTypeStrs =
 {
   "point",
   "box",
   "cylinder",
-  "ellipsoid",
-  "cone",
+  "ellipsoid"
 };
 
 class sdf::ParticleEmitter::Implementation

--- a/src/ParticleEmitter_TEST.cc
+++ b/src/ParticleEmitter_TEST.cc
@@ -35,8 +35,6 @@ TEST(DOMParticleEmitter, Construction)
   EXPECT_TRUE(emitter.SetType("box"));
   EXPECT_EQ("box", emitter.TypeStr());
   EXPECT_EQ(sdf::ParticleEmitterType::BOX, emitter.Type());
-  emitter.SetType(sdf::ParticleEmitterType::CONE);
-  EXPECT_EQ("cone", emitter.TypeStr());
   emitter.SetType(sdf::ParticleEmitterType::CYLINDER);
   EXPECT_EQ("cylinder", emitter.TypeStr());
 


### PR DESCRIPTION


# 🦟 Bug fix


## Summary
Cone shape particle emitters are not supported in gz yet. We should add this only when there is support for it, see https://github.com/gazebosim/gz-rendering/pull/1003#pullrequestreview-2082665533

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
