### PR TITLE
Prepare for 13.8.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.7.0)
+project (sdformat13 VERSION 13.8.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## libsdformat 13.X
 
+### libsdformat 13.7.0 (2024-06-25)
+
+1. Added `World::ActorByName`
+    * [Pull request #1436](https://github.com/gazebosim/sdformat/pull/1436)
+
+1. Backport #1367 to Garden: Fix find Python3 logic.
+    * [Pull request #1370](https://github.com/gazebosim/sdformat/pull/1370)
+
 ### libsdformat 13.7.0 (2024-06-13)
 
 1. Add support for no gravity link

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## libsdformat 13.X
 
-### libsdformat 13.7.0 (2024-06-25)
+### libsdformat 13.8.0 (2024-06-25)
 
 1. Added `World::ActorByName`
     * [Pull request #1436](https://github.com/gazebosim/sdformat/pull/1436)


### PR DESCRIPTION

# 🎈 Release

Preparation for 13.8.0 release.

Comparison to 13.7.0: https://github.com/gazebosim/sdformat/compare/sdformat13_13.7.0...sdf13

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sim/pull/2452

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
