### PR TITLE
Fix symbol checking test when compiled with debug symbols

### DIFF
--- a/test/integration/all_symbols_have_version.bash.in
+++ b/test/integration/all_symbols_have_version.bash.in
@@ -7,7 +7,7 @@ VERSIONED_NS=v@PROJECT_VERSION_MAJOR@
 
 # nm options:
 # -D to get only dynamic symbols exported
-# 3 before the sdf is <lenght, id> used by
+# 3 before the sdf is <length, id> used by
 # mangled symbols in C++ to check for the
 # sdf namespace
 NUM_SYMBOLS=$(nm -D $LIBPATH | grep -e "3sdf" | wc -l)

--- a/test/integration/all_symbols_have_version.bash.in
+++ b/test/integration/all_symbols_have_version.bash.in
@@ -4,7 +4,13 @@ LIBPATH=$1
 VERSIONED_NS=v@PROJECT_VERSION_MAJOR@
 
 # Sanity check - there should be at least one symbol
-NUM_SYMBOLS=$(nm $LIBPATH | grep -e "sdf" | wc -l)
+
+# nm options:
+# -D to get only dynamic symbols exported
+# 3 before the sdf is <lenght, id> used by
+# mangled symbols in C++ to check for the
+# sdf namespace
+NUM_SYMBOLS=$(nm -D $LIBPATH | grep -e "3sdf" | wc -l)
 
 if [ $NUM_SYMBOLS -eq 0 ]
 then
@@ -13,7 +19,7 @@ then
 fi
 
 # There must be no unversioned symbols
-UNVERSIONED_SYMBOLS=$(nm $LIBPATH | grep -e "sdf" | grep -e "$VERSIONED_NS" -v)
+UNVERSIONED_SYMBOLS=$(nm -D $LIBPATH | grep -e "3sdf" | grep -e "$VERSIONED_NS" -v)
 UNVERSIONED_SYMBOL_CHARS=$(printf "$UNVERSIONED_SYMBOLS" | wc -m)
 
 if [ $UNVERSIONED_SYMBOL_CHARS -ne 0 ]


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The test that checks for prefixed binary symbols was broken when compiled with DebWithRelInfo since it was checking debugging symbols that broke the heuristics used.

The commit fixes it doing a couple of actions:
  *  Include the length of the namespace sdf according to the mangling rules: `3sdf`
  *  Check only dynamic symbols being exported

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.