### PR TITLE
Disable latex and class hierarchy generation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -13,9 +13,6 @@ if (DOXYGEN_FOUND)
             ${CMAKE_BINARY_DIR}/doxygen/html
     COMMAND cp ${CMAKE_SOURCE_DIR}/doc/search.js
             ${CMAKE_BINARY_DIR}/doxygen/html/search
-    COMMAND make -C ${CMAKE_BINARY_DIR}/doxygen/latex
-    COMMAND mv ${CMAKE_BINARY_DIR}/doxygen/latex/refman.pdf
-    ${CMAKE_BINARY_DIR}/doxygen/latex/sdf-${PROJECT_VERSION_FULL}.pdf
 
     COMMENT "Generating API documentation with Doxygen" VERBATIM)
 endif()

--- a/doc/sdf.in
+++ b/doc/sdf.in
@@ -1234,7 +1234,7 @@ SERVER_BASED_SEARCH    = NO
 # If the GENERATE_LATEX tag is set to YES (the default) Doxygen will
 # generate Latex output.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put.
 # If a relative path is entered the value of OUTPUT_DIRECTORY will be
@@ -1595,7 +1595,7 @@ PERL_PATH              = /usr/bin/perl
 # this option also works with HAVE_DOT disabled, but it is recommended to
 # install and use dot, since it yields more powerful graphs.
 
-CLASS_DIAGRAMS         = YES
+CLASS_DIAGRAMS         = NO
 
 # You can define message sequence charts within doxygen comments using the \msc
 # command. Doxygen will then run the mscgen tool (see
@@ -1617,7 +1617,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # toolkit from AT&T and Lucent Bell Labs. The other options in this section
 # have no effect if this option is set to NO (the default)
 
-HAVE_DOT               = YES
+HAVE_DOT               = NO
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is
 # allowed to run in parallel. When set to 0 (the default) doxygen will


### PR DESCRIPTION
## Summary
We don't use the latex output anywhere, but it brings in a big dependency when building documentation or deb packages. The class [hierarchy](https://gazebosim.org/api/sdformat/14/inherits.html) is also not that useful since there is not much inheritance used in the codebase. This also brings the doxygen parameters of sdformat closer to other Gazebo libraries.

Note: I plan to Backport this to all the previous versions of sdformat

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.