### PR TITLE
Prepare for 15.1.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat15 VERSION 15.0.0)
+project (sdformat15 VERSION 15.1.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,34 @@
 ## libsdformat 15.X
 
+### libsdformat 15.1.0 (2024-11-13)
+
+1. Bazel CI
+    * [Pull request #1500](https://github.com/gazebosim/sdformat/pull/1500)
+
+1. Add bzlmod support to sdf15
+    * [Pull request #1493](https://github.com/gazebosim/sdformat/pull/1493)
+
+1. Support removing the actor, light, or model from the root
+    * [Pull request #1492](https://github.com/gazebosim/sdformat/pull/1492)
+
+1. Only look for psutil if testing is enabled
+    * [Pull request #1495](https://github.com/gazebosim/sdformat/pull/1495)
+
+1. Improve installation instructions
+    * [Pull request #1496](https://github.com/gazebosim/sdformat/pull/1496)
+
+1. Permit building python bindings separately from libsdformat library
+    * [Pull request #1491](https://github.com/gazebosim/sdformat/pull/1491)
+
+1. Change sdf\_config.h to sdf/config.hh everywhere
+    * [Pull request #1494](https://github.com/gazebosim/sdformat/pull/1494)
+
+1. Improve installation instructions
+    * [Pull request #1490](https://github.com/gazebosim/sdformat/pull/1490)
+
+1. Fix symbol checking test when compiled with debug symbols
+    * [Pull request #1474](https://github.com/gazebosim/sdformat/pull/1474)
+
 ### libsdformat 15.0.0 (2024-09-25)
 
 1. **Baseline:** this includes all changes from 14.5.0 and earlier.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat15</name>
-  <version>15.0.0</version>
+  <version>15.1.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 15.1.0 release.

Comparison to 15.0.0: https://github.com/osrf/sdformat/compare/sdformat15_15.0.0...sdf15

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.