### PR TITLE
Added SetHeightMap and Heighmap to Geometry Python binding

### DIFF
--- a/python/src/sdf/pyGeometry.cc
+++ b/python/src/sdf/pyGeometry.cc
@@ -26,6 +26,7 @@
 #include "sdf/Cylinder.hh"
 #include "sdf/Ellipsoid.hh"
 #include "sdf/Geometry.hh"
+#include "sdf/Heightmap.hh"
 #include "sdf/Mesh.hh"
 #include "sdf/Plane.hh"
 #include "sdf/Sphere.hh"
@@ -94,6 +95,11 @@ void defineGeometry(pybind11::object module)
          "geometry is not a mesh.")
     .def("set_mesh_shape", &sdf::Geometry::SetMeshShape,
          "Set the mesh shape.")
+    .def("set_heightmap_shape", &sdf::Geometry::SetHeightmapShape,
+         "Set the heightmap shape.")
+    .def("heightmap_shape", &sdf::Geometry::HeightmapShape,
+          pybind11::return_value_policy::reference,
+          "Get the heightmap geometry.")
     .def("__copy__", [](const sdf::Geometry &self) {
       return sdf::Geometry(self);
     })

--- a/python/test/pyGeometry_TEST.py
+++ b/python/test/pyGeometry_TEST.py
@@ -14,7 +14,7 @@
 
 import copy
 from gz_test_deps.sdformat import (Element, Error, Geometry, Box, Capsule, Cylinder, Ellipsoid,
-                                   Mesh, ParserConfig, Plane, Sphere)
+                                   Heightmap, Mesh, ParserConfig, Plane, Sphere)
 from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d, Vector2d
 import gz_test_deps.sdformat as sdf
 import math
@@ -169,6 +169,23 @@ class GeometryTEST(unittest.TestCase):
     self.assertEqual("banana", geom.mesh_shape().uri())
     self.assertEqual("orange", geom.mesh_shape().submesh())
     self.assertTrue(geom.mesh_shape().center_submesh())
+
+  def test_heighmap(self):
+    geom = Geometry()
+
+    geom.set_type(sdf.GeometryType.HEIGHTMAP)
+    heightmap = Heightmap()
+    geom.set_heightmap_shape(heightmap)
+
+    self.assertEqual(sdf.GeometryType.HEIGHTMAP, geom.type())
+    self.assertEqual(None, geom.box_shape())
+    self.assertEqual(None, geom.capsule_shape())
+    self.assertEqual(None, geom.cylinder_shape())
+    self.assertEqual(None, geom.ellipsoid_shape())
+    self.assertEqual(None, geom.sphere_shape())
+    self.assertEqual(None, geom.plane_shape())
+    self.assertEqual(None, geom.mesh_shape())
+    self.assertNotEqual(None, geom.heightmap_shape())
 
 
   def test_plane(self):


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/sdformat/issues/1439 

## Summary
Related with this issue https://github.com/gazebosim/sdformat/issues/1439

## Test it

```bash
colcon test --merge-install --event-handlers console_direct+ --packages-select sdformat14 --ctest-args -R pyGeometry_TEST
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.