### PR TITLE
Improve error messages when embedSdf.py fails

### DIFF
--- a/sdf/CMakeLists.txt
+++ b/sdf/CMakeLists.txt
@@ -19,11 +19,18 @@ endif()
 
 # Generate the EmbeddedSdf.cc file, which contains all the supported SDF
 # descriptions in a map of strings. The parser.cc file uses EmbeddedSdf.hh.
+set(EMBEDDED_SDF_CC_PATH "${PROJECT_BINARY_DIR}/src/EmbeddedSdf.cc")
 execute_process(
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/sdf/embedSdf.py
-    --output-file "${PROJECT_BINARY_DIR}/src/EmbeddedSdf.cc"
+    --output-file "${EMBEDDED_SDF_CC_PATH}"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/sdf"
+  RESULT_VARIABLE EMBEDDED_SDF_RESULT
+  ERROR_VARIABLE EMBEDDED_SDF_ERROR
 )
+# check process return code
+if(NOT EMBEDDED_SDF_RESULT EQUAL 0)
+  message(FATAL_ERROR "Error executing ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/sdf/embedSdf.py to create ${EMBEDDED_SDF_CC_PATH}: ${EMBEDDED_SDF_ERROR}")
+endif()
 
 # Generate aggregated SDF description files for use by the sdformat.org
 # website. If the description files change, the generated full*.sdf files need


### PR DESCRIPTION
# 🦟 Bug fix

Partial backport of #1549.

## Summary

The [embedSdf.py](https://github.com/gazebosim/sdformat/blob/sdf15/sdf/embedSdf.py) script is used to generate the EmbeddedSdf.cc source code that implements the interface defined in [src/EmbeddedSdf.hh](https://github.com/gazebosim/sdformat/blob/sdf14/src/EmbeddedSdf.hh). The contribution by @ efferre79 in https://github.com/gazebosim/sdformat/pull/1536 added error checking using a cmake feature that is too new for Harmonic, but part of the followup in #1549 are backported here:

* https://github.com/gazebosim/sdformat/commit/cf131fdc55ee21f8811f2e5ab06645fa7cb2763a: check return code of embedSdf.py and print stderr on failure


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
