### PR TITLE
Permit to test when building bindings separately from main library

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,6 +10,12 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(CMAKE_REQUIRE_FIND_PACKAGE_pybind11 TRUE)
   include(GNUInstallDirs)
   include(CTest)
+
+  if(BUILD_TESTING)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../test/test_config.hh.in 
+                   ${PROJECT_BINARY_DIR}/include/test_config.hh)
+    include_directories(${PROJECT_BINARY_DIR}/include)
+  endif()
 endif()
 
 set(PYBIND11_PYTHON_VERSION 3)
@@ -199,10 +205,10 @@ if (BUILD_TESTING AND NOT WIN32)
   foreach (test ${python_tests})
     if (pytest_FOUND)
       add_test(NAME ${test}.py COMMAND
-        "${Python3_EXECUTABLE}" -m pytest "${CMAKE_SOURCE_DIR}/python/test/${test}.py" --junitxml "${CMAKE_BINARY_DIR}/test_results/${test}.xml")
+        "${Python3_EXECUTABLE}" -m pytest "${CMAKE_CURRENT_SOURCE_DIR}/test/${test}.py" --junitxml "${CMAKE_BINARY_DIR}/test_results/${test}.xml")
     else()
       add_test(NAME ${test}.py COMMAND
-        "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/python/test/${test}.py")
+        "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test/${test}.py")
     endif()
     set(_env_vars)
     list(APPEND _env_vars "PYTHONPATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/python/:${CMAKE_BINARY_DIR}/lib:$ENV{PYTHONPATH}")


### PR DESCRIPTION
# 🦟 Bug fix

Follow up of https://github.com/gazebosim/sdformat/pull/1491 . https://github.com/gazebosim/sdformat/pull/1491 enable the compilation of bindings separately from the main library, but does not permit to set `BUILD_TESTING:BOOL=ON` in those binding-only builds. 

## Summary

This PR permits to pass `-DBUILD_TESTING:BOOL=ON` in bindings-only builds, by:
* Ensuring that `${PROJECT_BINARY_DIR}/include/test_config.hh` is generated also in bindings-only builds,
* Use `CMAKE_CURRENT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR` when creating the tests, as the `CMAKE_CURRENT_SOURCE_DIR` variable have a consistent value that is not influenced on which is the root directory of the CMake build.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
