### PR TITLE
Prepare for 15.2.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat15 VERSION 15.1.1)
+project (sdformat15 VERSION 15.2.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,34 @@
 ## libsdformat 15.X
 
+### libsdformat 15.2.0 (2025-02-12)
+
+1. Add entry to Migration guide about the updated auto-inertia behavior
+    * [Pull request #1528](https://github.com/gazebosim/sdformat/pull/1528)
+
+1. Add missed spec version 1.12 in the sdf_descriptions target
+    * [Pull request #1529](https://github.com/gazebosim/sdformat/pull/1529)
+
+1. Resolve auto inertia based on input mass
+    * [Pull request #1513](https://github.com/gazebosim/sdformat/pull/1513)
+
+1. ci.yml: run cppcheck, cpplint on noble
+    * [Pull request #1521](https://github.com/gazebosim/sdformat/pull/1521)
+
+1. Add non-const overload for Root::Model() getter
+    * [Pull request #1524](https://github.com/gazebosim/sdformat/pull/1524)
+
+1. Remove unncessary <iostream> includes
+    * [Pull request #1523](https://github.com/gazebosim/sdformat/pull/1523)
+
+1. Don't reparse parent elements when cloning.
+    * [Pull request #1484](https://github.com/gazebosim/sdformat/pull/1484)
+
+1. python bindings: get version from package.xml
+    * [Pull request #1504](https://github.com/gazebosim/sdformat/pull/1504)
+
+1. Permit to test when building bindings separately from main library
+    * [Pull request #1509](https://github.com/gazebosim/sdformat/pull/1509)
+
 ### libsdformat 15.1.1 (2024-11-15)
 
 1. **Baseline:** this includes all changes from 15.1.0 and earlier.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat15</name>
-  <version>15.1.1</version>
+  <version>15.2.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 15.2.0 release.

Comparison to 15.1.1: https://github.com/gazebosim/sdformat/compare/sdformat15_15.1.1...sdf15

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.