### PR TITLE
Prepare for 15.0.0~pre2, update changelog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if (BUILD_SDF)
   gz_configure_project(
     NO_PROJECT_PREFIX
     REPLACE_INCLUDE_PATH sdf
-    VERSION_SUFFIX pre1)
+    VERSION_SUFFIX pre2)
 
   #################################################
   # Find tinyxml2.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 1. **Baseline:** this includes all changes from 14.5.0 and earlier.
 
+1. Fix symbol checking test when compiled with debug symbols
+    * [Pull request #1474](https://github.com/gazebosim/sdformat/pull/1474)
+
 1. README: update badges for sdf15
     * [Pull request #1472](https://github.com/gazebosim/sdformat/pull/1472)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 15.0.0~pre2 release.

Comparison to 15.0.0~pre1: https://github.com/gazebosim/sdformat/compare/sdformat15_15.0.0-pre1...sdf15

The debbuild was broken, should be fixed by #1474

## Checklist
- [X] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
