### PR TITLE
Improve error messages when embedSdf.py fails

### DIFF
--- a/sdf/CMakeLists.txt
+++ b/sdf/CMakeLists.txt
@@ -25,8 +25,15 @@ execute_process(
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/sdf/embedSdf.py
     --output-file "${EMBEDDED_SDF_CC_PATH}"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/sdf"
+  RESULT_VARIABLE EMBEDDED_SDF_RESULT
+  ERROR_VARIABLE EMBEDDED_SDF_ERROR
 )
+# check process return code
+if(NOT EMBEDDED_SDF_RESULT EQUAL 0)
+  message(FATAL_ERROR "Error executing ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/sdf/embedSdf.py to create ${EMBEDDED_SDF_CC_PATH}: ${EMBEDDED_SDF_ERROR}")
+endif()
 # check that EmbeddedSdf.cc exists with non-zero size
+# this should not happen if embedSdf.py was successful
 if(EXISTS "${EMBEDDED_SDF_CC_PATH}")
   file(SIZE "${EMBEDDED_SDF_CC_PATH}" EMBEDDED_SDF_CC_SIZE)
 endif()

--- a/sdf/CMakeLists.txt
+++ b/sdf/CMakeLists.txt
@@ -20,14 +20,18 @@ endif()
 
 # Generate the EmbeddedSdf.cc file, which contains all the supported SDF
 # descriptions in a map of strings. The parser.cc file uses EmbeddedSdf.hh.
+set(EMBEDDED_SDF_CC_PATH "${PROJECT_BINARY_DIR}/src/EmbeddedSdf.cc")
 execute_process(
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/sdf/embedSdf.py
-    --output-file "${PROJECT_BINARY_DIR}/src/EmbeddedSdf.cc"
+    --output-file "${EMBEDDED_SDF_CC_PATH}"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/sdf"
 )
-file(SIZE "${PROJECT_BINARY_DIR}/src/EmbeddedSdf.cc" OUT_SIZE)
-if(${OUT_SIZE} EQUAL 0)
-   message(FATAL_ERROR "Problems executing ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/sdf/embedSdf.py")
+# check that EmbeddedSdf.cc exists with non-zero size
+if(EXISTS "${EMBEDDED_SDF_CC_PATH}")
+  file(SIZE "${EMBEDDED_SDF_CC_PATH}" EMBEDDED_SDF_CC_SIZE)
+endif()
+if("${EMBEDDED_SDF_CC_SIZE}" STREQUAL "0" OR "${EMBEDDED_SDF_CC_SIZE}" STREQUAL "")
+   message(FATAL_ERROR "${EMBEDDED_SDF_CC_PATH} is empty or does not exist")
 endif()
 
 # Generate aggregated SDF description files for use by the sdformat.org

--- a/sdf/CMakeLists.txt
+++ b/sdf/CMakeLists.txt
@@ -38,7 +38,7 @@ if(EXISTS "${EMBEDDED_SDF_CC_PATH}")
   file(SIZE "${EMBEDDED_SDF_CC_PATH}" EMBEDDED_SDF_CC_SIZE)
 endif()
 if("${EMBEDDED_SDF_CC_SIZE}" STREQUAL "0" OR "${EMBEDDED_SDF_CC_SIZE}" STREQUAL "")
-   message(FATAL_ERROR "${EMBEDDED_SDF_CC_PATH} is empty or does not exist")
+  message(FATAL_ERROR "${EMBEDDED_SDF_CC_PATH} is empty or does not exist")
 endif()
 
 # Generate aggregated SDF description files for use by the sdformat.org


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #1536.

## Summary

The [embedSdf.py](https://github.com/gazebosim/sdformat/blob/sdf15/sdf/embedSdf.py) script is used to generate the `EmbeddedSdf.cc` source code that implements the interface defined in [src/EmbeddedSdf.hh](https://github.com/gazebosim/sdformat/blob/sdf15/src/EmbeddedSdf.hh). The contribution by @ efferre79 in #1536 adds error checking to confirm that the generated `EmbeddedSdf.cc` file is not empty. This pull request makes some additional improvements to this error checking.

### a44ccb2: check that `EmbeddedSdf.cc` exists before checking its size, use string comparisons, and rephrase the error message

Currently the `file(SIZE)` call generates a cmake error if the `EmbeddedSdf.cc` file does not exist and the `if(${OUT_SIZE} EQUAL 0)` comparison fails if `OUT_SIZE` is an empty variable:

~~~
CMake Error at sdf/CMakeLists.txt:28 (file):
  file SIZE requested of path that is not readable:

    <CMAKE_BINARY_DIR>/src/EmbeddedSdf.cc


CMake Error at sdf/CMakeLists.txt:29 (if):
  if given arguments:

    "EQUAL" "0"

  Unknown arguments specified
~~~

After a44ccb2, the error message when EmbeddedSdf.cc is empty or does not exist changes to:

~~~
CMake Error at sdf/CMakeLists.txt:34 (message):
  <CMAKE_BINARY_DIR>/src/EmbeddedSdf.cc is
  empty or does not exist
~~~

### 1ca9bb63e6a3616d7f74059587c19a42f8544a0f: check return code of embedSdf.py and print stderr

This checks the `RESULT_VARIABLE` of the `execute_process` call and prints the `ERROR_VARIABLE` if it is not successful. After this change, the error message is:

~~~
CMake Error at sdf/CMakeLists.txt:33 (message):
  Error executing
  /usr/local/Frameworks/Python.framework/Versions/3.13/bin/python3.13
  /Users/scpeters/ws/sdformat_math/src/sdformat/sdf/embedSdf.py to create
  /Users/scpeters/ws/sdformat_math/src/sdformat/build/src/EmbeddedSdf.cc:
  Traceback (most recent call last):

    File "/Users/scpeters/ws/sdformat_math/src/sdformat/sdf/embedSdf.py", line 13, in <module>
      intentional_error

  NameError: name 'intentional_error' is not defined
~~~



## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
