### PR TITLE
Unify Python3_Development_FOUND checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,9 +95,6 @@ if (BUILD_SDF)
       COMPONENTS Interpreter
       OPTIONAL_COMPONENTS Development
     )
-    if (NOT Python3_Development_FOUND)
-      GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
-    endif()
   endif()
 
   #################################################
@@ -151,8 +148,12 @@ if (BUILD_SDF)
   add_subdirectory(sdf)
   add_subdirectory(conf)
   add_subdirectory(doc)
-  if (Python3_Development_FOUND AND NOT SKIP_PYBIND11)
-    add_subdirectory(python)
+  if (NOT SKIP_PYBIND11)
+    if (Python3_Development_FOUND)
+      add_subdirectory(python)
+    else()
+      message(WARNING "Python development libraries are missing: Python interfaces are disabled.")
+    endif()
   endif()
 endif(BUILD_SDF)
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes hidden warnings when python development libraries are not found, port of https://github.com/gazebosim/gz-transport/pull/565

## Summary

The value of `Python3_Development_FOUND` may change if other code paths call `find_package(Python3)`, so move the warning to be co-located with the `add_subdirectory` call. Otherwise python bindings may be silently ignored.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
