### PR TITLE
Add tests for auto-inertial with explicit mass

### DIFF
--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -2021,6 +2021,19 @@ TEST(inertial_stats, SDF)
     EXPECT_EQ(expectedOutput, output);
   }
 
+  // Check a good SDF file with auto-inertials and explicit mass
+  // from the same folder by passing a relative path
+  {
+    std::string path = "inertial_stats_auto_mass.sdf";
+    const auto pathBase = sdf::testing::TestFile("sdf");
+
+    std::string output =
+      custom_exec_str("cd " + pathBase + " && " +
+                      GzCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+
   expectedOutput =
           "Error Code " +
           std::to_string(static_cast<int>(

--- a/test/integration/link_dom.cc
+++ b/test/integration/link_dom.cc
@@ -970,6 +970,40 @@ TEST(DOMLink, InertialAuto)
 }
 
 /////////////////////////////////////////////////
+TEST(DOMLink, InertialAutoExplicitMass)
+{
+  const std::string testFile = sdf::testing::TestFile("sdf",
+        "inertial_stats_auto_mass.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty()) << errors;
+
+  const sdf::Model *model = root.Model();
+  ASSERT_NE(model, nullptr);
+
+  std::vector<std::string> linkNames{"link_1", "link_2", "link_3", "link_4"};
+  for (const std::string &linkName : linkNames)
+  {
+    const sdf::Link *link = model->LinkByName(linkName);
+    ASSERT_NE(link, nullptr);
+
+    // Verify inertial values for link_i match those in inertial_stats.sdf
+    gz::math::Inertiald inertial = link->Inertial();
+    gz::math::MassMatrix3d massMatrix = inertial.MassMatrix();
+    EXPECT_EQ(gz::math::Pose3d::Zero, inertial.Pose());
+    EXPECT_DOUBLE_EQ(6.0, massMatrix.Mass());
+    EXPECT_DOUBLE_EQ(1.0, massMatrix.Ixx());
+    EXPECT_DOUBLE_EQ(1.0, massMatrix.Iyy());
+    EXPECT_DOUBLE_EQ(1.0, massMatrix.Izz());
+    EXPECT_DOUBLE_EQ(0.0, massMatrix.Ixy());
+    EXPECT_DOUBLE_EQ(0.0, massMatrix.Ixz());
+    EXPECT_DOUBLE_EQ(0.0, massMatrix.Iyz());
+  }
+}
+
+/////////////////////////////////////////////////
 TEST(DOMLink, InertialAutoSaveInElement)
 {
   const std::string testFile = sdf::testing::TestFile("sdf",

--- a/test/integration/link_dom.cc
+++ b/test/integration/link_dom.cc
@@ -948,7 +948,7 @@ TEST(DOMLink, InertialAuto)
   const sdf::Link *link = model->LinkByName("link_1");
   ASSERT_NE(link, nullptr);
 
-  // Verify inertial values for link_1 match thos in inertial_stats.sdf
+  // Verify inertial values for link_1 match those in inertial_stats.sdf
   gz::math::Inertiald inertial = link->Inertial();
   gz::math::MassMatrix3d massMatrix = inertial.MassMatrix();
   EXPECT_EQ(gz::math::Pose3d::Zero, inertial.Pose());
@@ -990,7 +990,7 @@ TEST(DOMLink, InertialAutoSaveInElement)
   const sdf::Link *link = model->LinkByName("link_1");
   ASSERT_NE(link, nullptr);
 
-  // Verify inertial values for link_1 match thos in inertial_stats.sdf
+  // Verify inertial values for link_1 match those in inertial_stats.sdf
   gz::math::Inertiald inertial = link->Inertial();
   gz::math::MassMatrix3d massMatrix = inertial.MassMatrix();
   EXPECT_EQ(gz::math::Pose3d::Zero, inertial.Pose());

--- a/test/sdf/inertial_stats_auto_mass.sdf
+++ b/test/sdf/inertial_stats_auto_mass.sdf
@@ -1,0 +1,140 @@
+<?xml version="1.0" ?>
+<sdf version="1.11">
+  <!---
+  Model consists of 4 cubes places symmetrically in the XY plane.
+              +y
+              │
+            ┌─┼─┐
+         L3 │ │ │(0,5,0)
+            └─┼─┘
+              │
+    L2┌───┐   │     ┌───┐L1
+  ────┼┼┼┼┼───┼─────┼┼┼┼┼─── +x
+      └───┘   │     └───┘
+    (-5,0,0)  │     (5,0,0)
+            ┌─┼─┐
+            │ │ │(0,-5,0)
+            └─┼─┘
+            L4│
+  -->
+  <![CDATA[
+  This model is used to verify the "gz sdf --inertial-stats" tool.
+  ]]>
+    <model name="test_model">
+      <pose>0 0 0 0 0 0</pose>
+
+      <!-- set //inertial/density -->
+      <link name="link_1">
+        <pose>5 0 0 0 0 0</pose>
+        <inertial auto="true">
+          <density>6</density>
+        </inertial>
+        <collision name="collision_1">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_1">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <!-- set //inertial/mass and default collision density -->
+      <link name="link_2">
+        <pose>-5 0 0 0 0 0</pose>
+        <inertial auto="true">
+          <mass>6</mass>
+        </inertial>
+        <collision name="collision_2">
+          <density>1000</density>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_2">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <!-- use two half-cube collisions instead of single cube -->
+      <!-- set //inertial/mass and default collision density -->
+      <link name="link_3">
+        <pose>0 5 0 0 0 0</pose>
+        <inertial auto="true">
+          <mass>6</mass>
+        </inertial>
+        <collision name="collision_3_up">
+          <pose>0 0 0.25 0 0 0</pose>
+          <density>1000</density>
+          <geometry>
+            <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+        <collision name="collision_3_down">
+          <pose>0 0 -0.25 0 0 0</pose>
+          <density>1000</density>
+          <geometry>
+            <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_3">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <!-- use two half-cube collisions instead of single cube -->
+      <!-- set //inertial/mass and identical non-default collision densities -->
+      <link name="link_4">
+        <pose>0 -5 0 0 0 0</pose>
+        <inertial auto="true">
+          <mass>6</mass>
+        </inertial>
+        <collision name="collision_4_up">
+          <pose>0 0 0.25 0 0 0</pose>
+          <density>123.456</density>
+          <geometry>
+            <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+        <collision name="collision_4_down">
+          <pose>0 0 -0.25 0 0 0</pose>
+          <density>123.456</density>
+          <geometry>
+            <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_4">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Adds more tests to #1513

## Summary

The implementation in #1513 looks correct to me; this just adds a new SDFormat test file and a few more tests.

The new test file [test/sdf/inertial_stats_auto_mass.sdf](https://github.com/gazebosim/sdformat/blob/cd505f5867743cbd298025f463a5839850502326/test/sdf/inertial_stats_auto_mass.sdf) is a variant of [test/sdf/inertial_stats_auto.sdf](https://github.com/gazebosim/sdformat/blob/cd505f5867743cbd298025f463a5839850502326/test/sdf/inertial_stats_auto.sdf) that explicitly sets `//inertial/mass` with `//inertial/@auto == true`. Each of these files contains 4 links, with each link holding a cube-shaped collision geometries symmetrically placed around the origin. The new test file replaces some of the cubes with a pair of equivalent half-cubes, and different density values are tested, while ensuring that the lumped inertial is equivalent between the two files.

Test cases for this new file are added to `INTEGRATION_link_dom` and `UNIT_gz_TEST`.

## Test it

1. Build this branch
2. Run `INTEGRATION_link_dom`
3. Run `UNIT_gz_TEST`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
