### PR TITLE
Prepare for Ionic prerelease

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if (BUILD_SDF)
   gz_configure_project(
     NO_PROJECT_PREFIX
     REPLACE_INCLUDE_PATH sdf
-    VERSION_SUFFIX)
+    VERSION_SUFFIX pre1)
 
   #################################################
   # Find tinyxml2.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 1. **Baseline:** this includes all changes from 14.5.0 and earlier.
 
 1. README: update badges for sdf15
-    * [Pull request #README: update badges for sdf15](https://github.com/gazebosim/sdformat/pull/README: update badges for sdf15)
+    * [Pull request #1472](https://github.com/gazebosim/sdformat/pull/1472)
 
 1. Ionic Changelog
     * [Pull request #1471](https://github.com/gazebosim/sdformat/pull/1471)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,14 @@
 
 ### libsdformat 15.0.0 (2024-09-XX)
 
+1. **Baseline:** this includes all changes from 14.5.0 and earlier.
+
+1. README: update badges for sdf15
+    * [Pull request #README: update badges for sdf15](https://github.com/gazebosim/sdformat/pull/README: update badges for sdf15)
+
+1. Ionic Changelog
+    * [Pull request #1471](https://github.com/gazebosim/sdformat/pull/1471)
+
 1. Spec 1.12: add `_state` suffix to //state subelements
     * [Pull request #1455](https://github.com/gazebosim/sdformat/pull/1455)
 
@@ -27,6 +35,10 @@
 1. Print auto inertial values with `gz sdf --print --expand-auto-inertials`
     * [Pull request #1422](https://github.com/gazebosim/sdformat/pull/1422)
 
+1. Add cone shape to SDFormat spec
+    * [Pull request #1418](https://github.com/gazebosim/sdformat/pull/1418)
+    * [Pull request #1434](https://github.com/gazebosim/sdformat/pull/1434)
+
 1. Enable 24.04 CI, remove distutils dependency
     * [Pull request #1408](https://github.com/gazebosim/sdformat/pull/1408)
 
@@ -37,6 +49,11 @@
     * [Pull request #1390](https://github.com/gazebosim/sdformat/pull/1390)
     * [Pull request #1399](https://github.com/gazebosim/sdformat/pull/1399)
     * [Pull request #1462](https://github.com/gazebosim/sdformat/pull/1462)
+
+1. Spec 1.11+: add `//mesh/@optimization`, `//mesh/convex_decomposition`
+    * [Pull request #1382](https://github.com/gazebosim/sdformat/pull/1382)
+    * [Pull request #1386](https://github.com/gazebosim/sdformat/pull/1386)
+    * [Pull request #1403](https://github.com/gazebosim/sdformat/pull/1403)
 
 1. Copy 1.11 spec to 1.12 for libsdformat15
     * [Pull request #1375](https://github.com/gazebosim/sdformat/pull/1375)


### PR DESCRIPTION
# 🎈 Release

Preparation for `15.0.0~pre1` release.

Comparison to 14.5.0: https://github.com/gazebosim/sdformat/compare/sdformat14_14.5.0...sdf15

Used https://github.com/gazebo-tooling/release-tools/pull/1175 to generate the changelog baseline entry

## Checklist
- [X] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
