### PR TITLE
Prepare for 14.7.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat14 VERSION 14.6.0)
+project (sdformat14 VERSION 14.7.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,17 @@
 ## libsdformat 14.X
 
+### libsdformat 14.7.0 (2025-01-30)
+
+1. Resolve auto inertia based on input mass
+    * [Pull request #1513](https://github.com/gazebosim/sdformat/pull/1513)
+    * [Pull request #1530](https://github.com/gazebosim/sdformat/pull/1530)
+
+1. Print auto inertial values with gz sdf --print --expand-auto-inertials
+    * [Pull request #1422](https://github.com/gazebosim/sdformat/pull/1422)
+
+1. Only look for psutil if testing is enabled
+    * [Pull request #1495](https://github.com/gazebosim/sdformat/pull/1495)
+
 ### libsdformat 14.6.0 (2024-11-18)
 
 1. Support removing the actor, light, or model from the root.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat14</name>
-  <version>14.6.0</version>
+  <version>14.7.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 14.7.0 release.

Comparison to 14.6.0: https://github.com/gazebosim/sdformat/compare/sdformat14_14.6.0...sdf14

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.