### PR TITLE
Prepare for 14.3.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat14 VERSION 14.2.0)
+project (sdformat14 VERSION 14.3.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,37 @@
 ## libsdformat 14.X
 
+### libsdformat 14.3.0 (2024-06-14)
+
+1. Backport voxel_resolution sdf element
+    * [Pull request #1429](https://github.com/gazebosim/sdformat/pull/1429)
+
+1. Added Automatic Moment of Inertia Calculations for Basic Shapes Python wrappers
+    * [Pull request #1424](https://github.com/gazebosim/sdformat/pull/1424)
+
+1. Add support for no gravity link
+    * [Pull request #1410](https://github.com/gazebosim/sdformat/pull/1410)
+    * [Pull request #1419](https://github.com/gazebosim/sdformat/pull/1419)
+
+1. Update default camera instrinsics skew to 0, which matches spec
+    * [Pull request #1423](https://github.com/gazebosim/sdformat/pull/1423)
+    * [Pull request #1425](https://github.com/gazebosim/sdformat/pull/1425)
+
+1. Allow empty strings in plugin and custom attributes
+    * [Pull request #1407](https://github.com/gazebosim/sdformat/pull/1407)
+
+1. (Backport) Enable 24.04 CI, remove distutils dependency
+    * [Pull request #1413](https://github.com/gazebosim/sdformat/pull/1413)
+
+1. Fix macOS workflow and backport windows fix
+    * [Pull request #1409](https://github.com/gazebosim/sdformat/pull/1409)
+
+1. Fix warning with pybind11 2.12
+    * [Pull request #1389](https://github.com/gazebosim/sdformat/pull/1389)
+
+1. Add bullet and torsional friction DOM
+    * [Pull request #1351](https://github.com/gazebosim/sdformat/pull/1351)
+    * [Pull request #1427](https://github.com/gazebosim/sdformat/pull/1427)
+
 ### libsdformat 14.2.0 (2024-04-23)
 
 1. Fix trivial warning on 24.04 for JointAxis_TEST.cc

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat14</name>
-  <version>14.2.0</version>
+  <version>14.3.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION


# 🎈 Release

Preparation for 14.3.0 release.

Comparison to 14.2.0: https://github.com/gazebosim/sdformat/compare/sdformat14_14.2.0...prep_14.3.0

<!-- Add links to PRs that require this release (if needed) -->


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

