### PR TITLE
Prepare for 13.9.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat13 VERSION 13.8.0)
+project (sdformat13 VERSION 13.9.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 ## libsdformat 13.X
 
+### libsdformat 13.9.0 (2024-11-06)
+
+1. Add Errors structure to XmlUtils
+    * [Pull request #1296](https://github.com/gazebosim/sdformat/pull/1296)
+
+1. Disable latex and class hierarchy generation
+    * [Pull request #1447](https://github.com/gazebosim/sdformat/pull/1447)
+
+1. SDF.cc update calls to use sdf::Errors output
+    * [Pull request #1295](https://github.com/gazebosim/sdformat/pull/1295)
+
 ### libsdformat 13.8.0 (2024-06-25)
 
 1. Added `World::ActorByName`


### PR DESCRIPTION
# 🎈 Release

Preparation for 13.9.0 release. **This will be the final release of sdf13 as it has reached [EOL with Garden](https://github.com/gazebosim/docs/blob/master/tools/versions.md)**

Part of https://github.com/gazebo-tooling/release-tools/issues/1165

Comparison to 13.8.0: https://github.com/gazebosim/sdformat/compare/sdformat13_13.8.0...sdf13

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.