### PR TITLE
Add _state suffix to //state subelements

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -596,6 +596,22 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 
 ## SDFormat specification 1.11 to 1.12
 
+### Modifications
+
+1. **state.sdf**, **model_state.sdf**, **joint_state.sdf**, **link_state.sdf**,
+   **light_state.sdf**: A `_state` suffix has been added to state element names
+   to match the `.sdf` file names and for consistency.
+    + `//state/light` renamed to `//state/light_state`
+    + `//state/model` renamed to `//state/model_state`
+    + `//state/model/joint` renamed to `//state/model_state/joint_state`
+    + `//state/model/light` renamed to `//state/model_state/light_state`
+    + `//state/model/link`  renamed to `//state/model_state/link_state`
+    + `//state/model/model` renamed to `//state/model_state/model_state`
+    + `//state/model/link/collision` renamed to `//state/model_state/link_state/collision_state`
+
+ 1. `//state/joint_state` has been added to represent the state of a
+    `//world/joint`.
+
 ## SDFormat specification 1.10 to 1.11
 
 ### Additions

--- a/Migration.md
+++ b/Migration.md
@@ -642,7 +642,8 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
     + `//state/model/link/collision` renamed to `//state/model_state/link_state/collision_state`
 
 1. **state.sdf**: `//state/joint_state` has been added to represent the state of a
-    `//world/joint`.
+    `//world/joint` and `//state/insertions/joint` can represent inserted
+    `//world/joint` elements.
 
 ## SDFormat specification 1.10 to 1.11
 

--- a/Migration.md
+++ b/Migration.md
@@ -641,7 +641,7 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
     + `//state/model/model` renamed to `//state/model_state/model_state`
     + `//state/model/link/collision` renamed to `//state/model_state/link_state/collision_state`
 
- 1. `//state/joint_state` has been added to represent the state of a
+1. **state.sdf**: `//state/joint_state` has been added to represent the state of a
     `//world/joint`.
 
 ## SDFormat specification 1.10 to 1.11

