### PR TITLE
Add //sensor/frame_id to SDF spec 1.12

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -30,6 +30,18 @@ but with improved human-readability..
       matches `"0"`, `"1"`, `"true"`, or `"false"` and returns `false`
       otherwise.
 
+### Deprecations
+
+- **sdf/Camera.hh**:
+   + The `//sensor/camera/optical_frame_id` SDF element and corresponding functions
+     in the Camera DOM class are deprecated. Please specify camera frame using
+     the `//sensor/frame_id` SDF element instead.
+   + ***Deprecation:*** std::string OpticalFrameId() const
+   + ***Replacement:*** std::string Sensor::FrameId() const
+   + ***Deprecation:*** void SetOpticalFrameId(const std::string &)
+   + ***Replacement:*** void Sensor::SetFrameId(const std::string &)
+
+
 ## libsdformat 13.x to 14.x
 
 ### Additions

--- a/include/sdf/Camera.hh
+++ b/include/sdf/Camera.hh
@@ -363,12 +363,12 @@ namespace sdf
     /// The Camera sensor assumes that the color and depth images are captured
     /// at the same frame_id.
     /// \return The name of the frame this camera uses in its camera_info topic.
-    public: const std::string OpticalFrameId() const;
+    public: const std::string GZ_DEPRECATED(15) OpticalFrameId() const;
 
     /// \brief Set the name of the coordinate frame relative to which this
     /// object's camera_info is expressed.
     /// \param[in] _frame The frame this camera uses in its camera_info topic.
-    public: void SetOpticalFrameId(const std::string &_frame);
+    public: void GZ_DEPRECATED(15) SetOpticalFrameId(const std::string &_frame);
 
     /// \brief Get the lens type. This is the type of the lens mapping.
     /// Supported values are gnomonical, stereographic, equidistant,

--- a/include/sdf/Sensor.hh
+++ b/include/sdf/Sensor.hh
@@ -160,6 +160,14 @@ namespace sdf
     /// \param[in] _name Name of the sensor.
     public: void SetName(const std::string &_name);
 
+    /// \brief Get the frame ID of the sensor.
+    /// \return Sensor frame ID.
+    public: std::string FrameId() const;
+
+    /// \brief Set the frame ID of the sensor.
+    /// \param[in] _frameId Frame ID to set.
+    public: void SetFrameId(const std::string &_frameId);
+
     /// \brief Get the topic on which sensor data should be published.
     /// \return Topic for this sensor's data.
     public: std::string Topic() const;

--- a/python/src/sdf/pyCamera.cc
+++ b/python/src/sdf/pyCamera.cc
@@ -32,6 +32,9 @@ namespace python
 /////////////////////////////////////////////////
 void defineCamera(pybind11::object module)
 {
+  // \todo(iche033) OpticalFrameId and SetOpticalFrameId are deprecated
+  // Remove sdformat16
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   pybind11::class_<sdf::Camera> cameraModule(module, "Camera");
   cameraModule
     .def(pybind11::init<>())
@@ -296,6 +299,8 @@ void defineCamera(pybind11::object module)
       .value("BAYER_BGGR8", sdf::PixelFormatType::BAYER_BGGR8)
       .value("BAYER_GBRG8", sdf::PixelFormatType::BAYER_GBRG8)
       .value("BAYER_GRBG8", sdf::PixelFormatType::BAYER_GRBG8);
+
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 }
 }  // namespace python
 }  // namespace SDF_VERSION_NAMESPACE

--- a/python/src/sdf/pySensor.cc
+++ b/python/src/sdf/pySensor.cc
@@ -51,6 +51,10 @@ void defineSensor(pybind11::object module)
          "Get the name of the sensor.")
     .def("set_name", &sdf::Sensor::SetName,
          "Set the name of the sensor.")
