### PR TITLE
Fix initialization and thread-safety of SDF::Version() global

### DIFF
--- a/include/sdf/SDFImpl.hh
+++ b/include/sdf/SDFImpl.hh
@@ -236,6 +236,8 @@ namespace sdf
     public: const std::string &OriginalVersion() const;
 
     /// \brief Get the version
+    /// The result will be set to SDF_VERSION by default, unless overridden by a
+    /// call to the Version(const std::string &) function at runtime.
     /// \return The version as a string
     public: static std::string Version();
 
@@ -290,10 +292,6 @@ namespace sdf
     /// \internal
     /// \brief Pointer to private data.
     private: std::unique_ptr<SDFPrivate> dataPtr;
-
-    /// \brief The SDF version. Set to SDF_VERSION by default, or through
-    /// the Version function at runtime.
-    private: static std::string version;
   };
   /// \}
   }


### PR DESCRIPTION
# 🦟 Bug fix

Towards #552, but just one piece.

## Summary

Replace a static global variable that used a pre-main constructor with a latch-initialized static local variable and mutex to guard the writes.

This does not change API but it does change ABI.  Therefore, it targets the `main` branch instead of `sdf15`.

## Checklist
- [x] Signed all commits for DCO
- [x] (N/A) Added tests
- [x] Updated documentation (as needed)
- [x] (N/A) Updated migration guide (as needed)
- [x] (N/A) Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