--- a/sdf/1.12/CMakeLists.txt
+++ b/sdf/1.12/CMakeLists.txt
@@ -26,6 +26,7 @@ set (sdfs
   imu.sdf
   inertial.sdf
   joint.sdf
+  joint_state.sdf
   lidar.sdf
   light.sdf
   light_state.sdf

--- a/sdf/1.12/joint_state.sdf
+++ b/sdf/1.12/joint_state.sdf
@@ -1,6 +1,9 @@
 <!-- State information for a joint -->
 <element name="joint_state" required="*">
-  <description>Joint angle</description>
+  <description>
+    The joint state element encapsulates variables within a joint that may
+    change over time, currently limited to the joint angle.
+  </description>
 
   <attribute name="name" type="string" default="__default__" required="1">
     <description>Name of the joint</description>

--- a/sdf/1.12/joint_state.sdf
+++ b/sdf/1.12/joint_state.sdf
@@ -1,0 +1,16 @@
+<!-- State information for a joint -->
+<element name="joint_state" required="*">
+  <description>Joint angle</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>Name of the joint</description>
+  </attribute>
+
+  <element name="angle" type="double" default="0" required="+">
+    <attribute name="axis" type="unsigned int" default="0" required="1">
+      <description>Index of the axis.</description>
+    </attribute>
+
+    <description>Angle of an axis</description>
+  </element>
+</element> <!-- End Joint -->

--- a/sdf/1.12/light_state.sdf
+++ b/sdf/1.12/light_state.sdf
@@ -1,6 +1,9 @@
 <!-- State information for a light -->
 <element name="light_state" required="*">
-  <description>Light state</description>
+  <description>
+    The light state element encapsulates variables within a light that may
+    change over time, currently limited to its pose.
+  </description>
 
   <attribute name="name" type="string" default="__default__" required="1">
     <description>Name of the light</description>

--- a/sdf/1.12/light_state.sdf
+++ b/sdf/1.12/light_state.sdf
@@ -1,5 +1,5 @@
 <!-- State information for a light -->
-<element name="light" required="*">
+<element name="light_state" required="*">
   <description>Light state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">

--- a/sdf/1.12/link_state.sdf
+++ b/sdf/1.12/link_state.sdf
@@ -1,6 +1,10 @@
 <!-- State information for a link -->
 <element name="link_state" required="*">
-  <description>Link state</description>
+  <description>
+    The link state element encapsulates variables within a link that may
+    change over time, including pose, velocity, acceleration, applied wrench,
+    and the state of attached collisions.
+  </description>
 
   <attribute name="name" type="string" default="__default__" required="1">
     <description>Name of the link</description>

--- a/sdf/1.12/link_state.sdf
+++ b/sdf/1.12/link_state.sdf
@@ -1,5 +1,5 @@
 <!-- State information for a link -->
-<element name="link" required="*">
+<element name="link_state" required="*">
   <description>Link state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">
@@ -27,7 +27,7 @@
     </description>
   </element>
 
-  <element name="collision" required="*">
+  <element name="collision_state" required="*">
     <description>Collision state</description>
 
     <attribute name="name" type="string" default="__default__" required="1">

--- a/sdf/1.12/model_state.sdf
+++ b/sdf/1.12/model_state.sdf
@@ -1,6 +1,10 @@
 <!-- State information for a model -->
 <element name="model_state" required="*">
-  <description>Model state</description>
+  <description>
+    The model state element encapsulates variables within a model that may
+    change over time, including object poses, the states of its nested models
+    and links and joints, and changes in model scale.
+  </description>
 
   <attribute name="name" type="string" default="__default__" required="1">
     <description>Name of the model</description>

--- a/sdf/1.12/model_state.sdf
+++ b/sdf/1.12/model_state.sdf
@@ -1,12 +1,12 @@
 <!-- State information for a model -->
-<element name="model" required="*">
+<element name="model_state" required="*">
   <description>Model state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">
     <description>Name of the model</description>
   </attribute>
 
-  <element name="joint" required="*">
+  <element name="joint_state" required="*">
     <description>Joint angle</description>
 
     <attribute name="name" type="string" default="__default__" required="1">
@@ -22,7 +22,7 @@
     </element>
   </element>
 
-  <element name="model" ref="model_state" required="*">
+  <element name="model_state" ref="model_state" required="*">
     <description>A nested model state element</description>
     <attribute name="name" type="string" default="__default__" required="1">
       <description>Name of the model. </description>

--- a/sdf/1.12/model_state.sdf
+++ b/sdf/1.12/model_state.sdf
@@ -6,21 +6,7 @@
     <description>Name of the model</description>
   </attribute>
 
-  <element name="joint_state" required="*">
-    <description>Joint angle</description>
-
-    <attribute name="name" type="string" default="__default__" required="1">
-      <description>Name of the joint</description>
-    </attribute>
-
-    <element name="angle" type="double" default="0" required="+">
-      <attribute name="axis" type="unsigned int" default="0" required="1">
-        <description>Index of the axis.</description>
-      </attribute>
-
-      <description>Angle of an axis</description>
-    </element>
-  </element>
+  <include filename="joint_state.sdf" required="*"/>
 
   <element name="model_state" ref="model_state" required="*">
     <description>A nested model state element</description>

--- a/sdf/1.12/state.sdf
+++ b/sdf/1.12/state.sdf
@@ -25,6 +25,7 @@
     <description>A list containing the entire description of entities inserted.</description>
     <include filename="model.sdf" required="+"/>
     <include filename="light.sdf" required="+"/>
+    <include filename="joint.sdf" required="+"/>
   </element>
 
   <element name="deletions" required="0">

--- a/sdf/1.12/state.sdf
+++ b/sdf/1.12/state.sdf
@@ -1,5 +1,12 @@
 <!-- State Info -->
 <element name="state" required="*">
+  <description>
+    The state element encapsulates variables within a world that may change
+    over time, including object poses, dynamic states such as velocity and
+    acceleration, a description of objects added to the world, and a list
+    of objects deleted from the world.
+  </description>
+
   <!-- Name of the world this state applies to -->
   <attribute name="world_name" type="string" default="__default__" required="1">
     <description>Name of the world this state applies to</description>
@@ -22,14 +29,14 @@
   </element>
 
   <element name="insertions" required="0">
-    <description>A list containing the entire description of entities inserted.</description>
+    <description>A list containing the entire description of entities inserted into the world.</description>
     <include filename="model.sdf" required="+"/>
     <include filename="light.sdf" required="+"/>
     <include filename="joint.sdf" required="+"/>
   </element>
 
   <element name="deletions" required="0">
-    <description>A list of names of deleted entities/</description>
+    <description>A list of names of entities deleted from the world./</description>
     <element name="name" type="string" default="__default__" required="+">
       <description>The name of a deleted entity.</description>
     </element>

--- a/sdf/1.12/state.sdf
+++ b/sdf/1.12/state.sdf
@@ -38,4 +38,6 @@
 
   <include filename="light_state.sdf" required="*"/>
 
+  <include filename="joint_state.sdf" required="*"/>
+
 </element> <!-- End State -->

--- a/test/integration/frame.cc
+++ b/test/integration/frame.cc
@@ -213,18 +213,18 @@ TEST(Frame, StateFrame)
   sdfStr << "<sdf version ='" << SDF_VERSION << "'>"
     << "<world name='default'>"
     << "<state world_name='default'>"
-    << "<model name='my_model'>"
+    << "<model_state name='my_model'>"
     << "  <frame name='mframe'>"
     << "    <pose relative_to='/world'>1 0 2 0 0 0</pose>"
     << "  </frame>"
     << "  <pose relative_to='mframe'>3 3 9 0 0 0</pose>"
-    << "  <link name='my_link'>"
+    << "  <link_state name='my_link'>"
     << "    <pose relative_to='lframe'>111 3 0 0 0 0</pose>"
-    << "  </link>"
-    << "</model>"
-    << "<light name='my_light'>"
+    << "  </link_state>"
+    << "</model_state>"
+    << "<light_state name='my_light'>"
     << "    <pose relative_to='lframe'>99 0 22 0 0 0</pose>"
-    << "</light>"
+    << "</light_state>"
     << "</state>"
     << "</world>"
     << "</sdf>";
@@ -239,8 +239,8 @@ TEST(Frame, StateFrame)
   EXPECT_TRUE(worldElem->HasElement("state"));
   sdf::ElementPtr stateElem = worldElem->GetElement("state");
 
-  EXPECT_TRUE(stateElem->HasElement("model"));
-  sdf::ElementPtr modelStateElem = stateElem->GetElement("model");
+  EXPECT_TRUE(stateElem->HasElement("model_state"));
+  sdf::ElementPtr modelStateElem = stateElem->GetElement("model_state");
 
   // model
   EXPECT_TRUE(modelStateElem->HasAttribute("name"));
@@ -271,8 +271,8 @@ TEST(Frame, StateFrame)
   }
 
   // link