+    .def("frame_id", &sdf::Sensor::FrameId,
+         "Get the frame id of the sensor.")
+    .def("set_frame_id", &sdf::Sensor::SetFrameId,
+         "Set the frame id of the sensor.")
     .def("topic", &sdf::Sensor::Topic,
          "Get the topic on which sensor data should be published.")
     .def("set_topic", &sdf::Sensor::SetTopic,

--- a/python/test/pySensor_TEST.py
+++ b/python/test/pySensor_TEST.py
@@ -60,12 +60,14 @@ class SensorTEST(unittest.TestCase):
 
         self.assertAlmostEqual(0.0, sensor.update_rate())
 
+        self.assertFalse(sensor.frame_id())
         self.assertFalse(sensor.topic())
         self.assertFalse(sensor == sensor2)
         self.assertTrue(sensor != sensor2)
 
     def test_copy_construction(self):
         sensor = Sensor()
+        sensor.set_frame_id("test_frame_id")
         sensor.set_raw_pose(Pose3d(1, 2, 3, 0, 0, 0))
         sensor.set_type(sdf.Sensortype.MAGNETOMETER)
         sensor.set_pose_relative_to("a_frame")
@@ -79,6 +81,7 @@ class SensorTEST(unittest.TestCase):
 
         sensor2 = Sensor(sensor)
 
+        self.assertEqual("test_frame_id", sensor.frame_id())
         self.assertEqual(sdf.Sensortype.MAGNETOMETER, sensor.type())
         self.assertEqual(Pose3d(1, 2, 3, 0, 0, 0), sensor.raw_pose())
         self.assertEqual("a_frame", sensor.pose_relative_to())
@@ -86,6 +89,7 @@ class SensorTEST(unittest.TestCase):
         self.assertAlmostEqual(mag.x_noise().mean(),
                                sensor.magnetometer_sensor().x_noise().mean())
 
+        self.assertEqual("test_frame_id", sensor2.frame_id())
         self.assertEqual(sdf.Sensortype.MAGNETOMETER, sensor2.type())
         self.assertEqual(Pose3d(1, 2, 3, 0, 0, 0), sensor2.raw_pose())
         self.assertEqual("a_frame", sensor2.pose_relative_to())
@@ -96,6 +100,7 @@ class SensorTEST(unittest.TestCase):
 
     def test_deepcopy(self):
         sensor = Sensor()
+        sensor.set_frame_id("test_frame_id")
         sensor.set_raw_pose(Pose3d(1, 2, 3, 0, 0, 0))
         sensor.set_type(sdf.Sensortype.MAGNETOMETER)
         sensor.set_pose_relative_to("a_frame")
@@ -108,6 +113,7 @@ class SensorTEST(unittest.TestCase):
 
         sensor2 = copy.deepcopy(sensor)
 
+        self.assertEqual("test_frame_id", sensor.frame_id())
         self.assertEqual(sdf.Sensortype.MAGNETOMETER, sensor.type())
         self.assertEqual(Pose3d(1, 2, 3, 0, 0, 0), sensor.raw_pose())
         self.assertEqual("a_frame", sensor.pose_relative_to())
@@ -115,6 +121,7 @@ class SensorTEST(unittest.TestCase):
         self.assertAlmostEqual(mag.x_noise().mean(),
                                sensor.magnetometer_sensor().x_noise().mean())
 
+        self.assertEqual("test_frame_id", sensor2.frame_id())
         self.assertEqual(sdf.Sensortype.MAGNETOMETER, sensor2.type())
         self.assertEqual(Pose3d(1, 2, 3, 0, 0, 0), sensor2.raw_pose())
         self.assertEqual("a_frame", sensor2.pose_relative_to())

--- a/sdf/1.12/camera.sdf
+++ b/sdf/1.12/camera.sdf
@@ -222,7 +222,7 @@
     <description><![CDATA[Visibility mask of a camera. When (camera's visibility_mask & visual's visibility_flags) evaluates to non-zero, the visual will be visible to the camera.]]></description>
   </element>
 
-  <element name="optical_frame_id" type="string" default="" required="0">
+  <element name="optical_frame_id" type="string" default="" required="-1">
     <description>An optional frame id name to be used in the camera_info message header.</description>
   </element>
 

--- a/sdf/1.12/sensor.sdf
+++ b/sdf/1.12/sensor.sdf
@@ -59,6 +59,10 @@
     <description>If true, the sensor will publish performance metrics</description>
   </element>
 
+  <element name="frame_id" type="string" default="" required="0">
+    <description>An optional frame id which indicates the sensor's frame of reference.</description>
+  </element>
+
   <include filename="pose.sdf" required="0"/>
   <include filename="plugin.sdf" required="*"/>
   <include filename="air_pressure.sdf" required="0"/>

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -752,6 +752,9 @@ void Camera::SetSaveFramesPath(const std::string &_path)
 //////////////////////////////////////////////////
 bool Camera::operator==(const Camera &_cam) const
 {
+
+  // \todo(iche033) Remove in sdformat16
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   return this->Name() == _cam.Name() &&
     this->HorizontalFov() == _cam.HorizontalFov() &&
     this->ImageWidth() == _cam.ImageWidth() &&
@@ -764,6 +767,7 @@ bool Camera::operator==(const Camera &_cam) const
     this->ImageNoise() == _cam.ImageNoise() &&
     this->VisibilityMask() == _cam.VisibilityMask() &&
     this->OpticalFrameId() == _cam.OpticalFrameId();
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 }
 
 //////////////////////////////////////////////////
@@ -1332,8 +1336,11 @@ sdf::ElementPtr Camera::ToElement() const
         this->SegmentationType());
   }
 
