### PR TITLE
Prepare for sdformat 14.5.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat14 VERSION 14.4.0)
+project (sdformat14 VERSION 14.5.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,25 @@
 ## libsdformat 14.X
 
+### libsdformat 14.5.0 (2024-08-05)
+
+1. Adding Errors structure to XmlUtils
+    * [Pull request #1296](https://github.com/gazebosim/sdformat/pull/1296)
+
+1. Disable latex and class hierarchy generation
+    * [Pull request #1447](https://github.com/gazebosim/sdformat/pull/1447)
+
+1. Added SetHeightMap and Heighmap to Geometry Python binding
+    * [Pull request #1440](https://github.com/gazebosim/sdformat/pull/1440)
+
+1. workflows/ci.yml fix push branch regex
+    * [Pull request #1445](https://github.com/gazebosim/sdformat/pull/1445)
+
+1. SDF.cc update calls to use sdf::Errors output
+    * [Pull request #1295](https://github.com/gazebosim/sdformat/pull/1295)
+
+1. Added World::ActorByName
+    * [Pull request #1436](https://github.com/gazebosim/sdformat/pull/1436)
+
 ### libsdformat 14.4.0 (2024-06-20)
 
 1. Add Cone as a primitive parametric shape.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat14</name>
-  <version>14.4.0</version>
+  <version>14.5.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION


# 🎈 Release

Preparation for 14.5.0 release.

Comparison to 14.4.0: https://github.com/gazebosim/sdformat/compare/sdformat14_14.4.0...prep_14.5.0

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sim/pull/2504

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