-  EXPECT_TRUE(modelStateElem->HasElement("link"));
-  sdf::ElementPtr linkStateElem = modelStateElem->GetElement("link");
+  EXPECT_TRUE(modelStateElem->HasElement("link_state"));
+  sdf::ElementPtr linkStateElem = modelStateElem->GetElement("link_state");
   EXPECT_TRUE(linkStateElem->HasAttribute("name"));
   EXPECT_EQ(linkStateElem->Get<std::string>("name"), "my_link");
 
@@ -286,8 +286,8 @@ TEST(Frame, StateFrame)
               gz::math::Pose3d(111, 3, 0, 0, 0, 0));
   }
 
-  EXPECT_TRUE(stateElem->HasElement("light"));
-  sdf::ElementPtr lightStateElem = stateElem->GetElement("light");
+  EXPECT_TRUE(stateElem->HasElement("light_state"));
+  sdf::ElementPtr lightStateElem = stateElem->GetElement("light_state");
 
   // light
   EXPECT_TRUE(lightStateElem->HasAttribute("name"));

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -114,33 +114,33 @@ TEST(NestedModel, State)
   sdfStr << "<sdf version ='" << SDF_VERSION << "'>"
     << "<world name='default'>"
     << "<state world_name='default'>"
-    << "<model name='model_00'>"
+    << "<model_state name='model_00'>"
     << "  <pose>0 0 0.5 0 0 0</pose>"
-    << "  <link name='link_00'>"
+    << "  <link_state name='link_00'>"
     << "    <pose>0 0 0.5 0 0 0</pose>"
     << "    <velocity>0.001 0 0 0 0 0</velocity>"
     << "    <acceleration>0 0.006121 0 0.012288 0 0.001751</acceleration>"
     << "    <wrench>0 0.006121 0 0 0 0</wrench>"
