### PR TITLE
Remove deprecated APIs for Ionic

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -41,6 +41,23 @@ but with improved human-readability..
    + ***Deprecation:*** void SetOpticalFrameId(const std::string &)
    + ***Replacement:*** void Sensor::SetFrameId(const std::string &)
 
+### Removals
+
+- **sdf/Joint.hh**:
+   + `const std::string &ChildLinkName() const` (use `ChildName()` instead)
+   + `const std::string &ParentLinkName() const` (use `ParentName()` instead)
+   + `void SetChildLinkName(const std::string &)` (use `SetChildName()` instead)
+   + `void SetParentLinkName(const std::string &)` (use `SetParentName()` instead)
+
+- **sdf/SDFImpl.hh**:
+   + `void Root(const ElementPtr)` (use `SetRoot(const ElementPtr)` instead)
+
+- **sdf/Types.hh**:
+   + `const std::string &kSdfScopeDelimiter` (use `kScopeDelimiter` instead)
+   + `const std::string &SdfScopeDelimiter()` (use `kScopeDelimiter` instead)
+
+- **sdf/parser.hh**:
+   + `bool checkJointParentChildLinkNames(const sdf::Root *)` (use `checkJointParentChildNames(const sdf::Root *)` instead)
 
 ## libsdformat 13.x to 14.x
 

--- a/include/sdf/Joint.hh
+++ b/include/sdf/Joint.hh
@@ -129,26 +129,6 @@ namespace sdf
     /// \param[in] _name Name of the child frame.
     public: void SetChildName(const std::string &_name);
 
-    /// \brief Get the name of this joint's parent link.
-    /// \return The name of the parent link.
-    /// \deprecated Use ParentName.
-    public: GZ_DEPRECATED(13) const std::string &ParentLinkName() const;
-
-    /// \brief Set the name of the parent link.
-    /// \param[in] _name Name of the parent link.
-    /// \deprecated Use SetParentName.
-    public: GZ_DEPRECATED(13) void SetParentLinkName(const std::string &_name);
-
-    /// \brief Get the name of this joint's child link.
-    /// \return The name of the child link.
-    /// \deprecated Use ChildName.
-    public: GZ_DEPRECATED(13) const std::string &ChildLinkName() const;
-
-    /// \brief Set the name of the child link.
-    /// \param[in] _name Name of the child link.
-    /// \deprecated Use SetChildName.
-    public: GZ_DEPRECATED(13) void SetChildLinkName(const std::string &_name);
-
     /// \brief Resolve the name of the child link from the
     /// FrameAttachedToGraph.
     /// \param[out] _body Name of child link of this joint.

--- a/include/sdf/SDFImpl.hh
+++ b/include/sdf/SDFImpl.hh
@@ -148,11 +148,6 @@ namespace sdf
     /// \param[in] _root Root element
     public: void SetRoot(const ElementPtr _root);
 
-    /// \brief Set the root pointer
-    /// \param[in] _root Root element
-    /// \deprecated Use SetRoot
-    public: GZ_DEPRECATED(13) void Root(const ElementPtr _root);
-
     /// \brief Get the path to the SDF document on disk.
     /// \return The full path to the SDF document.
     public: std::string FilePath() const;

--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -36,21 +36,7 @@ namespace sdf
   inline namespace SDF_VERSION_NAMESPACE {
   //
 
-  namespace internal
-  {
-    /// \brief Initializes the scope delimiter as a function-local static
-    /// variable so it can be used to initialize kSdfScopeDelimiter.
-    /// \note This should not be used directly in user code. It will likely be
-    /// removed in libsdformat 15 with kSdfScopeDelimiter.
-    SDFORMAT_VISIBLE const std::string &SdfScopeDelimiter();
-  }  // namespace internal
-
   constexpr std::string_view kScopeDelimiter{"::"};
-
-  // Deprecated because it violates the Google Style Guide as it is not
-  // trivially destructible. Please use sdf::kScopeDelimiter instead.
-  GZ_DEPRECATED(14)
-  inline const std::string &kSdfScopeDelimiter = internal::SdfScopeDelimiter();
 
   /// \brief The source path replacement if it was parsed from a string,
   /// instead of a file.
@@ -156,12 +142,6 @@ namespace sdf
 
     /// \brief Nanoseconds.
     public: int32_t nsec;
-  };
-
-  /// \brief A class for inertial information about a link.
-  class SDFORMAT_VISIBLE GZ_DEPRECATED(13) Inertia
-  {
-    public: double mass;
   };
 
   /// \brief Transforms a string to its lowercase equivalent

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -504,17 +504,6 @@ namespace sdf
   bool checkJointParentChildNames(const sdf::Root *_root);
 
   /// \brief Check that all joints in contained models specify parent
