### PR TITLE
Use std::vector::reserve in Element::Clone

### DIFF
--- a/src/Element.cc
+++ b/src/Element.cc
@@ -252,6 +252,7 @@ ElementPtr Element::Clone(sdf::Errors &_errors) const
   clone->dataPtr->explicitlySetInFile = this->dataPtr->explicitlySetInFile;
 
   Param_V::const_iterator aiter;
+  clone->dataPtr->attributes.reserve(this->dataPtr->attributes.size());
   for (aiter = this->dataPtr->attributes.begin();
        aiter != this->dataPtr->attributes.end(); ++aiter)
   {
@@ -263,12 +264,15 @@ ElementPtr Element::Clone(sdf::Errors &_errors) const
   }
 
   ElementPtr_V::const_iterator eiter;
+  clone->dataPtr->elementDescriptions.reserve(
+    this->dataPtr->elementDescriptions.size());
   for (eiter = this->dataPtr->elementDescriptions.begin();
       eiter != this->dataPtr->elementDescriptions.end(); ++eiter)
   {
     clone->dataPtr->elementDescriptions.push_back((*eiter)->Clone(_errors));
   }
 
+  clone->dataPtr->elements.reserve(this->dataPtr->elements.size());
   for (eiter = this->dataPtr->elements.begin();
        eiter != this->dataPtr->elements.end(); ++eiter)
   {


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/sdformat/issues/1478

## Summary

The performance of `Element::Clone` is poor, as noted in #1478. This is a small change to attempt to improve memory allocation.

There are several for-loops in `Element::Clone` that call `std::vector::push_back`, and since the vector size is known in advance, use `std::vector::reserve` to avoid multiple vector resizes.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
