### PR TITLE
workflows/ci.yml fix push branch regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - 'sdf[0-9]?'
+      - 'sdf[1-9]?[0-9]'
       - 'main'
 
 jobs:


### PR DESCRIPTION
# 🦟 Bug fix

Fixes triggering of GitHub workflows on branches with double-digit major version.

## Summary

Ubuntu workflows for branches with a double digit major version number haven't been running for a while ([6 months](https://github.com/gazebosim/sdformat/actions/workflows/ci.yml?query=branch%3Asdf14) since the last `sdf14` build). I believe this is due to the regex pattern used to match our release branches.

The current pattern matches the following:
"sdf", "sdf0", "sdf1", ..., "sdf8", "sdf9"
of which "sdf" is incorrect, and only "sdf9"
is currently supported. This updates the pattern
to match single digits "sdf1" - "sdf9" and double
digits "sdf10" to "sdf99".

I don't think we can test this without merging it?

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