-    << "  </link>"
-    << "  <model name='model_01'>"
+    << "  </link_state>"
+    << "  <model_state name='model_01'>"
     << "    <pose>1 0 0.5 0 0 0</pose>"
-    << "    <link name='link_01'>"
+    << "    <link_state name='link_01'>"
     << "      <pose>1.25 0 0.5 0 0 0</pose>"
     << "      <velocity>0 -0.001 0 0 0 0</velocity>"
     << "      <acceleration>0 0.000674 0 -0.001268 0 0</acceleration>"
     << "      <wrench>0 0.000674 0 0 0 0</wrench>"
-    << "    </link>"
-    << "    <model name='model_02'>"
+    << "    </link_state>"
+    << "    <model_state name='model_02'>"
     << "      <pose>1 1 0.5 0 0 0</pose>"
-    << "      <link name='link_02'>"
+    << "      <link_state name='link_02'>"
     << "        <pose>1.25 1 0.5 0 0 0</pose>"
     << "        <velocity>0 0 0.001 0 0 0</velocity>"
     << "        <acceleration>0 0 0 0 0 0</acceleration>"
     << "        <wrench>0 0 0 0 0 0</wrench>"
-    << "      </link>"
-    << "    </model>"
-    << "  </model>"
-    << "</model>"
+    << "      </link_state>"
+    << "    </model_state>"
+    << "  </model_state>"
+    << "</model_state>"
     << "</state>"
     << "</world>"
     << "</sdf>";
@@ -154,9 +154,9 @@ TEST(NestedModel, State)
   sdf::ElementPtr worldElem = sdfParsed->Root()->GetElement("world");
   EXPECT_TRUE(worldElem->HasElement("state"));
   sdf::ElementPtr stateElem = worldElem->GetElement("state");
-  EXPECT_TRUE(stateElem->HasElement("model"));
+  EXPECT_TRUE(stateElem->HasElement("model_state"));
 
-  sdf::ElementPtr modelStateElem = stateElem->GetElement("model");
+  sdf::ElementPtr modelStateElem = stateElem->GetElement("model_state");
 
   // model sdf
   EXPECT_TRUE(modelStateElem->HasAttribute("name"));
@@ -164,11 +164,12 @@ TEST(NestedModel, State)
   EXPECT_TRUE(modelStateElem->HasElement("pose"));
   EXPECT_EQ(modelStateElem->Get<gz::math::Pose3d>("pose"),
     gz::math::Pose3d(0, 0, 0.5, 0, 0, 0));
-  EXPECT_TRUE(!modelStateElem->HasElement("joint"));
+  EXPECT_FALSE(modelStateElem->HasElement("joint"));
+  EXPECT_FALSE(modelStateElem->HasElement("joint_state"));
 
   // link sdf
-  EXPECT_TRUE(modelStateElem->HasElement("link"));
-  sdf::ElementPtr linkStateElem = modelStateElem->GetElement("link");
+  EXPECT_TRUE(modelStateElem->HasElement("link_state"));
+  sdf::ElementPtr linkStateElem = modelStateElem->GetElement("link_state");
   EXPECT_TRUE(linkStateElem->HasAttribute("name"));
   EXPECT_EQ(linkStateElem->Get<std::string>("name"), "link_00");
   EXPECT_TRUE(linkStateElem->HasElement("pose"));
@@ -185,20 +186,21 @@ TEST(NestedModel, State)
     gz::math::Pose3d(0, 0.006121, 0, 0, 0, 0));
 
   // nested model sdf
-  EXPECT_TRUE(modelStateElem->HasElement("model"));
+  EXPECT_TRUE(modelStateElem->HasElement("model_state"));
   sdf::ElementPtr nestedModelStateElem =
-    modelStateElem->GetElement("model");
+    modelStateElem->GetElement("model_state");
   EXPECT_TRUE(nestedModelStateElem->HasAttribute("name"));
   EXPECT_EQ(nestedModelStateElem->Get<std::string>("name"), "model_01");
   EXPECT_TRUE(nestedModelStateElem->HasElement("pose"));
   EXPECT_EQ(nestedModelStateElem->Get<gz::math::Pose3d>("pose"),
     gz::math::Pose3d(1, 0, 0.5, 0, 0, 0));
