### PR TITLE
Suggestion for #1295: use FILE_READ instead of new enum

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -179,9 +179,6 @@ namespace sdf
 
     /// \brief Generic error during parsing.
     PARSING_ERROR,
-
-    /// \brief File not found error.
-    FILE_NOT_FOUND,
   };
 
   class SDFORMAT_VISIBLE Error

--- a/src/SDF.cc
+++ b/src/SDF.cc
@@ -190,7 +190,7 @@ std::string findFile(sdf::Errors &_errors, const std::string &_filename,
   {
     if (!_config.FindFileCallback())
     {
-      _errors.push_back({sdf::ErrorCode::FILE_NOT_FOUND,
+      _errors.push_back({sdf::ErrorCode::FILE_READ,
         "Tried to use callback in sdf::findFile(), but the callback "
         "is empty.  Did you call sdf::setFindCallback()?"});
       return std::string();
@@ -378,7 +378,7 @@ void SDF::Write(sdf::Errors &_errors, const std::string &_filename)
 
   if (!out)
   {
-    _errors.push_back({sdf::ErrorCode::FILE_NOT_FOUND,
+    _errors.push_back({sdf::ErrorCode::FILE_READ,
       "Unable to open file[" + _filename + "] for writing."});
     return;
   }
@@ -546,7 +546,7 @@ const std::string &SDF::EmbeddedSpec(
   }
   catch(const std::out_of_range &)
   {
-      _errors.push_back({sdf::ErrorCode::FILE_NOT_FOUND,
+      _errors.push_back({sdf::ErrorCode::FILE_READ,
           "Unable to find SDF filename[" + _filename + "] with " +
           "version " + SDF::Version()});
   }


### PR DESCRIPTION
# 🦟 Bug fix

Proposed change to #1295

## Summary

Implements the suggestion from https://github.com/gazebosim/sdformat/pull/1296/files#r1303216024

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
