### PR TITLE
python bindings: get version from package.xml

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Detect if we are doing a standalone build of the bindings, using an external sdformat
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   cmake_minimum_required(VERSION 3.22.1)
-  set(SDF_VER 15)
-  project(sdformat${SDF_VER}-python VERSION ${SDF_VER})
-  find_package(sdformat${SDF_VER} REQUIRED)
+  find_package(gz-cmake4 4.1.0 REQUIRED)
+  gz_get_package_xml_version(${CMAKE_SOURCE_DIR}/../package.xml PACKAGE_XML)
+  project(sdformat${PACKAGE_XML_VERSION_MAJOR}-python VERSION ${PACKAGE_XML_VERSION})
+  find_package(sdformat${PROJECT_VERSION_MAJOR} REQUIRED)
   set(PROJECT_LIBRARY_TARGET_NAME "sdformat${PROJECT_VERSION_MAJOR}::sdformat${PROJECT_VERSION_MAJOR}")
   # require python dependencies to be found
   find_package(Python3 COMPONENTS Interpreter Development REQUIRED)


### PR DESCRIPTION
# 🎉 New feature

Similar to https://github.com/gazebosim/gz-math/pull/642 using https://github.com/gazebosim/gz-cmake/pull/456 from gz-cmake 4.1.0

## Summary

When building python bindings separately from the main library, the major version of libsdformat has been hard-coded, but this changes it to parse the version number from the `package.xml` file in this repository using a gz-cmake feature added in https://github.com/gazebosim/gz-cmake/pull/456 and released in 4.1.0. We could also consider using this feature in the root CMakeLists.txt file, but for now it is just used when building python bindings separately from the main library.

## Test it

1. Configure the `python` folder:

~~~
cd python
mkdir build
cd build
cmake ..
~~~

2. Verify that it found `sdformat15`

~~~
-- Looking for sdformat15 -- found version 15.0.0
~~~

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
