### PR TITLE
Prepare for release 15.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat15 VERSION 15.1.0)
+project (sdformat15 VERSION 15.1.1)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
     * [Pull request #1507](https://github.com/gazebosim/sdformat/pull/1507)
   
 1. Enable header layering checks for bazel build
-    * [Pull request #1505(https://github.com/gazebosim/sdformat/pull/15057)
+    * [Pull request #1505](https://github.com/gazebosim/sdformat/pull/1505)
 
 ### libsdformat 15.1.0 (2024-11-13)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@
 
 1. Fix bazel rules for layering_check and parse_headers with clang
     * [Pull request #1507](https://github.com/gazebosim/sdformat/pull/1507)
+  
+1. Enable header layering checks for bazel build
+    * [Pull request #1505(https://github.com/gazebosim/sdformat/pull/15057)
 
 ### libsdformat 15.1.0 (2024-11-13)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 ## libsdformat 15.X
 
+### libsdformat 15.1.1 (2024-11-15)
+
+1. **Baseline:** this includes all changes from 15.1.0 and earlier.
+
+1. Fix bazel rules for layering_check and parse_headers with clang
+    * [Pull request #1507](https://github.com/gazebosim/sdformat/pull/1507)
+
 ### libsdformat 15.1.0 (2024-11-13)
 
 1. Bazel CI

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat15</name>
-  <version>15.1.0</version>
+  <version>15.1.1</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 15.1.1 release.

Comparison to 15.1.0: https://github.com/gazebosim/sdformat/compare/sdformat15_15.1.0...sdf1

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