-  /// and child link names that match the names of sibling links.
-  /// This checks recursively and should check the files exhaustively
-  /// rather than terminating early when the first error is found.
-  /// \param[in] _root SDF Root object to check recursively.
-  /// \return True if all models have joints with valid parent and child
-  /// link names.
-  /// \deprecated Use checkJointParentChildNames.
-  SDFORMAT_VISIBLE GZ_DEPRECATED(13)
-  bool checkJointParentChildLinkNames(const sdf::Root *_root);
-
-  /// \brief Check that all joints in contained models specify parent
   /// and child names that match the names of sibling links, joints,
   /// models, or frames.
   /// This checks recursively and should check the files exhaustively

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -307,30 +307,6 @@ void Joint::SetChildName(const std::string &_name)
 }
 
 /////////////////////////////////////////////////
-const std::string &Joint::ParentLinkName() const
-{
-  return this->ParentName();
-}
-
-/////////////////////////////////////////////////
-void Joint::SetParentLinkName(const std::string &_name)
-{
-  this->SetParentName(_name);
-}
-
-/////////////////////////////////////////////////
-const std::string &Joint::ChildLinkName() const
-{
-  return this->ChildName();
-}
-
-/////////////////////////////////////////////////
-void Joint::SetChildLinkName(const std::string &_name)
-{
-  this->SetChildName(_name);
-}
-
-/////////////////////////////////////////////////
 const JointAxis *Joint::Axis(const unsigned int _index) const
 {
   return optionalToPointer(this->dataPtr->axis[std::min(_index, 1u)]);

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -30,10 +30,6 @@ TEST(DOMJoint, Construction)
 
   EXPECT_TRUE(joint.ParentName().empty());
   EXPECT_TRUE(joint.ChildName().empty());
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-  EXPECT_TRUE(joint.ParentLinkName().empty());
-  EXPECT_TRUE(joint.ChildLinkName().empty());
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   EXPECT_EQ(gz::math::Pose3d::Zero, joint.RawPose());
   EXPECT_TRUE(joint.PoseRelativeTo().empty());
@@ -64,18 +60,6 @@ TEST(DOMJoint, Construction)
 
   joint.SetName("test_joint");
   EXPECT_EQ("test_joint", joint.Name());
-
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-  joint.SetParentLinkName("parent");
-  EXPECT_EQ("parent", joint.ParentLinkName());
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
-  EXPECT_EQ("parent", joint.ParentName());
-
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-  joint.SetChildLinkName("child");
-  EXPECT_EQ("child", joint.ChildLinkName());
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
-  EXPECT_EQ("child", joint.ChildName());
 
   joint.SetParentName("parent2");
   EXPECT_EQ("parent2", joint.ParentName());

--- a/src/SDF.cc
+++ b/src/SDF.cc
@@ -384,12 +384,6 @@ void SDF::SetRoot(const ElementPtr _root)
 }
 
 /////////////////////////////////////////////////
-void SDF::Root(const ElementPtr _root)
-{
-  this->SetRoot(_root);
-}
-
-/////////////////////////////////////////////////
 std::string SDF::FilePath() const
 {
   return this->dataPtr->path;

--- a/src/SDF_TEST.cc
+++ b/src/SDF_TEST.cc
@@ -290,14 +290,6 @@ TEST(SDF, SetRoot)
   elem->AddValue("bool", "true", false, "description");
   s.SetRoot(elem);
   EXPECT_EQ(elem, s.Root());
-
-  // Test deprecated setter, remove in libsdformat14
-  s.SetRoot(nullptr);
-  EXPECT_EQ(nullptr, s.Root());
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-  s.Root(elem);
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
-  EXPECT_EQ(elem, s.Root());
 }
 
 ////////////////////////////////////////////////////

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -144,13 +144,5 @@ std::string JoinName(
   else
     return _scopeName + std::string(kScopeDelimiter) + _localName;
 }
-
-/////////////////////////////////////////////////
-const std::string &internal::SdfScopeDelimiter()
-{
-  static const gz::utils::NeverDestroyed<std::string> delimiter{
-      kScopeDelimiter};
-  return delimiter.Access();
-}
 }
 }

--- a/src/Types_TEST.cc
+++ b/src/Types_TEST.cc
@@ -200,11 +200,3 @@ TEST(Types, JoinName)
     EXPECT_EQ(joinedName, "");
   }
 }
-
-/////////////////////////////////////////////////
-TEST(Types, ScopeDelimiters)
-{
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-  EXPECT_EQ(sdf::kScopeDelimiter, sdf::kSdfScopeDelimiter);
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
-}

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -2725,12 +2725,6 @@ bool checkPoseRelativeToGraph(sdf::Errors &_errors, const sdf::Root *_root)
 }
 
 //////////////////////////////////////////////////
-bool checkJointParentChildLinkNames(const sdf::Root *_root)
-{
-  return checkJointParentChildNames(_root);
-}
-
-//////////////////////////////////////////////////
 bool checkJointParentChildNames(const sdf::Root *_root)
 {
   Errors errors;


### PR DESCRIPTION
# 🎉 New feature

Removes deprecated APIs

## Summary

These APIs were deprecated in `sdf13` or `sdf14`, so they can now be removed.

## Test it

Build gz-sim9 and confirm that it compiles successfully.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
