### PR TITLE
Add non-const overload for Root::Model() getter

### DIFF
--- a/include/sdf/Root.hh
+++ b/include/sdf/Root.hh
@@ -170,6 +170,11 @@ namespace sdf
     /// \return A pointer to the model, nullptr if it doesn't exist
     public: const sdf::Model *Model() const;
 
+    /// \brief Get a mutable pointer to the model object if it exists.
+    ///
+    /// \return A pointer to the model; nullptr if it doesn't exist.
+    public: sdf::Model *Model();
+
     /// \brief Set the model object. This will override any existing model,
     /// actor, and light object.
     /// \param[in] _model The model to use.

--- a/python/src/sdf/pyRoot.cc
+++ b/python/src/sdf/pyRoot.cc
@@ -83,7 +83,7 @@ void defineRoot(pybind11::object module)
          "Get a world based on an index.")
      .def("world_name_exists", &sdf::Root::WorldNameExists,
           "Get whether a world name exists.")
-    .def("model", &sdf::Root::Model,
+    .def("model", pybind11::overload_cast<sdf::Model *>(&sdf::Root::Model),
          pybind11::return_value_policy::reference_internal,
          "Get a model object if it exists.")
     .def("set_model", &sdf::Root::SetModel,

--- a/python/src/sdf/pyRoot.cc
+++ b/python/src/sdf/pyRoot.cc
@@ -83,7 +83,7 @@ void defineRoot(pybind11::object module)
          "Get a world based on an index.")
      .def("world_name_exists", &sdf::Root::WorldNameExists,
           "Get whether a world name exists.")
-    .def("model", pybind11::overload_cast<sdf::Model *>(&sdf::Root::Model),
+    .def("model", pybind11::overload_cast<>(&sdf::Root::Model),
          pybind11::return_value_policy::reference_internal,
          "Get a model object if it exists.")
     .def("set_model", &sdf::Root::SetModel,

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -476,6 +476,12 @@ const Model *Root::Model() const
 }
 
 /////////////////////////////////////////////////
+Model *Root::Model()
+{
+  return std::get_if<sdf::Model>(&this->dataPtr->modelLightOrActor);
+}
+
+/////////////////////////////////////////////////
 void Root::SetModel(const sdf::Model &_model)
 {
   this->dataPtr->modelLightOrActor = _model;

--- a/src/Root_TEST.cc
+++ b/src/Root_TEST.cc
@@ -46,6 +46,9 @@ TEST(DOMRoot, Construction)
   EXPECT_EQ(nullptr, root.Model());
   EXPECT_EQ(nullptr, root.Light());
   EXPECT_EQ(nullptr, root.Actor());
+
+  const sdf::Root &const_root = root;
+  EXPECT_EQ(nullptr, const_root.Model());
 }
 
 /////////////////////////////////////////////////
@@ -424,6 +427,7 @@ TEST(DOMRoot, ToElementEmpty)
 TEST(DOMRoot, ToElementModel)
 {
   sdf::Root root;
+  const sdf::Root &const_root = root;
 
   sdf::Actor actor1;
   actor1.SetName("actor1");
@@ -438,6 +442,7 @@ TEST(DOMRoot, ToElementModel)
   root.SetModel(model1);
 
   ASSERT_NE(nullptr, root.Model());
+  ASSERT_NE(nullptr, const_root.Model());
   ASSERT_EQ(nullptr, root.Light());
   ASSERT_EQ(nullptr, root.Actor());
   EXPECT_EQ(0u, root.WorldCount());
@@ -447,12 +452,15 @@ TEST(DOMRoot, ToElementModel)
   ASSERT_NE(nullptr, elem);
 
   sdf::Root root2;
+  const sdf::Root &const_root2 = root2;
   root2.LoadSdfString(elem->ToString(""));
 
   EXPECT_EQ(SDF_VERSION, root2.Version());
 
   ASSERT_NE(nullptr, root2.Model());
+  ASSERT_NE(nullptr, const_root2.Model());
   EXPECT_EQ("model1", root2.Model()->Name());
+  EXPECT_EQ("model1", const_root2.Model()->Name());
 
   ASSERT_EQ(nullptr, root2.Actor());
   ASSERT_EQ(nullptr, root2.Light());
@@ -651,24 +659,25 @@ TEST(DOMRoot, CopyConstructor)
 TEST(DOMRoot, WorldByName)
 {
   sdf::Root root;
-  EXPECT_EQ(0u, root.WorldCount());
+  const sdf::Root &const_root = root;
+  EXPECT_EQ(0u, const_root.WorldCount());
 
   sdf::World world;
   world.SetName("world1");
   EXPECT_TRUE(root.AddWorld(world).empty());
-  EXPECT_EQ(1u, root.WorldCount());
+  EXPECT_EQ(1u, const_root.WorldCount());
 
-  EXPECT_TRUE(root.WorldNameExists("world1"));
-  const sdf::World *wPtr = root.WorldByName("world1");
-  EXPECT_NE(nullptr, wPtr);
+  EXPECT_TRUE(const_root.WorldNameExists("world1"));
+  EXPECT_NE(nullptr, root.WorldByName("world1"));
+  EXPECT_NE(nullptr, const_root.WorldByName("world1"));
 
   // Modify the world
   sdf::World *w = root.WorldByName("world1");
   ASSERT_NE(nullptr, w);
   EXPECT_EQ("world1", w->Name());
   w->SetName("world2");
-  ASSERT_TRUE(root.WorldNameExists("world2"));
-  EXPECT_EQ("world2", root.WorldByName("world2")->Name());
+  ASSERT_TRUE(const_root.WorldNameExists("world2"));
+  EXPECT_EQ("world2", const_root.WorldByName("world2")->Name());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Closes (N/A).

## Summary

Adds a non-const overload for `Root::Model()` getter. This is consistent with the getters for `World` which also overload on const-ness.

## Test it

> Explain how reviewers can test this new feature manually.

There are automated unit tests.  Manual testing is unnecessary.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] (N/A) Added example and/or tutorial
- [x] (N/A) Updated documentation (as needed)
- [x] (N/A) Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
