### PR TITLE
Update joinPaths implementation in InstallationDirectories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,11 +49,6 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PRIVATE
     TINYXML2::TINYXML2)
 
-if (WIN32)
-  target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
-    PRIVATE shlwapi)
-endif()
-
   if (USE_INTERNAL_URDF)
     target_include_directories(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/urdf)


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Updates the copy of `jointPaths` code in InstallationDirectories.cc to the version in gz-common5.
Removes dep on `shlwapi` on windows.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