+  // \todo(iche033) Remove in sdformat16
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   elem->GetElement("optical_frame_id")->Set<std::string>(
       this->OpticalFrameId());
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   return elem;
 }

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -134,9 +134,12 @@ TEST(DOMCamera, Construction)
   cam.SetPoseRelativeTo("/frame");
   EXPECT_EQ("/frame", cam.PoseRelativeTo());
 
+  // \todo(iche033) Remove in sdformat16
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   EXPECT_TRUE(cam.OpticalFrameId().empty());
   cam.SetOpticalFrameId("/optical_frame");
   EXPECT_EQ("/optical_frame", cam.OpticalFrameId());
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   EXPECT_EQ("stereographic", cam.LensType());
   cam.SetLensType("custom");
@@ -273,7 +276,12 @@ TEST(DOMCamera, ToElement)
   cam.SetPoseRelativeTo("/frame");
   cam.SetSaveFrames(true);
   cam.SetSaveFramesPath("/tmp");
+
+  // \todo(iche033) Remove in sdformat16
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   cam.SetOpticalFrameId("/optical_frame");
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
   cam.SetCameraInfoTopic("/camera_info_test");
   cam.SetTriggerTopic("/trigger_topic_test");
   cam.SetTriggered(true);
@@ -296,7 +304,12 @@ TEST(DOMCamera, ToElement)
   EXPECT_EQ("/frame", cam2.PoseRelativeTo());
   EXPECT_TRUE(cam2.SaveFrames());
   EXPECT_EQ("/tmp", cam2.SaveFramesPath());
+
+  // \todo(iche033) Remove in sdformat16
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   EXPECT_EQ("/optical_frame", cam2.OpticalFrameId());
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
   EXPECT_EQ("/camera_info_test", cam2.CameraInfoTopic());
   EXPECT_EQ("/trigger_topic_test", cam2.TriggerTopic());
   EXPECT_TRUE(cam2.Triggered());

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -82,6 +82,9 @@ class sdf::Sensor::Implementation
   /// \brief Name of the sensor.
   public: std::string name = "";
 
+  /// \brief Sensor frame ID
+  public: std::string frameId{""};
+
   /// \brief Sensor data topic.
   public: std::string topic = "";
 
@@ -243,7 +246,8 @@ Errors Sensor::Load(ElementPtr _sdf)
                      "The supplied sensor name [" + this->dataPtr->name +
                      "] is reserved."});
   }
-
+  this->dataPtr->frameId = _sdf->Get<std::string>("frame_id",
+      this->dataPtr->frameId).first;
   this->dataPtr->updateRate = _sdf->Get<double>("update_rate",
       this->dataPtr->updateRate).first;
   this->dataPtr->topic = _sdf->Get<std::string>("topic");
@@ -437,6 +441,18 @@ std::string Sensor::Name() const
 void Sensor::SetName(const std::string &_name)
 {
   this->dataPtr->name = _name;
+}
+
+/////////////////////////////////////////////////
+std::string Sensor::FrameId() const
+{
+  return this->dataPtr->frameId;
+}
+
+/////////////////////////////////////////////////
+void Sensor::SetFrameId(const std::string &_frameId)
+{
+  this->dataPtr->frameId = _frameId;
 }
 
 /////////////////////////////////////////////////
@@ -750,6 +766,7 @@ sdf::ElementPtr Sensor::ToElement(sdf::Errors &_errors) const
   }
   poseElem->Set<gz::math::Pose3d>(this->RawPose());
 
+  elem->GetElement("frame_id")->Set<std::string>(this->FrameId());
   elem->GetElement("topic")->Set<std::string>(this->Topic());
   elem->GetElement("update_rate")->Set<double>(this->UpdateRate());
   elem->GetElement("enable_metrics")->Set<double>(this->EnableMetrics());

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -60,6 +60,9 @@ TEST(DOMSensor, Construction)
     EXPECT_FALSE(semanticPose.Resolve(pose).empty());
   }
 
