### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ git clone https://github.com/gazebosim/sdformat -b sdf<#>
 Be sure to replace `<#>` with a number value, such as 14 or 15, depending on
 which version you need.
 
+### Install dependencies
+
+#### Ubuntu
+
+```sh
+cd sdformat
+sudo apt -y install \
+  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | tr '\n' ' '))
+```
+
+#### macOS
+
+```sh
+brew install --only-dependencies sdformat<#>
+```
+
+Be sure to replace `<#>` with a number value, such as 14 or 15, depending on
+which version you need.
+
 ### Build from Source
 
 Standard installation can be performed in UNIX systems using the following
@@ -157,44 +176,6 @@ To uninstall the software installed with the previous steps:
 cd build
 make uninstall
 ```
-
-## macOS
-
-### Prerequisites
-
-Clone the repository
-```sh
-git clone https://github.com/gazebosim/sdformat -b sdf<#>
-```
-Be sure to replace `<#>` with a number value, such as 14 or 15, depending on
-which version you need.
-
-Install dependencies
-```sh
-brew install --only-dependencies sdformat<#>
-```
-
-### Build from Source
-
-1. Configure and build
-  ```sh
-  cd sdformat
-  mkdir build
-  cd build
-  cmake .. # Consider specifying -DCMAKE_INSTALL_PREFIX=...
-  make
-  ```
-
-2. Optionally, install and uninstall
-  ```sh
-  sudo make install
-  ```
-
-  To uninstall the software installed with the previous steps:
-  ```sh
-  cd build/
-  sudo make uninstall
-  ```
 
 ## Windows
 


### PR DESCRIPTION
# 🦟 Bug fix

Improves installation instructions in README

## Summary

* Refer to https://brew.sh/ instead of duplicating the brew installation command.
* List cmake variables in a markdown table.
* Combine Ubuntu and macOS build-from-source instructions (https://github.com/gazebosim/sdformat/commit/85e50675bd7b975ca9130fbbd8832a0ae6105593)

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
