### PR TITLE
Spec 1.12: link_state, joint_state changes

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -628,6 +628,16 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 
 ## SDFormat specification 1.11 to 1.12
 
+### Additions
+
+1. **joint_state.sdf**:
+    + `//joint_state/axis_state/position`
+    + `//joint_state/axis_state/velocity`
+    + `//joint_state/axis_state/acceleration`
+    + `//joint_state/axis2_state/position`
+    + `//joint_state/axis2_state/velocity`
+    + `//joint_state/axis2_state/acceleration`
+
 ### Modifications
 
 1. **state.sdf**, **model_state.sdf**, **joint_state.sdf**, **link_state.sdf**,
@@ -643,6 +653,12 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 
 1. **state.sdf**: `//state/joint_state` has been added to represent the state of a
     `//world/joint`.
+
+### Deprecations
+
+1. **joint_state.sdf**:
+    + `//joint_state/angle` is deprecated in favor of `//axis_state/position`
+      and  `//axis2_state/position`.
 
 ## SDFormat specification 1.10 to 1.11
 

--- a/Migration.md
+++ b/Migration.md
@@ -638,6 +638,12 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
     + `//joint_state/axis2_state/velocity`
     + `//joint_state/axis2_state/acceleration`
 
+1. **link_state.sdf**:
+    + `//link_state/linear_velocity`
+    + `//link_state/angular_velocity`
+    + `//link_state/linear_acceleration`
+    + `//link_state/angular_acceleration`
+
 ### Modifications
 
 1. **state.sdf**, **model_state.sdf**, **joint_state.sdf**, **link_state.sdf**,
@@ -659,6 +665,12 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 1. **joint_state.sdf**:
     + `//joint_state/angle` is deprecated in favor of `//axis_state/position`
       and  `//axis2_state/position`.
+
+1. **link_state.sdf**:
+    + `//link_state/velocity` is deprecated in favor of `//link_state/angular_velocity`
+      and  `//link_state/linear_velocity`.
+    + `//link_state/acceleration` is deprecated in favor of `//link_state/angular_acceleration`
+      and  `//link_state/linear_acceleration`.
 
 ## SDFormat specification 1.10 to 1.11
 

--- a/sdf/1.12/joint_state.sdf
+++ b/sdf/1.12/joint_state.sdf
@@ -1,16 +1,98 @@
 <!-- State information for a joint -->
 <element name="joint_state" required="*">
-  <description>Joint angle</description>
+  <description>State of the joint</description>
 
   <attribute name="name" type="string" default="__default__" required="1">
     <description>Name of the joint</description>
   </attribute>
 
-  <element name="angle" type="double" default="0" required="+">
+  <element name="angle" type="double" default="0" required="-1">
     <attribute name="axis" type="unsigned int" default="0" required="1">
       <description>Index of the axis.</description>
     </attribute>
 
     <description>Angle of an axis</description>
+  </element>
+
+  <element name="axis_state" required="0">
+    <description>
+      Contains the state of the first joint axis.
+    </description>
+
+    <element name="position" type="double" default="0" required="0">
+      <description>The position of the first joint axis.</description>
+
+      <attribute name="degrees" type="bool" default="false" required="0">
+        <description>
+          Whether or not the joint position is interpreted in degrees,
+          otherwise they will be interpreted as radians by default.
+        </description>
+      </attribute>
+    </element>
+
+    <element name="velocity" type="double" default="0" required="0">
+      <description>The velocity of the first joint axis.</description>
+
+      <attribute name="degrees" type="bool" default="false" required="0">
+        <description>
+          Whether or not the joint velocity is interpreted in degrees per
+          second, otherwise they will be interpreted as radians per second
+          by default.
+        </description>
+      </attribute>
+    </element>
+
+    <element name="acceleration" type="double" default="0" required="0">
+      <description>The acceleration of the first joint axis.</description>
+
+      <attribute name="degrees" type="bool" default="false" required="0">
+        <description>
+          Whether or not the joint acceleration is interpreted in degrees per
+          second per second, otherwise they will be interpreted as radians per
+          second per second by default.
+        </description>
+      </attribute>
+    </element>
+  </element>
+
+  <element name="axis2_state" required="0">
+    <description>
+      Contains the state of the second joint axis.
+    </description>
+
+    <element name="position" type="double" default="0" required="0">
+      <description>The position of the second joint axis.</description>
+
+      <attribute name="degrees" type="bool" default="false" required="0">
+        <description>
+          Whether or not the joint position is interpreted in degrees,
+          otherwise they will be interpreted as radians by default.
+        </description>
+      </attribute>
+    </element>
+
+    <element name="velocity" type="double" default="0" required="0">
+      <description>The velocity of the second joint axis.</description>
+
+      <attribute name="degrees" type="bool" default="false" required="0">
+        <description>
+          Whether or not the joint velocity is interpreted in degrees per
+          second, otherwise they will be interpreted as radians per second
+          by default.
+        </description>
+      </attribute>
+    </element>
+
+    <element name="acceleration" type="double" default="0" required="0">
+      <description>The acceleration of the second joint axis.</description>
+
+      <attribute name="degrees" type="bool" default="false" required="0">
+        <description>
+          Whether or not the joint acceleration is interpreted in degrees per
+          second per second, otherwise they will be interpreted as radians per
+          second per second by default.
+        </description>
+      </attribute>
+    </element>
   </element>
 </element> <!-- End Joint -->

--- a/sdf/1.12/link_state.sdf
+++ b/sdf/1.12/link_state.sdf
@@ -6,14 +6,34 @@
     <description>Name of the link</description>
   </attribute>
 
-  <element name="velocity" type="pose" default="0 0 0 0 0 0" required="0">
+  <element name="angular_velocity" type="vector3" default="0 0 0 0 0 0" required="0">
+    <description>Angular velocity of the link relative to the world frame.
+    </description>
+  </element>
+
+  <element name="linear_velocity" type="vector3" default="0 0 0 0 0 0" required="0">
+    <description>Linear velocity of the link relative to the world frame.
+    </description>
+  </element>
+
+  <element name="velocity" type="pose" default="0 0 0 0 0 0" required="-1">
     <description>Velocity of the link. The x, y, z components of the pose
       correspond to the linear velocity of the link, and the roll, pitch, yaw
       components correspond to the angular velocity of the link
     </description>
   </element>
 
-  <element name="acceleration" type="pose" default="0 0 0 0 0 0" required="0">
+  <element name="angular_acceleration" type="vector3" default="0 0 0 0 0 0" required="0">
+    <description>Angular acceleration of the link relative to the world frame.
+    </description>
+  </element>
+
+  <element name="linear_acceleration" type="vector3" default="0 0 0 0 0 0" required="0">
+    <description>Linear acceleration of the link relative to the world frame.
+    </description>
+  </element>
+
+  <element name="acceleration" type="pose" default="0 0 0 0 0 0" required="-1">
     <description>Acceleration of the link. The x, y, z components of the pose
       correspond to the linear acceleration of the link, and the roll,
       pitch, yaw components correspond to the angular acceleration of the link


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/sdformat/issues/1366, https://github.com/gazebosim/sdformat/issues/83

## Summary

work in progress

consider adding

* `//link_state/wrench_force` and `//link_state/wrench_torque`
* `//link_state/angular_*/@degrees` (see https://github.com/gazebosim/gz-sim/pull/2440)
* `//axis*_state/effort` (similar to wrench but just for the single axis)
* DOM objects

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