+  EXPECT_TRUE(sensor.FrameId().empty());
+  sensor.SetFrameId("new_frame_id");
+  EXPECT_EQ("new_frame_id", sensor.FrameId());
 
   EXPECT_DOUBLE_EQ(0.0, sensor.UpdateRate());
 
@@ -76,6 +79,7 @@ TEST(DOMSensor, MoveConstructor)
   sensor.SetType(sdf::SensorType::MAGNETOMETER);
   sensor.SetPoseRelativeTo("a_frame");
   sensor.SetUpdateRate(0.123);
+  sensor.SetFrameId("new_frame_id");
 
   sdf::Noise noise;
   noise.SetMean(0.1);
@@ -88,6 +92,7 @@ TEST(DOMSensor, MoveConstructor)
   EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor2.Type());
   EXPECT_EQ(gz::math::Pose3d(1, 2, 3, 0, 0, 0), sensor2.RawPose());
   EXPECT_EQ("a_frame", sensor2.PoseRelativeTo());
+  EXPECT_EQ("new_frame_id", sensor2.FrameId());
   ASSERT_TRUE(nullptr != sensor2.MagnetometerSensor());
   EXPECT_DOUBLE_EQ(mag.XNoise().Mean(),
                    sensor2.MagnetometerSensor()->XNoise().Mean());
@@ -102,6 +107,7 @@ TEST(DOMSensor, CopyConstructor)
   sensor.SetType(sdf::SensorType::MAGNETOMETER);
   sensor.SetPoseRelativeTo("a_frame");
   sensor.SetUpdateRate(0.123);
+  sensor.SetFrameId("new_frame_id");
 
   sdf::Noise noise;
   noise.SetMean(0.1);
@@ -114,6 +120,7 @@ TEST(DOMSensor, CopyConstructor)
   EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor.Type());
   EXPECT_EQ(gz::math::Pose3d(1, 2, 3, 0, 0, 0), sensor.RawPose());
   EXPECT_EQ("a_frame", sensor.PoseRelativeTo());
+  EXPECT_EQ("new_frame_id", sensor.FrameId());
   ASSERT_TRUE(nullptr != sensor.MagnetometerSensor());
   EXPECT_DOUBLE_EQ(mag.XNoise().Mean(),
                    sensor.MagnetometerSensor()->XNoise().Mean());
@@ -121,6 +128,7 @@ TEST(DOMSensor, CopyConstructor)
   EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor2.Type());
   EXPECT_EQ(gz::math::Pose3d(1, 2, 3, 0, 0, 0), sensor2.RawPose());
   EXPECT_EQ("a_frame", sensor2.PoseRelativeTo());
+  EXPECT_EQ("new_frame_id", sensor2.FrameId());
   ASSERT_TRUE(nullptr != sensor2.MagnetometerSensor());
   EXPECT_DOUBLE_EQ(mag.XNoise().Mean(),
                    sensor2.MagnetometerSensor()->XNoise().Mean());
@@ -134,6 +142,7 @@ TEST(DOMSensor, MoveAssignment)
   sensor.SetRawPose(gz::math::Pose3d(1, 2, 3, 0, 0, 0));
   sensor.SetType(sdf::SensorType::MAGNETOMETER);
   sensor.SetPoseRelativeTo("a_frame");
+  sensor.SetFrameId("new_frame_id");
 
   sdf::Noise noise;
   noise.SetMean(0.1);
@@ -147,6 +156,7 @@ TEST(DOMSensor, MoveAssignment)
   EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor2.Type());
   EXPECT_EQ(gz::math::Pose3d(1, 2, 3, 0, 0, 0), sensor2.RawPose());
   EXPECT_EQ("a_frame", sensor2.PoseRelativeTo());
+  EXPECT_EQ("new_frame_id", sensor2.FrameId());
   ASSERT_TRUE(nullptr != sensor2.MagnetometerSensor());
   EXPECT_DOUBLE_EQ(mag.XNoise().Mean(),
                    sensor2.MagnetometerSensor()->XNoise().Mean());
@@ -159,6 +169,7 @@ TEST(DOMSensor, CopyAssignment)
   sensor.SetRawPose(gz::math::Pose3d(1, 2, 3, 0, 0, 0));
   sensor.SetType(sdf::SensorType::MAGNETOMETER);
   sensor.SetPoseRelativeTo("a_frame");
+  sensor.SetFrameId("new_frame_id");
 
   sdf::Noise noise;
   noise.SetMean(0.1);