-  EXPECT_TRUE(!nestedModelStateElem->HasElement("joint"));
+  EXPECT_FALSE(nestedModelStateElem->HasElement("joint"));
+  EXPECT_FALSE(nestedModelStateElem->HasElement("joint_state"));
 
   // nested model's link sdf
-  EXPECT_TRUE(nestedModelStateElem->HasElement("link"));
+  EXPECT_TRUE(nestedModelStateElem->HasElement("link_state"));
   sdf::ElementPtr nestedLinkStateElem =
-    nestedModelStateElem->GetElement("link");
+    nestedModelStateElem->GetElement("link_state");
   EXPECT_TRUE(nestedLinkStateElem->HasAttribute("name"));
   EXPECT_EQ(nestedLinkStateElem->Get<std::string>("name"), "link_01");
   EXPECT_TRUE(nestedLinkStateElem->HasElement("pose"));
@@ -215,18 +217,19 @@ TEST(NestedModel, State)
     gz::math::Pose3d(0, 0.000674, 0, 0, 0, 0));
 
   // double nested model sdf
-  EXPECT_TRUE(nestedModelStateElem->HasElement("model"));
-  nestedModelStateElem = nestedModelStateElem->GetElement("model");
+  EXPECT_TRUE(nestedModelStateElem->HasElement("model_state"));
+  nestedModelStateElem = nestedModelStateElem->GetElement("model_state");
   EXPECT_TRUE(nestedModelStateElem->HasAttribute("name"));
   EXPECT_EQ(nestedModelStateElem->Get<std::string>("name"), "model_02");
   EXPECT_TRUE(nestedModelStateElem->HasElement("pose"));
   EXPECT_EQ(nestedModelStateElem->Get<gz::math::Pose3d>("pose"),
     gz::math::Pose3d(1, 1, 0.5, 0, 0, 0));
-  EXPECT_TRUE(!nestedModelStateElem->HasElement("joint"));
+  EXPECT_FALSE(nestedModelStateElem->HasElement("joint"));
+  EXPECT_FALSE(nestedModelStateElem->HasElement("joint_state"));
 
   // double nested model's link sdf
-  EXPECT_TRUE(nestedModelStateElem->HasElement("link"));
-  nestedLinkStateElem = nestedModelStateElem->GetElement("link");
+  EXPECT_TRUE(nestedModelStateElem->HasElement("link_state"));
+  nestedLinkStateElem = nestedModelStateElem->GetElement("link_state");
   EXPECT_TRUE(nestedLinkStateElem->HasAttribute("name"));
   EXPECT_EQ(nestedLinkStateElem->Get<std::string>("name"), "link_02");
   EXPECT_TRUE(nestedLinkStateElem->HasElement("pose"));


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/sdformat/issues/632, alternative to https://github.com/gazebosim/sdformat/pull/1377

## Summary

There is some overlap in the names used for elements in the `//world/state` specification and elsewhere, for example the [model_state.sdf](https://github.com/gazebosim/sdformat/blob/sdformat14_14.0.0/sdf/1.11/model_state.sdf#L2) file [included in state.sdf](https://github.com/gazebosim/sdformat/blob/sdformat14_14.0.0/sdf/1.11/state.sdf#L37) defines an element named [model](https://github.com/gazebosim/sdformat/blob/sdformat14_14.0.0/sdf/1.11/model_state.sdf#L2). This has caused challenges with aliasing in XSD (see https://github.com/gazebosim/sdformat/issues/632 and https://github.com/gazebosim/sdformat/pull/643), and it would be simpler if some of these elements had different names, so a `_state` suffix is appended to several subelements of the `//state` element. Additionally, the `//joint_state` definition is moved to its own file and included from `state.sdf` so that a `//state/joint_state` element can specify the state of a `//world/joint`.

I made a similar attempt at renaming these state elements in #1377 trying also to support backwards compatibility with a `1_11.convert` file but only achieving partial functionality. Given that the `//state` element hasn't been used in any version of gz-sim, this pull request opts for a breaking change instead of partial support for backwards compatibility.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
