### PR TITLE
Decouple linking to shlwapi from BUILD_TESTING

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,11 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PRIVATE
     TINYXML2::TINYXML2)
 
+if (WIN32)
+  target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+    PRIVATE shlwapi)
+endif()
+
   if (USE_INTERNAL_URDF)
     target_include_directories(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
@@ -108,11 +113,6 @@ if (BUILD_TESTING)
     $<TARGET_PROPERTY:${PROJECT_LIBRARY_TARGET_NAME},COMPILE_DEFINITIONS>
     -DGZ_SDFORMAT_STATIC_DEFINE
   )
-
-  if(WIN32)
-    target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
-      PRIVATE shlwapi)
-  endif()
 
   gz_build_tests(
     TYPE UNIT


### PR DESCRIPTION
# 🦟 Bug fix

Fixing test failures discussed in https://github.com/gazebosim/sdformat/pull/1414#issuecomment-2297021793.

## Summary

The windows builds were broken with `-DBUILD_TESTING=OFF` (see https://github.com/gazebosim/sdformat/pull/1414#issuecomment-2297021793), so move the `target_link_libraries` call outside the `if (BUILD_TESTING)` logical block.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
