### PR TITLE
Revert "FrameSemantics: fix NullVertex warnings (#1458)"

### DIFF
--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -77,8 +77,6 @@ FindSourceVertex(const ScopedGraph<T> &_graph,
   using DirectedEdge = typename ScopedGraph<T>::Edge;
   using Vertex = typename ScopedGraph<T>::Vertex;
   using VertexId = gz::math::graph::VertexId;
-  using VertexType = typename ScopedGraph<T>::VertexType;
-  using gz::math::graph::NullVertex;
   using EdgesType = std::vector<DirectedEdge>;
   using PairType = std::pair<const Vertex &, EdgesType>;
   EdgesType edges;
@@ -88,7 +86,7 @@ FindSourceVertex(const ScopedGraph<T> &_graph,
     _errors.push_back({ErrorCode::POSE_RELATIVE_TO_INVALID,
         "Unable to resolve pose, invalid vertex[" + std::to_string(_id) + "] "
         "in PoseRelativeToGraph."});
-    return PairType(NullVertex<VertexType>(), EdgesType());
+    return PairType(Vertex::NullVertex, EdgesType());
   }
 
   if (_id == _graph.ScopeVertexId())
@@ -108,7 +106,7 @@ FindSourceVertex(const ScopedGraph<T> &_graph,
       _errors.push_back({ErrorCode::POSE_RELATIVE_TO_GRAPH_ERROR,
           "PoseRelativeToGraph error: multiple incoming edges to "
           "current vertex [" + vertex.get().Name() + "]."});
-      return PairType(NullVertex<VertexType>(), EdgesType());
+      return PairType(Vertex::NullVertex, EdgesType());
     }
     auto const &edge = incidentsTo.begin()->second;
     vertex = _graph.Graph().VertexFromId(edge.get().Vertices().first);
@@ -118,7 +116,7 @@ FindSourceVertex(const ScopedGraph<T> &_graph,
       _errors.push_back({ErrorCode::POSE_RELATIVE_TO_CYCLE,
           "PoseRelativeToGraph cycle detected, already visited vertex [" +
           vertex.get().Name() + "]."});
-      return PairType(NullVertex<VertexType>(), EdgesType());
+      return PairType(Vertex::NullVertex, EdgesType());
     }
     if (vertex.get().Id() == _graph.ScopeVertexId())
     {
@@ -131,7 +129,7 @@ FindSourceVertex(const ScopedGraph<T> &_graph,
   if (vertex.get().Id() != _graph.ScopeVertexId())
   {
     // Error, the root vertex is not the same as the the source
-    return PairType(NullVertex<VertexType>(), EdgesType());
+    return PairType(Vertex::NullVertex, EdgesType());
   }
 
   return PairType(vertex, edges);
@@ -159,8 +157,6 @@ FindSinkVertex(
   using DirectedEdge = typename ScopedGraph<T>::Edge;
   using Vertex = typename ScopedGraph<T>::Vertex;
   using VertexId = gz::math::graph::VertexId;
-  using VertexType = typename ScopedGraph<T>::VertexType;
-  using gz::math::graph::NullVertex;
   using EdgesType = std::vector<DirectedEdge>;
   using PairType = std::pair<const Vertex &, EdgesType>;
   EdgesType edges;
@@ -170,7 +166,7 @@ FindSinkVertex(
     _errors.push_back({ErrorCode::FRAME_ATTACHED_TO_INVALID,
         "Invalid vertex[" + std::to_string(_id) + "] "
         "in FrameAttachedToGraph."});
-    return PairType(NullVertex<VertexType>(), EdgesType());
+    return PairType(Vertex::NullVertex, EdgesType());
   }
 
   std::set<VertexId> visited;
@@ -184,7 +180,7 @@ FindSinkVertex(
       _errors.push_back({ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR,
           "FrameAttachedToGraph error: multiple outgoing edges from "
           "current vertex [" + vertex.get().Name() + "]."});
-      return PairType(NullVertex<VertexType>(), EdgesType());
+      return PairType(Vertex::NullVertex, EdgesType());
     }
     auto const &edge = incidentsFrom.begin()->second;
     vertex = _graph.Graph().VertexFromId(edge.get().Vertices().second);
@@ -194,7 +190,7 @@ FindSinkVertex(
       _errors.push_back({ErrorCode::FRAME_ATTACHED_TO_CYCLE,
           "FrameAttachedToGraph cycle detected, already visited vertex [" +
           vertex.get().Name() + "]."});
-      return PairType(NullVertex<VertexType>(), EdgesType());
+      return PairType(Vertex::NullVertex, EdgesType());
     }
     visited.insert(vertex.get().Id());
     incidentsFrom = _graph.Graph().IncidentsFrom(vertex);


### PR DESCRIPTION
# 🦟 Bug fix

This reverts commit e40331e67301f88580dcdcdeba012832d3b239ab.

## Summary

It appears that [#606](https://github.com/gazebosim/gz-math/pull/606) and https://github.com/gazebosim/sdformat/pull/1458 caused test failures in gz-sim (see https://github.com/osrf/buildfarm-tools/issues/67#issuecomment-2232120738). I opened a test PR in gz-sim (https://github.com/gazebosim/gz-sim/pull/2482) that builds against gz-math8 and sdformat15 with those changes reverted, and the tests were fixed:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-ci-pr_any-homebrew-amd64&build=637)](https://build.osrfoundation.org/job/gz_sim-ci-pr_any-homebrew-amd64/637/) https://build.osrfoundation.org/job/gz_sim-ci-pr_any-homebrew-amd64/637/

I don't know why this broke tests, but I propose reverting these changes for now until we can figure it out.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-Merge**.
