### PR TITLE
sdf 14.6.0 prep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat14 VERSION 14.5.0)
+project (sdformat14 VERSION 14.6.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,28 @@
 ## libsdformat 14.X
 
+### libsdformat 14.6.0 (2024-11-18)
+
+1. Support removing the actor, light, or model from the root.
+    * [Pull request #1492](https://github.com/gazebosim/sdformat/pull/1492)
+
+1. Backport: Permit building python bindings separately from libsdformat library.
+    * [Pull request #1497](https://github.com/gazebosim/sdformat/pull/1497)
+
+1. Backport: Improve installation instructions.
+    * [Pull request #1496](https://github.com/gazebosim/sdformat/pull/1496)
+
+1. Backport: Fix symbol checking test when compiled with debug symbols.
+    * [Pull request #1476](https://github.com/gazebosim/sdformat/pull/1476)
+
+1. Update joinPaths implementation in InstallationDirectories.
+    * [Pull request #1469](https://github.com/gazebosim/sdformat/pull/1469)
+
+1. Decouple linking to shlwapi from `BUILD_TESTING`.
+    * [Pull request #1468](https://github.com/gazebosim/sdformat/pull/1468)
+
+1. Add optional binary relocatability.
+    * [Pull request #1414](https://github.com/gazebosim/sdformat/pull/1414)
+
 ### libsdformat 14.5.0 (2024-08-05)
 
 1. Adding Errors structure to XmlUtils


### PR DESCRIPTION
# 🎈 Release

Preparation for 14.6.0 release.

Comparison to 14.5.0: https://github.com/gazebosim/sdformat/compare/sdformat14_14.5.0...sdf14

Needed by [<PR(s)>](https://github.com/gazebosim/gz-sim/pull/2672)

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
