### PR TITLE
Expand SDF description on link kinematic property

### DIFF
--- a/sdf/1.12/link.sdf
+++ b/sdf/1.12/link.sdf
@@ -19,7 +19,7 @@
   </element>
 
   <element name="kinematic" type="bool" default="false" required="0">
-    <description>If true, the link is kinematic only. A kinematic link does not react to forces such as gravity, applied force / torque, or influences from other dynamic bodies. The link can be animated by changing its position or velocity. Kinematic links can also be connected by joints, and moved by joint position or velcoity commands.</description>
+    <description>If true, the link is kinematic only. A kinematic link does not react to forces such as gravity, applied force / torque, or influences from other dynamic bodies. The link can be animated by changing its position or velocity. Kinematic links can also be connected by joints, and moved by joint position or velocity commands.</description>
   </element>
 
   <element name="must_be_base_link" type="bool" default="false" required="0">

--- a/sdf/1.12/link.sdf
+++ b/sdf/1.12/link.sdf
@@ -19,7 +19,7 @@
   </element>
 
   <element name="kinematic" type="bool" default="false" required="0">
-    <description>If true, the link is kinematic only</description>
+    <description>If true, the link is kinematic only. A kinematic link does not react to forces such as gravity, applied force / torque, or influences from other dynamic bodies. The link can be animated by changing its position or velocity. Kinematic links can also be connected by joints, and moved by joint position or velcoity commands.</description>
   </element>
 
   <element name="must_be_base_link" type="bool" default="false" required="0">


### PR DESCRIPTION



# 🎉 New feature

Related PR: https://github.com/gazebosim/gz-physics/pull/618

## Summary

Added more documentation on what kinematic only mode means for a link. Consulted bullet / dart / ode documentation (as pointed out in https://github.com/gazebosim/gz-physics/pull/618#issuecomment-2164297268) and extract common properties from their descriptions.

I think not all physics engine support joints between dynamic and kinematic links so I left that out in our SDF description.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

