### PR TITLE
Prepare release 14.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat14 VERSION 14.3.0)
+project (sdformat14 VERSION 14.4.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 ## libsdformat 14.X
 
+### libsdformat 14.4.0 (2024-06-20)
+
+1. Add Cone as a primitive parametric shape.
+    * [Pull request #1415](https://github.com/gazebosim/sdformat/pull/1415)
+    * Thanks to Benjamin Perseghetti
+
+1. Add custom attribute to custom element in test
+    * [Pull request #1406](https://github.com/gazebosim/sdformat/pull/1406)
+
 ### libsdformat 14.3.0 (2024-06-14)
 
 1. Backport voxel_resolution sdf element

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat14</name>
-  <version>14.3.0</version>
+  <version>14.4.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 14.4.0 release.

Comparison to 14.3.0: https://github.com/gazebosim/sdformat/compare/sdformat14_14.3.0...sdf14

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.