@@ -172,6 +183,7 @@ TEST(DOMSensor, CopyAssignment)
   EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor.Type());
   EXPECT_EQ(gz::math::Pose3d(1, 2, 3, 0, 0, 0), sensor.RawPose());
   EXPECT_EQ("a_frame", sensor.PoseRelativeTo());
+  EXPECT_EQ("new_frame_id", sensor.FrameId());
   ASSERT_TRUE(nullptr != sensor.MagnetometerSensor());
   EXPECT_DOUBLE_EQ(mag.XNoise().Mean(),
                    sensor.MagnetometerSensor()->XNoise().Mean());
@@ -179,6 +191,7 @@ TEST(DOMSensor, CopyAssignment)
   EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor2.Type());
   EXPECT_EQ(gz::math::Pose3d(1, 2, 3, 0, 0, 0), sensor2.RawPose());
   EXPECT_EQ("a_frame", sensor2.PoseRelativeTo());
+  EXPECT_EQ("new_frame_id", sensor.FrameId());
   ASSERT_TRUE(nullptr != sensor2.MagnetometerSensor());
   EXPECT_DOUBLE_EQ(mag.XNoise().Mean(),
                    sensor2.MagnetometerSensor()->XNoise().Mean());
@@ -191,11 +204,13 @@ TEST(DOMSensor, CopyAssignmentAfterMove)
   sensor1.SetRawPose(gz::math::Pose3d(1, 2, 3, 0, 0, 0));
   sensor1.SetType(sdf::SensorType::MAGNETOMETER);
   sensor1.SetPoseRelativeTo("frame1");
+  sensor1.SetFrameId("new_frame_id");
 
   sdf::Sensor sensor2;
   sensor2.SetRawPose(gz::math::Pose3d(4, 5, 6, 0, 0, 0));
   sensor2.SetType(sdf::SensorType::CAMERA);
   sensor2.SetPoseRelativeTo("frame2");
+  sensor2.SetFrameId("new_frame_id2");
 
   // This is similar to what std::swap does except it uses std::move for each
   // assignment
@@ -206,10 +221,12 @@ TEST(DOMSensor, CopyAssignmentAfterMove)
   EXPECT_EQ(sdf::SensorType::CAMERA, sensor1.Type());
   EXPECT_EQ(gz::math::Pose3d(4, 5, 6, 0, 0, 0), sensor1.RawPose());
   EXPECT_EQ("frame2", sensor1.PoseRelativeTo());
+  EXPECT_EQ("new_frame_id2", sensor1.FrameId());
 
   EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor2.Type());
   EXPECT_EQ(gz::math::Pose3d(1, 2, 3, 0, 0, 0), sensor2.RawPose());
   EXPECT_EQ("frame1", sensor2.PoseRelativeTo());
+  EXPECT_EQ("new_frame_id", sensor2.FrameId());
 }
 
 /////////////////////////////////////////////////
@@ -509,6 +526,7 @@ TEST(DOMSensor, ToElement)
   // test calling ToElement on a DOM object constructed without calling Load
   sdf::Sensor sensor;
   sensor.SetName("my_sensor");
+  sensor.SetFrameId("my_sensor_frame_id");
   sensor.SetRawPose(gz::math::Pose3d(1, 2, 3, 0, 0, 0));
   sensor.SetType(sdf::SensorType::MAGNETOMETER);
   sensor.SetPoseRelativeTo("a_frame");
@@ -534,6 +552,7 @@ TEST(DOMSensor, ToElement)
   sensor2.Load(sensorElem);
 
   EXPECT_EQ("my_sensor", sensor2.Name());
+  EXPECT_EQ("my_sensor_frame_id", sensor2.FrameId());
   EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor2.Type());
   EXPECT_EQ(gz::math::Pose3d(1, 2, 3, 0, 0, 0), sensor2.RawPose());
   EXPECT_EQ("a_frame", sensor2.PoseRelativeTo());


### PR DESCRIPTION

# 🎉 New feature

Related issue: https://github.com/gazebosim/gz-sensors/issues/306

## Summary

There are many ways to specify the sensor frame id in gazebo, e.g. 
* `//sensor/gz_frame_id` - Parsed by gz-sensors. Not in official sdf spec
* `//sensor/ignition_frame_id` - Parsed by gz-sensors (removed in harmonic). Not in official sdf spec
* `//sensor/camera/optical_frame_id`

This PR proposes a `//sensor/frame_id` sdf element to rule them all. Yes now it just adds one more way to do it but fear not, all others are being deprecated (`ignition_frame_id` is already gone)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

