### PR TITLE
Code cleanup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -122,7 +122,6 @@ cc_library(
         "@gz-math",
         "@gz-utils//:Environment",
         "@gz-utils//:ImplPtr",
-        "@gz-utils//:NeverDestroyed",
         "@gz-utils//:SuppressWarning",
         "@tinyxml2",
     ],

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,7 @@
 1. Add non-const overload for Root::Model() getter
     * [Pull request #1524](https://github.com/gazebosim/sdformat/pull/1524)
 
-1. Remove unncessary <iostream> includes
+1. Remove unnecessary <iostream> includes
     * [Pull request #1523](https://github.com/gazebosim/sdformat/pull/1523)
 
 1. Don't reparse parent elements when cloning.

--- a/Migration.md
+++ b/Migration.md
@@ -183,7 +183,7 @@ one root level model, actor or light.
     + const std::string &BoundingBoxType() const
     + void SetBoundingBoxType(const std::string &)
 
-1. **sdf/Elementh.hh**
+1. **sdf/Element.hh**
     + const Param_V &GetAttributes() const
 
 1. **sdf/Error.hh**
@@ -708,7 +708,7 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
     `//joint/axis2` to specify a linear relationship between the position of two
     joint axes according to the following equation:
     `follower_position = multiplier * (leader_position - reference) + offset`.
-    The joint axis containing the mimic tag is the follwer and the leader is
+    The joint axis containing the mimic tag is the follower and the leader is
     specified using the `@joint` and `@axis` attributes.
     + `//mimic/@joint`: name of joint containing the leader axis.
     + `//mimic/@axis`: name of the leader axis. Only valid values are "axis" or "axis2".
@@ -825,7 +825,7 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 
 ### Removals
 
-1. **inerial.sdf** `//inertial/pose/@relative_to` attribute is removed
+1. **inertial.sdf** `//inertial/pose/@relative_to` attribute is removed
     + [Pull request 480](https://github.com/osrf/sdformat/pull/480)
 
 ## SDFormat specification 1.6 to 1.7
@@ -895,7 +895,7 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
       It has a special interpretation when specified as a parent or child link
       of a joint.
       Names starting and ending with double underscores (eg. `__wheel__`) must
-      be reserved for use by library implementors and the specification.
+      be reserved for use by library implementers and the specification.
       For example, such names might be useful during parsing for setting
       sentinel or default names for elements with missing names.
       If explicitly stated, they can be referred to (e.g. `__model__` / `world`
@@ -1003,7 +1003,7 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
 
 1. **model.sdf** `enable_wind` element
     + description: If set to true, all links in the model will be affected by
-      the wind.  Can be overriden by the link wind property.
+      the wind.  Can be overridden by the link wind property.
     + type: bool
     + default: false
     + required: 0

--- a/doc/mainpage.html
+++ b/doc/mainpage.html
@@ -2,7 +2,7 @@
 /** \mainpage SDF API Reference
 
 This documentation provides useful information about the Simulation
-Desctiption Format API. The code reference is divided into the groups below.
+Description Format API. The code reference is divided into the groups below.
 Should you find problems with this documentation - typos, unclear phrases,
 or insufficient detail - please create a <a
   href="https://github.com/gazebosim/sdformat/issues/new">new GitHub issue</a>.
@@ -14,7 +14,7 @@ Priority - minor; Version - blank.
    <dt>Class</dt>
    <dd><a href="classes.html">List</a> - Index of all classes in Gazebo, organized alphabetically</dd>
 
-   <dd><a href="hierarchy.html">Hierarchy</a> - Index of classes, organized hierachically according to their inheritance</dd>
+   <dd><a href="hierarchy.html">Hierarchy</a> - Index of classes, organized hierarchically according to their inheritance</dd>
 </dl>
 
 

--- a/doc/sdf.in
+++ b/doc/sdf.in
@@ -913,7 +913,7 @@ HTML_STYLESHEET        = "@CMAKE_SOURCE_DIR@/doc/doxygen.css"
 # user-defined cascading style sheet that is included after the standard
 # style sheets created by doxygen. Using this option one can overrule
 # certain style aspects. This is preferred over using HTML_STYLESHEET
-# since it does not replace the standard style sheet and is therefor more
+# since it does not replace the standard style sheet and is therefore more
 # robust against future updates. Doxygen will copy the style sheet file to
 # the output directory.
 
@@ -1676,7 +1676,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/include/sdf/Actor.hh
+++ b/include/sdf/Actor.hh
@@ -33,7 +33,7 @@
 
 namespace sdf
 {
-  // Inline bracke to help doxygen filtering.
+  // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   //
   /// \brief Animation in Actor.

--- a/include/sdf/AirPressure.hh
+++ b/include/sdf/AirPressure.hh
@@ -26,7 +26,7 @@
 
 namespace sdf
 {
-  // Inline bracke to help doxygen filtering.
+  // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   /// \brief AirPressure contains information about a general
   /// purpose fluid pressure sensor.
@@ -75,13 +75,13 @@ namespace sdf
     /// \brief Return true if both AirPressure objects contain the
     /// same values.
     /// \param[_in] _mag AirPressure value to compare.
-    /// \returen True if 'this' == _mag.
+    /// \return True if 'this' == _mag.
     public: bool operator==(const AirPressure &_air) const;
 
     /// \brief Return true this AirPressure object does not contain
     /// the same values as the passed in parameter.
     /// \param[_in] _mag AirPressure value to compare.
-    /// \returen True if 'this' != _mag.
+    /// \return True if 'this' != _mag.
     public: bool operator!=(const AirPressure &_air) const;
 
     /// \brief Create and return an SDF element filled with data from this

--- a/include/sdf/AirSpeed.hh
+++ b/include/sdf/AirSpeed.hh
@@ -26,7 +26,7 @@
 
 namespace sdf
 {
-  // Inline bracke to help doxygen filtering.
+  // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   /// \brief AirSpeed contains information about a general
   /// purpose air speed sensor.
@@ -61,13 +61,13 @@ namespace sdf
     /// \brief Return true if both AirSpeed objects contain the
     /// same values.
     /// \param[_in] _air AirSpeed value to compare.
-    /// \returen True if 'this' == _air.
+    /// \return True if 'this' == _air.
     public: bool operator==(const AirSpeed &_air) const;
 
     /// \brief Return true this AirSpeed object does not contain
     /// the same values as the passed in parameter.
     /// \param[_in] _air AirSpeed value to compare.
-    /// \returen True if 'this' != _air.
+    /// \return True if 'this' != _air.
     public: bool operator!=(const AirSpeed &_air) const;
 
     /// \brief Create and return an SDF element filled with data from this

--- a/include/sdf/Altimeter.hh
+++ b/include/sdf/Altimeter.hh
@@ -67,13 +67,13 @@ namespace sdf
 
     /// \brief Return true if both Altimeter objects contain the same values.
     /// \param[_in] _alt Altimeter value to compare.
-    /// \returen True if 'this' == _alt.
+    /// \return True if 'this' == _alt.
     public: bool operator==(const Altimeter &_alt) const;
 
     /// \brief Return true this Altimeter object does not contain the same
     /// values as the passed in parameter.
     /// \param[_in] _alt Altimeter value to compare.
-    /// \returen True if 'this' != _alt.
+    /// \return True if 'this' != _alt.
     public: bool operator!=(const Altimeter &_alt) const;
 
     /// \brief Create and return an SDF element filled with data from this

--- a/include/sdf/CMakeLists.txt
+++ b/include/sdf/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Exlcude some files so that they are not added to the master header.
+# Exclude some files so that they are not added to the master header.
 gz_install_all_headers(EXCLUDE_FILES sdf.hh sdf_config.h)
 install(
   FILES

--- a/include/sdf/Camera.hh
+++ b/include/sdf/Camera.hh
@@ -64,13 +64,13 @@ namespace sdf
 
     /// \brief Return true if both Camera objects contain the same values.
     /// \param[_in] _alt Camera value to compare.
-    /// \returen True if 'this' == _alt.
+    /// \return True if 'this' == _alt.
     public: bool operator==(const Camera &_alt) const;
 
     /// \brief Return true this Camera object does not contain the same
     /// values as the passed in parameter.
     /// \param[_in] _alt Camera value to compare.
-    /// \returen True if 'this' != _alt.
+    /// \return True if 'this' != _alt.
     public: bool operator!=(const Camera &_alt) const;
 
     /// \brief Load the camera sensor based on an element pointer.
@@ -334,7 +334,7 @@ namespace sdf
     /// \param[in] _center Distortion center or principal point.
     public: void SetDistortionCenter(const gz::math::Vector2d &_center);
 
-    /// \brief Get the pose of the camer. This is the pose of the camera
+    /// \brief Get the pose of the camera. This is the pose of the camera
     /// as specified in SDF (<camera> <pose> ... </pose></camera>).
     /// \return The pose of the link.
     public: const gz::math::Pose3d &RawPose() const;
@@ -562,8 +562,8 @@ namespace sdf
     /// \param[in] _mask visibility mask
     public: void SetVisibilityMask(uint32_t _mask);
 
-    /// \brief Get whether or not the camera has instrinsics values set
-    /// \return True if the camera has instrinsics values set, false otherwise
+    /// \brief Get whether or not the camera has intrinsics values set
+    /// \return True if the camera has intrinsics values set, false otherwise
     public: bool HasLensIntrinsics() const;
 
     /// \brief Get whether or not the camera has projection values set

--- a/include/sdf/Collision.hh
+++ b/include/sdf/Collision.hh
@@ -43,7 +43,7 @@ namespace sdf
   struct PoseRelativeToGraph;
   template <typename T> class ScopedGraph;
 
-  /// \brief A collision element descibes the collision properties associated
+  /// \brief A collision element describes the collision properties associated
   /// with a link. This can be different from the visual properties of a link.
   /// For example, simple collision models are often used to reduce
   /// computation time.
@@ -121,7 +121,7 @@ namespace sdf
     public: void SetSurface(const sdf::Surface &_surface);
 
     /// \brief Get the pose of the collision object. This is the pose of the
-    /// collison as specified in SDF
+    /// collision as specified in SDF
     /// (<collision><pose> ... </pose></collision>).
     /// \return The pose of the collision object.
     public: const gz::math::Pose3d &RawPose() const;

--- a/include/sdf/CustomInertiaCalcProperties.hh
+++ b/include/sdf/CustomInertiaCalcProperties.hh
@@ -58,7 +58,7 @@ class SDFORMAT_VISIBLE CustomInertiaCalcProperties
   /// \param[in] _density Double density value
   public: void SetDensity(double _density);
 
-  /// \brief Get the reference to the mesh oject being used.
+  /// \brief Get the reference to the mesh object being used.
   /// \return Reference to the sdf::Mesh object.
   public: const std::optional<sdf::Mesh> &Mesh() const;
 

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -639,7 +639,7 @@ namespace sdf
     /// FindElement
     /// \remarks If there are multiple elements with the given tag, it returns
     ///          the first one.
-    /// \param[in] _name Name of the child element to retreive.
+    /// \param[in] _name Name of the child element to retrieve.
     /// \return Pointer to the existing child element, or a new child
     /// element if an existing child element did not exist.
     public: ElementPtr GetElement(const std::string &_name);
@@ -651,7 +651,7 @@ namespace sdf
     /// FindElement
     /// \remarks If there are multiple elements with the given tag, it returns
     ///          the first one.
-    /// \param[in] _name Name of the child element to retreive.
+    /// \param[in] _name Name of the child element to retrieve.
     /// \param[out] _errors Vector of errors.
     /// \return Pointer to the existing child element, or a new child
     /// element if an existing child element did not exist.
@@ -664,7 +664,7 @@ namespace sdf
     /// fails to find an existing element.
     /// \remarks If there are multiple elements with the given tag, it returns
     ///          the first one.
-    /// \param[in] _name Name of the child element to retreive.
+    /// \param[in] _name Name of the child element to retrieve.
     /// \return Pointer to the existing child element, or nullptr
     /// if the child element was not found.
     public: ElementPtr FindElement(const std::string &_name);
@@ -675,7 +675,7 @@ namespace sdf
     /// fails to find an existing element.
     /// \remarks If there are multiple elements with the given tag, it returns
     ///          the first one.
-    /// \param[in] _name Name of the child element to retreive.
+    /// \param[in] _name Name of the child element to retrieve.
     /// \return Pointer to the existing child element, or nullptr
     /// if the child element was not found.
     public: ElementConstPtr FindElement(const std::string &_name) const;

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -92,7 +92,7 @@ namespace sdf
     /// \brief A URI is invalid.
     URI_INVALID,
 
-    /// \brief A error occured while trying to resolve a URI.
+    /// \brief A error occurred while trying to resolve a URI.
     URI_LOOKUP,
 
     /// \brief A filesystem directory does not exist.
@@ -151,7 +151,7 @@ namespace sdf
     /// \brief The provided version has been deprecated or it is pre-versioning
     VERSION_DEPRECATED,
 
-    /// \brief Merge include is unspported for the type of entity being
+    /// \brief Merge include is unsupported for the type of entity being
     /// included, or the custom parser does not support merge includes.
     MERGE_INCLUDE_UNSUPPORTED,
 

--- a/include/sdf/Exception.hh
+++ b/include/sdf/Exception.hh
@@ -106,7 +106,7 @@ namespace sdf
 
   /// \class InternalError Exception.hh common/common.hh
   /// \brief Class for generating Internal Gazebo Errors:
-  ///        those errors which should never happend and
+  ///        those errors which should never happened and
   ///        represent programming bugs.
   class SDFORMAT_VISIBLE InternalError : public Exception
   {

--- a/include/sdf/Filesystem.hh
+++ b/include/sdf/Filesystem.hh
@@ -27,7 +27,7 @@
 
 namespace sdf
 {
-  // Inline bracke to help doxygen filtering.
+  // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   //
 

--- a/include/sdf/ForceTorque.hh
+++ b/include/sdf/ForceTorque.hh
@@ -145,13 +145,13 @@ namespace sdf
 
     /// \brief Return true if both force torque objects contain the same values.
     /// \param[_in] _ft Force torque value to compare.
-    /// \returen True if 'this' == _ft.
+    /// \return True if 'this' == _ft.
     public: bool operator==(const ForceTorque &_ft) const;
 
     /// \brief Return true this force torque object does not contain the same
     /// values as the passed-in parameter.
     /// \param[_in] _ft Force torque value to compare.
-    /// \returen True if 'this' != _ft.
+    /// \return True if 'this' != _ft.
     public: bool operator!=(const ForceTorque &_ft) const;
 
     /// \brief Create and return an SDF element filled with data from this

--- a/include/sdf/Frame.hh
+++ b/include/sdf/Frame.hh
@@ -37,7 +37,7 @@ namespace sdf
   struct PoseRelativeToGraph;
   template <typename T> class ScopedGraph;
 
-  /// \brief A Frame element descibes the properties associated with an
+  /// \brief A Frame element describes the properties associated with an
   /// explicit frame defined in a Model or World.
   class SDFORMAT_VISIBLE Frame
   {

--- a/include/sdf/Imu.hh
+++ b/include/sdf/Imu.hh
@@ -211,11 +211,11 @@ namespace sdf
     ///    facing +z). (default gazebo camera is +x:view direction, +y:left,
     ///    +z:up).
     ///    Example sdf: parent_frame="local", custom_rpy="-0.5*M_PI 0 -0.5*M_PI"
-    /// \return Custom RPY vectory
+    /// \return Custom RPY vector
     public: const gz::math::Vector3d &CustomRpy() const;
 
     /// \brief See CustomRpy() const.
-    /// \param[in] Custom RPY vectory
+    /// \param[in] Custom RPY vector
     public: void SetCustomRpy(const gz::math::Vector3d &_rpy);
 
     /// \brief Get the name of parent frame which the custom_rpy transform is
@@ -244,13 +244,13 @@ namespace sdf
 
     /// \brief Return true if both Imu objects contain the same values.
     /// \param[_in] _imu Imu value to compare.
-    /// \returen True if 'this' == _imu.
+    /// \return True if 'this' == _imu.
     public: bool operator==(const Imu &_imu) const;
 
     /// \brief Return true this Imu object does not contain the same
     /// values as the passed in parameter.
     /// \param[_in] _imu Imu value to compare.
-    /// \returen True if 'this' != _imu.
+    /// \return True if 'this' != _imu.
     public: bool operator!=(const Imu &_imu) const;
 
     /// \brief Create and return an SDF element filled with data from this

--- a/include/sdf/InterfaceElements.hh
+++ b/include/sdf/InterfaceElements.hh
@@ -17,8 +17,10 @@
 #ifndef SDF_INTERFACE_ELEMENTS_HH_
 #define SDF_INTERFACE_ELEMENTS_HH_
 
+#include <functional>
 #include <string>
 #include <memory>
+#include <optional>
 
 #include <gz/math/Pose3.hh>
 #include <gz/utils/ImplPtr.hh>

--- a/include/sdf/InterfaceModel.hh
+++ b/include/sdf/InterfaceModel.hh
@@ -20,6 +20,7 @@
 
 #include <functional>
 #include <string>
+#include <optional>
 #include <memory>
 #include <vector>
 

--- a/include/sdf/InterfaceModelPoseGraph.hh
+++ b/include/sdf/InterfaceModelPoseGraph.hh
@@ -19,8 +19,6 @@
 #define SDF_INTERFACE_MODEL_POSE_GRAPH
 
 #include <string>
-#include <memory>
-#include <vector>
 
 #include <gz/math/Pose3.hh>
 #include <gz/utils/ImplPtr.hh>

--- a/include/sdf/Joint.hh
+++ b/include/sdf/Joint.hh
@@ -17,7 +17,6 @@
 #ifndef SDF_JOINT_HH_
 #define SDF_JOINT_HH_
 
-#include <memory>
 #include <string>
 #include <gz/math/Pose3.hh>
 #include <gz/utils/ImplPtr.hh>
@@ -197,13 +196,13 @@ namespace sdf
     /// \brief Get the thread pitch in gazebo-classic format (only valid for
     /// screw joints). This will be deprecated in a future version.
     /// \return The thread pitch with units of radians / meters and a positive
-    /// value coresponding to a left-handed thread.
+    /// value corresponding to a left-handed thread.
     public: double ThreadPitch() const;
 
     /// \brief Set the thread pitch in gazebo-classic format (only valid for
     /// screw joints). This will be deprecated in a future version.
     /// \param[in] _threadPitch The thread pitch with units of radians / meters
-    /// and a positive value coresponding to a left-handed thread.
+    /// and a positive value corresponding to a left-handed thread.
     public: void SetThreadPitch(double _threadPitch);
 
     /// \brief Get a pointer to the SDF element that was used during

--- a/include/sdf/JointAxis.hh
+++ b/include/sdf/JointAxis.hh
@@ -17,9 +17,8 @@
 #ifndef SDF_JOINTAXIS_HH_
 #define SDF_JOINTAXIS_HH_
 
-#include <memory>
 #include <string>
-#include <utility>
+#include <optional>
 #include <gz/math/Vector3.hh>
 #include <gz/utils/ImplPtr.hh>
 #include "sdf/Element.hh"

--- a/include/sdf/Lidar.hh
+++ b/include/sdf/Lidar.hh
@@ -35,7 +35,7 @@ namespace sdf
   /// \brief Lidar contains information about a Lidar sensor.
   /// This sensor can be attached to a link. The Lidar sensor can be defined
   /// SDF XML using either the "ray" or "lidar" types. The "lidar" type is
-  /// preffered as "ray" is considered legacy.
+  /// preferred as "ray" is considered legacy.
   ///
   /// # Example SDF XML using lidar type:
   ///

--- a/include/sdf/Light.hh
+++ b/include/sdf/Light.hh
@@ -185,24 +185,24 @@ namespace sdf
     /// \brief Get the linear attenuation factor. This value is clamped to
     /// a value between 0 and 1, where 1 means attenuate evenly over the
     /// distance.
-    /// \return Linear attentuation factor.
+    /// \return Linear attenuation factor.
     public: double LinearAttenuationFactor() const;
 
     /// \brief Set the linear attenuation factor. This value is clamped to
     /// a value between 0 and 1, where 1 means attenuate evenly over the
     /// distance.
-    /// \param[in] _factor Linear attentuation factor.
+    /// \param[in] _factor Linear attenuation factor.
     public: void SetLinearAttenuationFactor(const double _factor);
 
     /// \brief Get the constant attenuation factor. This value is clamped to
     /// a value between 0 and 1,  where 1.0 means never attenuate and 0.0 is
-    /// complete attenutation.
+    /// complete attenuation.
     /// \return Constant attenuation factor.
     public: double ConstantAttenuationFactor() const;
 
     /// \brief Set the constant attenuation factor. This value is clamped to
     /// a value between 0 and 1,  where 1.0 means never attenuate and 0.0 is
-    /// complete attenutation.
+    /// complete attenuation.
     /// \param[in] _factor Constant attenuation factor.
     public: void SetConstantAttenuationFactor(const double _factor);
 

--- a/include/sdf/Magnetometer.hh
+++ b/include/sdf/Magnetometer.hh
@@ -25,7 +25,7 @@
 
 namespace sdf
 {
-  // Inline bracke to help doxygen filtering.
+  // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   //
 
@@ -76,13 +76,13 @@ namespace sdf
 
     /// \brief Return true if both Magnetometer objects contain the same values.
     /// \param[_in] _mag Magnetometer value to compare.
-    /// \returen True if 'this' == _mag.
+    /// \return True if 'this' == _mag.
     public: bool operator==(const Magnetometer &_mag) const;
 
     /// \brief Return true this Magnetometer object does not contain the same
     /// values as the passed in parameter.
     /// \param[_in] _mag Magnetometer value to compare.
-    /// \returen True if 'this' != _mag.
+    /// \return True if 'this' != _mag.
     public: bool operator!=(const Magnetometer &_mag) const;
 
     /// \brief Create and return an SDF element filled with data from this

--- a/include/sdf/Mesh.hh
+++ b/include/sdf/Mesh.hh
@@ -116,12 +116,12 @@ namespace sdf
 
     /// \brief Get the mesh's optimization method
     /// \return The mesh optimization method.
-    /// MeshOptimization::NONE if no mesh simplificaton is done.
+    /// MeshOptimization::NONE if no mesh simplification is done.
     public: MeshOptimization Optimization() const;
 
     /// \brief Get the mesh's optimization method
     /// \return The mesh optimization method.
-    /// Empty string if no mesh simplificaton is done.
+    /// Empty string if no mesh simplification is done.
     public: std::string OptimizationStr() const;
 
     /// \brief Set the mesh optimization method.

--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -18,9 +18,11 @@
 #define SDF_MODEL_HH_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
+
 #include <gz/math/Pose3.hh>
 #include <gz/utils/ImplPtr.hh>
 #include "sdf/Element.hh"
@@ -218,7 +220,7 @@ namespace sdf
     /// \sa bool JointNameExists(const std::string &_name) const
     public: const Joint *JointByName(const std::string &_name) const;
 
-    /// \brief Get a mubtable joint based on a name.
+    /// \brief Get a mutable joint based on a name.
     /// \param[in] _name Name of the joint.
     /// To get a joint in a nested model, prefix the joint name with the
     /// sequence of nested models containing this joint, delimited by "::".
@@ -510,7 +512,7 @@ namespace sdf
 
     /// \brief Calculate and set the inertials for all the links belonging
     /// to the model object
-    /// \param[out] _errrors A vector of Errors objects. Each errors contains an
+    /// \param[out] _errors A vector of Errors objects. Each errors contains an
     /// Error code and a message. An empty errors vector indicates no errors
     /// \param[in] _config Custom parser configuration
     public: void ResolveAutoInertials(sdf::Errors &_errors,
@@ -543,7 +545,7 @@ namespace sdf
     private: bool IsMerged() const;
 
     /// \brief Prepare the model to be merged into the parent model or world.
-    /// As part of the perparation, this will create the proxy frame that would
+    /// As part of the preparation, this will create the proxy frame that would
     /// be need to be added to the parent object.
     /// \param[out] _errors A list of errors encountered during the operation.
     /// \param[in] _parentOfProxyFrame Name of parent of the proxy frame that

--- a/include/sdf/Noise.hh
+++ b/include/sdf/Noise.hh
@@ -24,7 +24,7 @@
 
 namespace sdf
 {
-  // Inline bracke to help doxygen filtering.
+  // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   /// \enum NoiseType
   /// \brief The set of noise types.
@@ -56,7 +56,7 @@ namespace sdf
 
     /// \brief Return true the Noise objects do not contain the same values.
     /// \param[_in] _noise Noise value to compare.
-    /// \returen True if 'this' != _noise.
+    /// \return True if 'this' != _noise.
     public: bool operator!=(const Noise &_noise) const;
 
     /// \brief Load the noise based on a element pointer. This is *not*
@@ -78,49 +78,49 @@ namespace sdf
     /// \brief Get the mean of the Gaussian distribution
     /// from which noise values are drawn. This is applicable to "gaussian*"
     /// noise types.
-    /// \return The mean of the Guassian distribution.
+    /// \return The mean of the Gaussian distribution.
     public: double Mean() const;
 
     /// \brief Set the mean of the Gaussian distribution
     /// from which noise values are drawn. This is applicable to "gaussian*"
     /// noise types.
-    /// \param[in] _mean The mean of the Guassian distribution.
+    /// \param[in] _mean The mean of the Gaussian distribution.
     public: void SetMean(double _mean);
 
     /// \brief Get the standard deviation of the Gaussian distribution
     /// from which noise values are drawn. This is applicable to "gaussian*"
     /// noise types.
-    /// \return The standard deviation of the Guassian distribution.
+    /// \return The standard deviation of the Gaussian distribution.
     public: double StdDev() const;
 
     /// \brief Set the standard deviation of the Gaussian distribution
     /// from which noise values are drawn. This is applicable to "gaussian*"
     /// noise types.
-    /// \param[in] _stddev The standard deviation of the Guassian distribution.
+    /// \param[in] _stddev The standard deviation of the Gaussian distribution.
     public: void SetStdDev(double _stddev);
 
     /// \brief Get the mean of the Gaussian distribution
     /// from which bias values are drawn. This is applicable to "gaussian*"
     /// noise types.
-    /// \return The mean of the bias Guassian distribution.
+    /// \return The mean of the bias Gaussian distribution.
     public: double BiasMean() const;
 
     /// \brief Set the mean of the Gaussian distribution
     /// from which bias values are drawn. This is applicable to "gaussian*"
     /// noise types.
-    /// \param[in] _bias The mean of the bias Guassian distribution.
+    /// \param[in] _bias The mean of the bias Gaussian distribution.
     public: void SetBiasMean(double _bias);
 
     /// \brief Get the standard deviation of the Gaussian distribution
     /// from which bias values are drawn. This is applicable to "gaussian*"
     /// noise types.
-    /// \return The standard deviation of the bias Guassian distribution.
+    /// \return The standard deviation of the bias Gaussian distribution.
     public: double BiasStdDev() const;
 
     /// \brief Set the standard deviation of the Gaussian distribution
     /// from which bias values are drawn. This is applicable to "gaussian*"
     /// noise types.
-    /// \param[in] _bias The standard deviation of the bias Guassian
+    /// \param[in] _bias The standard deviation of the bias Gaussian
     /// distribution.
     public: void SetBiasStdDev(double _bias);
 

--- a/include/sdf/OutputConfig.hh
+++ b/include/sdf/OutputConfig.hh
@@ -34,7 +34,7 @@ class OutputConfigPrivate;
 
 /// This class contains configuration options for SDF output. Output
 /// configuration can be used to specify how SDF is generated from in-memory
-/// represenations, such as the DOM classes.
+/// representations, such as the DOM classes.
 ///
 /// Example:
 /// The default behavior of the `ToElement` functions is to use `<include>`

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -339,7 +339,7 @@ namespace sdf
 
     /// \brief Reparse the parameter value. This should be called after the
     /// parent element's attributes have been modified, in the event that the
-    /// value was set using SetFromString or posesses a default value, and that
+    /// value was set using SetFromString or possesses a default value, and that
     /// the final parsed value is dependent on the attributes of the parent
     /// element. For example, the rotation component of a pose element can
     /// be parsed as degrees or radians, depending on the attribute @degrees
@@ -352,7 +352,7 @@ namespace sdf
 
     /// \brief Reparse the parameter value. This should be called after the
     /// parent element's attributes have been modified, in the event that the
-    /// value was set using SetFromString or posesses a default value, and that
+    /// value was set using SetFromString or possesses a default value, and that
     /// the final parsed value is dependent on the attributes of the parent
     /// element. For example, the rotation component of a pose element can
     /// be parsed as degrees or radians, depending on the attribute @degrees

--- a/include/sdf/ParserConfig.hh
+++ b/include/sdf/ParserConfig.hh
@@ -158,13 +158,13 @@ class SDFORMAT_VISIBLE ParserConfig
   public: const SchemeToPathMap &URIPathMap() const;
 
   /// \brief Associate paths to a URI.
-  /// Example paramters: "model://", "/usr/share/models:~/.gazebo/models"
+  /// Example parameters: "model://", "/usr/share/models:~/.gazebo/models"
   /// \param[in] _uri URI that will be mapped to _path
   /// \param[in] _path Colon separated set of paths.
   /// \sa sdf::findFile() for the order of search operations
   public: void AddURIPath(const std::string &_uri, const std::string &_path);
 
-  /// \brief Set the warning enforcment policy.
+  /// \brief Set the warning enforcement policy.
   /// \param[in] _policy policy enum value to set
   public: void SetWarningsPolicy(EnforcementPolicy _policy);
 
@@ -172,7 +172,7 @@ class SDFORMAT_VISIBLE ParserConfig
   /// \return The warning enforcement policy enum value
   public: EnforcementPolicy WarningsPolicy() const;
 
-  /// \brief Set the policy for unrecogonized elements without an xmlns
+  /// \brief Set the policy for unrecognized elements without an xmlns
   /// \param[in] _policy The unrecognized elements enforcement policy
   public: void SetUnrecognizedElementsPolicy(EnforcementPolicy _policy);
 
@@ -189,11 +189,11 @@ class SDFORMAT_VISIBLE ParserConfig
   public: void ResetDeprecatedElementsPolicy();
 
   /// \brief Get the current deprecated elements policy. By default, the policy
-  /// is the same as the overall WarningsPolicy, but it can be overriden by
-  /// SetDeprecatedElementsPolicy. Once it is overriden, changing
+  /// is the same as the overall WarningsPolicy, but it can be overridden by
+  /// SetDeprecatedElementsPolicy. Once it is overridden, changing
   /// SetWarningsPolicy will not change the value of DeprecatedElementsPolicy
   /// unless ResetDeprecatedElementsPolicy is called.
-  /// \return The deperacted elements policy enum value
+  /// \return The deprecated elements policy enum value
   public: EnforcementPolicy DeprecatedElementsPolicy() const;
 
   /// \brief Get the current configuration for the CalculateInertial()

--- a/include/sdf/ParticleEmitter.hh
+++ b/include/sdf/ParticleEmitter.hh
@@ -151,7 +151,7 @@ namespace sdf
 
     /// \brief Set the amount by which to scale the particles in both x
     /// and y direction per second.
-    /// \param[in] _scaleRate The caling amount in the x and y directions.
+    /// \param[in] _scaleRate The calling amount in the x and y directions.
     /// A value of zero will be used if _scaleRate is negative.
     public: void SetScaleRate(double _scaleRate);
 
@@ -176,7 +176,7 @@ namespace sdf
     /// \brief Get the size of the emitter where the particles are sampled.
     // Default value is (1, 1, 1).
     // Note that the interpretation of the emitter area varies
-    // depending on the emmiter type:
+    // depending on the emitter type:
     //   - point: The area is ignored.
     //   - box: The area is interpreted as width X height X depth.
     //   - cylinder: The area is interpreted as the bounding box of the

--- a/include/sdf/Pbr.hh
+++ b/include/sdf/Pbr.hh
@@ -26,7 +26,7 @@
 
 namespace sdf
 {
-  // Inline bracke to help doxygen filtering.
+  // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   //
 
@@ -70,13 +70,13 @@ namespace sdf
 
     /// \brief Return true if both PbrWorkflow objects contain the same values.
     /// \param[_in] _workflow PbrWorkflow value to compare.
-    /// \returen True if 'this' == _workflow.
+    /// \return True if 'this' == _workflow.
     public: bool operator==(const PbrWorkflow &_workflow) const;
 
     /// \brief Return true this PbrWorkflow object does not contain the same
     /// values as the passed in parameter.
     /// \param[_in] _workflow PbrWorkflow value to compare.
-    /// \returen True if 'this' != _workflow.
+    /// \return True if 'this' != _workflow.
     public: bool operator!=(const PbrWorkflow &_workflow) const;
 
     /// \brief Get the albedo map filename. This will be an empty string if

--- a/include/sdf/SDFImpl.hh
+++ b/include/sdf/SDFImpl.hh
@@ -61,11 +61,11 @@ namespace sdf
   ///    scheme of the input.
   /// 2. If enabled via _searchLocalPath, prepend the input with the current
   ///    working directory and check if the result path exists.
-  /// 3. Seach in the path defined by the macro `SDF_SHARE_PATH`.
+  /// 3. Search in the path defined by the macro `SDF_SHARE_PATH`.
   /// 4. Search in the the libsdformat install path. The path is formed by
   ///    has the pattern `SDF_SHARE_PATH/sdformat<major version>/<version>/`
   /// 5. Directly check if the input path exists in the filesystem.
-  /// 6. Seach in the path defined by the environment variable `SDF_PATH`.
+  /// 6. Search in the path defined by the environment variable `SDF_PATH`.
   /// 7. If enabled via _useCallback and the global callback function is set,
   ///    invoke the function and return its result.
   ///
@@ -85,11 +85,11 @@ namespace sdf
   /// The search order in the function is as follows:
   /// 1. Using the global URI path map, search in paths associated with the URI
   ///    scheme of the input.
-  /// 2. Seach in the path defined by the macro `SDF_SHARE_PATH`.
+  /// 2. Search in the path defined by the macro `SDF_SHARE_PATH`.
   /// 3. Search in the the libsdformat install path. The path is formed by
   ///    has the pattern `SDF_SHARE_PATH/sdformat<major version>/<version>/`
   /// 4. Directly check if the input path exists in the filesystem.
-  /// 5. Seach in the path defined by the environment variable `SDF_PATH`.
+  /// 5. Search in the path defined by the environment variable `SDF_PATH`.
   /// 6. If enabled via _searchLocalPath, prepend the input with the current
   ///    working directory and check if the result path exists.
   /// 7. If enabled via _useCallback and the global callback function is set,
@@ -149,7 +149,7 @@ namespace sdf
                        const ParserConfig &_config);
 
   /// \brief Associate paths to a URI.
-  /// Example paramters: "model://", "/usr/share/models:~/.gazebo/models"
+  /// Example parameters: "model://", "/usr/share/models:~/.gazebo/models"
   /// \param[in] _uri URI that will be mapped to _path
   /// \param[in] _path Colon separated set of paths.
   SDFORMAT_VISIBLE
@@ -179,7 +179,7 @@ namespace sdf
     public: void PrintValues(const PrintConfig &_config = PrintConfig());
 
     /// \brief Output SDF's values to stdout.
-    /// \param[out] _errors Vector of errrors.
+    /// \param[out] _errors Vector of errors.
     /// \param[in] _config Configuration for printing the values.
     public: void PrintValues(sdf::Errors &_errors,
                              const PrintConfig &_config = PrintConfig());

--- a/include/sdf/Sensor.hh
+++ b/include/sdf/Sensor.hh
@@ -268,13 +268,13 @@ namespace sdf
 
     /// \brief Return true if both Sensor objects contain the same values.
     /// \param[_in] _sensor Sensor object to compare.
-    /// \returen True if 'this' == _sensor.
+    /// \return True if 'this' == _sensor.
     public: bool operator==(const Sensor &_sensor) const;
 
     /// \brief Return true this Sensor object does not contain the same
     /// values as the passed in parameter.
     /// \param[_in] _sensor Sensor object to compare.
-    /// \returen True if 'this' != _sensor.
+    /// \return True if 'this' != _sensor.
     public: bool operator!=(const Sensor &_sensor) const;
 
     /// \brief Get the magnetometer sensor, or nullptr if this sensor type

--- a/include/sdf/Sky.hh
+++ b/include/sdf/Sky.hh
@@ -94,7 +94,7 @@ namespace sdf
     /// \return cloud mean size [0..1]
     public: double CloudMeanSize() const;
 
-    /// \brief Set cloud mean siz
+    /// \brief Set cloud mean size
     /// \param[in] _size cloud mean size [0..1]
     public: void SetCloudMeanSize(double _size);
 

--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -142,7 +142,7 @@ namespace sdf
     public: double Friction() const;
 
     /// \brief Set friction coefficient in first friction pyramid direction.
-    /// \param[in] _fricton Friction coefficient
+    /// \param[in] _friction Friction coefficient
     public: void SetFriction(double _friction);
 
     /// \brief Get the friction coefficient in second friction pyramid
@@ -151,7 +151,7 @@ namespace sdf
     public: double Friction2() const;
 
     /// \brief Set friction coefficient in second friction pyramid direction.
-    /// \param[in] _fricton Friction coefficient
+    /// \param[in] _friction Friction coefficient
     public: void SetFriction2(double _friction);
 
     /// \brief Get the first friction pyramid direction in collision-fixed
@@ -201,7 +201,7 @@ namespace sdf
     public: double Coefficient() const;
 
     /// \brief Set the torsional friction coefficient.
-    /// \param[in] _fricton Torsional friction coefficient
+    /// \param[in] _friction Torsional friction coefficient
     public: void SetCoefficient(double _coefficient);
 
     /// \brief Get whether the patch radius is used to calculate torsional

--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -25,7 +25,6 @@
 #include <utility>
 #include <vector>
 
-#include <gz/utils/NeverDestroyed.hh>
 #include "sdf/config.hh"
 #include "sdf/system_util.hh"
 #include "sdf/Error.hh"
@@ -146,10 +145,10 @@ namespace sdf
 
   /// \brief Transforms a string to its lowercase equivalent
   /// \param[in] _in String to convert to lowercase
-  /// \return Lowercase equilvalent of _in.
+  /// \return Lowercase equivalent of _in.
   std::string SDFORMAT_VISIBLE lowercase(const std::string &_in);
 
-  /// \brief Split a name into a two strings based on the '::' delimeter
+  /// \brief Split a name into a two strings based on the '::' delimiter
   /// \param[in] _absoluteName The fully qualified absolute name
   /// \return A pair with the absolute name minus the leaf node name, and the
   /// leaf name
@@ -161,7 +160,7 @@ namespace sdf
   /// This checks for edge cases and is safe to use with any valid names
   /// \param[in] _scopeName the left-hand-side component
   /// \param[in] _localName the right-hand-side component
-  /// \return A full string with the names joined by the '::' delimeter.
+  /// \return A full string with the names joined by the '::' delimiter.
   SDFORMAT_VISIBLE
   std::string JoinName(
       const std::string &_scopeName, const std::string &_localName);

--- a/include/sdf/Visual.hh
+++ b/include/sdf/Visual.hh
@@ -164,7 +164,7 @@ namespace sdf
     /// \return True if the lidar reflective intensity was set was set.
     public: bool HasLaserRetro() const;
 
-    /// \brief Get the flidar reflective intensity.
+    /// \brief Get the lidar reflective intensity.
     /// \return The lidar reflective intensity.
     public: double LaserRetro() const;
 

--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -404,7 +404,7 @@ namespace sdf
 
     /// \brief Get a pointer to the atmosphere model associated with this
     /// world. A nullptr indicates that an atmosphere model has not been set.
-    /// \return Pointer to this world's atmosphere model. Nullptr inidicates
+    /// \return Pointer to this world's atmosphere model. Nullptr indicates
     /// that there is no atmosphere model.
     public: const sdf::Atmosphere *Atmosphere() const;
 
@@ -414,7 +414,7 @@ namespace sdf
 
     /// \brief Get a pointer to the Gui associated with this
     /// world. A nullptr indicates that a Gui element has not been specified.
-    /// \return Pointer to this world's Gui parameters. Nullptr inidicates
+    /// \return Pointer to this world's Gui parameters. Nullptr indicates
     /// that there are no Gui parameters.
     public: const sdf::Gui *Gui() const;
 
@@ -424,7 +424,7 @@ namespace sdf
 
     /// \brief Get a pointer to the Scene associated with this
     /// world. A nullptr indicates that a Scene element has not been specified.
-    /// \return Pointer to this world's Scene parameters. Nullptr inidicates
+    /// \return Pointer to this world's Scene parameters. Nullptr indicates
     /// that there are no Scene parameters.
     public: const sdf::Scene *Scene() const;
 
@@ -532,7 +532,7 @@ namespace sdf
 
     /// \brief Calculate and set the inertials for all the models in the world
     /// object
-    /// \param[out] _errrors A vector of Errors objects. Each errors contains an
+    /// \param[out] _errors A vector of Errors objects. Each errors contains an
     /// Error code and a message. An empty errors vector indicates no errors
     /// \param[in] _config Custom parser configuration
     public: void ResolveAutoInertials(sdf::Errors &_errors,

--- a/python/src/sdf/pyCamera.cc
+++ b/python/src/sdf/pyCamera.cc
@@ -166,7 +166,7 @@ void defineCamera(pybind11::object module)
     .def("set_distortion_center", &sdf::Camera::SetDistortionCenter,
          "Set the distortion center or principal point.")
     .def("raw_pose", &sdf::Camera::RawPose,
-         "Get the pose of the camer. This is the pose of the camera "
+         "Get the pose of the camera. This is the pose of the camera "
          "as specified in SDF (<camera> <pose> ... </pose></camera>).")
     .def("set_raw_pose", &sdf::Camera::SetRawPose,
          "Set the pose of the camera.")
@@ -269,9 +269,9 @@ void defineCamera(pybind11::object module)
     .def("set_visibility_mask", &sdf::Camera::SetVisibilityMask,
          "Set the visibility mask of a camera")
     .def("has_lens_intrinsics", &sdf::Camera::HasLensIntrinsics,
-         "Get whether or not the camera has instrinsics values set")
+         "Get whether or not the camera has intrinsics values set")
     .def("has_lens_projection", &sdf::Camera::HasLensProjection,
-         "Get whether or not the camera has proejction values set")
+         "Get whether or not the camera has projection values set")
     .def("__copy__", [](const sdf::Camera &self) {
       return sdf::Camera(self);
     })

--- a/python/src/sdf/pyCollision.cc
+++ b/python/src/sdf/pyCollision.cc
@@ -62,7 +62,7 @@ void defineCollision(pybind11::object module)
          "Set the collision's surface parameters")
     .def("raw_pose", &sdf::Collision::RawPose,
          "Get the pose of the collision object. This is the pose of the "
-         "collison as specified in SDF")
+         "collision as specified in SDF")
     .def("set_raw_pose", &sdf::Collision::SetRawPose,
          "Set the pose of the collision object.")
     .def("pose_relative_to", &sdf::Collision::PoseRelativeTo,

--- a/python/src/sdf/pyGeometry.cc
+++ b/python/src/sdf/pyGeometry.cc
@@ -83,7 +83,7 @@ void defineGeometry(pybind11::object module)
          "Get the ellipsoid geometry, or None if the contained "
          "geometry is not a ellipsoid.")
     .def("set_ellipsoid_shape", &sdf::Geometry::SetEllipsoidShape,
-         "Set the elliposid shape.")
+         "Set the ellipsoid shape.")
     .def("sphere_shape", &sdf::Geometry::SphereShape,
          pybind11::return_value_policy::reference,
          "Get the sphere geometry, or None if the contained "

--- a/python/src/sdf/pyLight.cc
+++ b/python/src/sdf/pyLight.cc
@@ -53,7 +53,7 @@ void defineLight(pybind11::object module)
     .def("set_name", &sdf::Light::SetName,
          "Set the name of the light.")
     .def("raw_pose", &sdf::Light::RawPose,
-         "Get the pose of the camer. This is the pose of the Light "
+         "Get the pose of the camera. This is the pose of the Light "
          "as specified in SDF (<light> <pose> ... </pose></light>).")
     .def("set_raw_pose", &sdf::Light::SetRawPose,
          "Set the pose of the Light.")
@@ -116,12 +116,12 @@ void defineLight(pybind11::object module)
     .def("constant_attenuation_factor", &sdf::Light::ConstantAttenuationFactor,
          "Get the constant attenuation factor. This value is clamped to "
          "a value between 0 and 1,  where 1.0 means never attenuate and 0.0 is "
-         "complete attenutation.")
+         "complete attenuation.")
     .def("set_constant_attenuation_factor",
          &sdf::Light::SetConstantAttenuationFactor,
          "Get the constant attenuation factor. This value is clamped to "
          "a value between 0 and 1,  where 1.0 means never attenuate and 0.0 is "
-         "complete attenutation.")
+         "complete attenuation.")
     .def("quadratic_attenuation_factor", &sdf::Light::QuadraticAttenuationFactor,
          "Get the quadratic attenuation factor which adds a curvature to "
          "the attenuation.")

--- a/python/src/sdf/pyParserConfig.cc
+++ b/python/src/sdf/pyParserConfig.cc
@@ -63,13 +63,13 @@ void defineParserConfig(pybind11::object module)
          "Associate paths to a URI.")
     .def("set_warnings_policy",
          &sdf::ParserConfig::SetWarningsPolicy,
-         "Set the warning enforcment policy.")
+         "Set the warning enforcement policy.")
     .def("warnings_policy",
          &sdf::ParserConfig::WarningsPolicy,
          "Get the current warning enforcement policy")
     .def("set_unrecognized_elements_policy",
          &sdf::ParserConfig::SetUnrecognizedElementsPolicy,
-         "Set the policy for unrecogonized elements without an xmlns")
+         "Set the policy for unrecognized elements without an xmlns")
     .def("unrecognized_elements_policy",
          &sdf::ParserConfig::UnrecognizedElementsPolicy,
          "Get the current unrecognized elements policy")

--- a/python/src/sdf/pyParticleEmitter.cc
+++ b/python/src/sdf/pyParticleEmitter.cc
@@ -118,7 +118,7 @@ void defineParticleEmitter(pybind11::object module)
          "Set the particle scatter ratio. This is used to determine the "
          "ratio of particles that will be detected by sensors.")
     .def("raw_pose", &sdf::ParticleEmitter::RawPose,
-         "Get the pose of the camer. This is the pose of the ParticleEmitter "
+         "Get the pose of the camera. This is the pose of the ParticleEmitter "
          "as specified in SDF (<particle_emitter> <pose> ... "
          "</pose></particle_emitter>).")
     .def("set_raw_pose", &sdf::ParticleEmitter::SetRawPose,

--- a/python/src/sdf/pySurface.cc
+++ b/python/src/sdf/pySurface.cc
@@ -147,7 +147,7 @@ void defineBulletFriction(pybind11::object module)
     .def("set_fdir1", &sdf::BulletFriction::SetFdir1,
          "Set the fdir1 parameter.")
     .def("rolling_friction", &sdf::BulletFriction::RollingFriction,
-         "Get the rolling fricion parameter.")
+         "Get the rolling friction parameter.")
     .def("set_rolling_friction", &sdf::BulletFriction::SetRollingFriction,
          "Set the rolling friction parameter.")
     .def("__copy__", [](const sdf::BulletFriction &self) {

--- a/python/src/sdf/pyVisual.cc
+++ b/python/src/sdf/pyVisual.cc
@@ -58,7 +58,7 @@ void defineVisual(pybind11::object module)
          "Set the visual's geometry")
     .def("raw_pose", &sdf::Visual::RawPose,
          "Get the pose of the visual object. This is the pose of the "
-         "collison as specified in SDF")
+         "collision as specified in SDF")
     .def("set_raw_pose", &sdf::Visual::SetRawPose,
          "Set the pose of the visual object.")
     .def("pose_relative_to", &sdf::Visual::PoseRelativeTo,
@@ -87,7 +87,7 @@ void defineVisual(pybind11::object module)
     .def("has_laser_retro", &sdf::Visual::HasLaserRetro,
          "Get whether the lidar reflective intensity was set was set.")
     .def("laser_retro", &sdf::Visual::LaserRetro,
-         "Get the flidar reflective intensity.")
+         "Get the lidar reflective intensity.")
     .def("set_laser_retro", &sdf::Visual::SetLaserRetro,
          "Set the lidar reflective intensity.")
     .def("plugins",

--- a/python/src/sdf/pybind11_helpers.hh
+++ b/python/src/sdf/pybind11_helpers.hh
@@ -37,7 +37,7 @@ void ThrowIfErrors(const sdf::Errors &_errors);
 
 
 /// \brief Implementation for ErrorWrappedCast
-// NOTE: This currently only works for member funtions
+// NOTE: This currently only works for member functions
 template <typename... Args>
 struct ErrorWrappedCastImpl
 {

--- a/python/test/pyCapsule_TEST.py
+++ b/python/test/pyCapsule_TEST.py
@@ -110,7 +110,7 @@ class CapsuleTEST(unittest.TestCase):
   def test_calculate_inertial(self):
     capsule = Capsule()
 
-    # density of aluminium
+    # density of Aluminum
     density = 2710
     l = 2.0
     r = 0.1

--- a/python/test/pyCylinder_TEST.py
+++ b/python/test/pyCylinder_TEST.py
@@ -111,7 +111,7 @@ class CylinderTEST(unittest.TestCase):
   def test_calculate_interial(self):
     cylinder = Cylinder()
 
-    # density of aluminium
+    # density of Aluminum
     density = 2170
 
     # Invalid dimensions leading to None return in

--- a/python/test/pyElement_TEST.py
+++ b/python/test/pyElement_TEST.py
@@ -39,7 +39,7 @@ class ElementTEST(unittest.TestCase):
         self.assertEqual(elem.get_required(), "1")
 
     def test_set_explicitly_set_in_file(self):
-        # The heirarchy in xml:
+        # The hierarchy in xml:
         # <parent>
         #   <elem>
         #     <child>
@@ -69,7 +69,7 @@ class ElementTEST(unittest.TestCase):
 
         self.assertTrue(elem.get_explicitly_set_in_file())
 
-        # the childs and siblings of the element should all be
+        # the children and siblings of the element should all be
         # set to the same value when using this function
         child = Element()
         child.set_parent(elem)

--- a/python/test/pyEllipsoid_TEST.py
+++ b/python/test/pyEllipsoid_TEST.py
@@ -80,7 +80,7 @@ class BoxTEST(unittest.TestCase):
   def test_calculate_inertial(self):
     ellipsoid = Ellipsoid()
 
-    # density of aluminium
+    # density of Aluminum
     density = 2170
 
     # Invalid dimensions leading to std::nullopt return in

--- a/python/test/pyGeometry_TEST.py
+++ b/python/test/pyGeometry_TEST.py
@@ -224,7 +224,7 @@ class GeometryTEST(unittest.TestCase):
   def test_calculate_inertial(self):
     geom = Geometry()
 
-    # Density of Aluminimum
+    # Density of Aluminum
     density = 2170.0
     expectedMass = 0
     expectedMassMat = MassMatrix3d()

--- a/python/test/pyLink_TEST.py
+++ b/python/test/pyLink_TEST.py
@@ -484,7 +484,7 @@ class LinkTEST(unittest.TestCase):
 
     def test_inertial_values_given_with_auto_set_to_true(self):
         # The inertia matrix is specified but should be ignored.
-        # <mass> is not speicifed so the inertial values should be computed
+        # <mass> is not specified so the inertial values should be computed
         # based on the collision density value.
         sdf = "<?xml version=\"1.0\"?>" + \
         "<sdf version=\"1.11\">" + \
@@ -528,7 +528,7 @@ class LinkTEST(unittest.TestCase):
 
     def test_resolveauto_inertialsWithMass(self):
         # The inertia matrix is specified but should be ignored.
-        # <mass> is speicifed - the auto computed inertial values should
+        # <mass> is specified - the auto computed inertial values should
         # be scaled based on the desired mass.
         sdf = "<?xml version=\"1.0\"?>" + \
         "<sdf version=\"1.11\">" + \
@@ -573,7 +573,7 @@ class LinkTEST(unittest.TestCase):
 
     def test_resolveauto_inertialsWithMassAndMultipleCollisions(self):
         # The inertia matrix is specified but should be ignored.
-        # <mass> is speicifed - the auto computed inertial values should
+        # <mass> is specified - the auto computed inertial values should
         # be scaled based on the desired mass.
         sdf = "<?xml version=\"1.0\"?>" + \
         "<sdf version=\"1.11\">" + \
@@ -629,7 +629,7 @@ class LinkTEST(unittest.TestCase):
 
     def test_resolveauto_inertialsWithMassAndDefaultDensity(self):
         # The inertia matrix is specified but should be ignored.
-        # <mass> is speicifed - the auto computed inertial values should
+        # <mass> is specified - the auto computed inertial values should
         # be scaled based on the desired mass.
         # Density is not specified for the bottom collision - it should
         # use the default value

--- a/python/test/pyPlugin_TEST.py
+++ b/python/test/pyPlugin_TEST.py
@@ -87,7 +87,7 @@ class PluginTEST(unittest.TestCase):
 
         completePlugin = "<plugin name='my-name' filename='my-filename'>\n" + completeContent + "</plugin>\n"
 
-        # Try out curly braces intitialization
+        # Try out curly braces initialization
         plugin2 = Plugin(plugin.filename(), plugin.name(), completeContent)
 
         # Try to insert poorly formed XML, which should fail and not modify the
@@ -97,17 +97,17 @@ class PluginTEST(unittest.TestCase):
         # An empty string will also fail and not modify the content
         self.assertFalse(plugin2.insert_content(""))
 
-        # Contructing a new plugin with no content
+        # Constructing a new plugin with no content
         plugin3 = Plugin("a filename", "a name")
         self.assertEqual("a filename", plugin3.filename())
         self.assertEqual("a name", plugin3.name())
 
-        # Contructing a new plugin with bad XML content
+        # Constructing a new plugin with bad XML content
         plugin4 = Plugin("filename", "name", "<garbage>")
         self.assertEqual("filename", plugin4.filename())
         self.assertEqual("name", plugin4.name())
 
-        # Contructing a new plugin with bad XML content
+        # Constructing a new plugin with bad XML content
         plugin5 = Plugin("filename", "name", "    ")
         self.assertEqual("filename", plugin5.filename())
         self.assertEqual("name", plugin5.name())

--- a/python/test/pySphere_TEST.py
+++ b/python/test/pySphere_TEST.py
@@ -80,7 +80,7 @@ class SphereTEST(unittest.TestCase):
   def test_calculate_inertial(self):
     sphere = Sphere()
 
-    # density of aluminium
+    # density of Aluminum
     density = 2170
 
     sphere.set_radius(-2)

--- a/sdf/1.10/camera.sdf
+++ b/sdf/1.10/camera.sdf
@@ -98,7 +98,7 @@
                                             on the visible parts of the objects
 
         - full_2d | full_box_2d: a full 2d box mode which provides axis aligned 2d boxes that fills the
-                                 object dimentions, even if it has an occluded part
+                                 object dimensions, even if it has an occluded part
 
         - 3d: a 3d mode which provides oriented 3d boxes
     </description>

--- a/sdf/1.10/frame.sdf
+++ b/sdf/1.10/frame.sdf
@@ -4,7 +4,7 @@
 
   <attribute name="name" type="string" default="" required="1">
     <description>
-      Name of the frame. It must be unique whithin its scope (model/world),
+      Name of the frame. It must be unique within its scope (model/world),
       i.e., it must not match the name of another frame, link, joint, or model
       within the same scope.
     </description>

--- a/sdf/1.10/model.sdf
+++ b/sdf/1.10/model.sdf
@@ -86,7 +86,7 @@
   </element>
 
   <element name="enable_wind" type="bool" default="false" required="0">
-    <description>If set to true, all links in the model will be affected by the wind. Can be overriden by the link wind property.</description>
+    <description>If set to true, all links in the model will be affected by the wind. Can be overridden by the link wind property.</description>
   </element>
 
 </element> <!-- End Model -->

--- a/sdf/1.10/transceiver.sdf
+++ b/sdf/1.10/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/sdf/1.11/camera.sdf
+++ b/sdf/1.11/camera.sdf
@@ -98,7 +98,7 @@
                                             on the visible parts of the objects
 
         - full_2d | full_box_2d: a full 2d box mode which provides axis aligned 2d boxes that fills the
-                                 object dimentions, even if it has an occluded part
+                                 object dimensions, even if it has an occluded part
 
         - 3d: a 3d mode which provides oriented 3d boxes
     </description>

--- a/sdf/1.11/frame.sdf
+++ b/sdf/1.11/frame.sdf
@@ -4,7 +4,7 @@
 
   <attribute name="name" type="string" default="" required="1">
     <description>
-      Name of the frame. It must be unique whithin its scope (model/world),
+      Name of the frame. It must be unique within its scope (model/world),
       i.e., it must not match the name of another frame, link, joint, or model
       within the same scope.
     </description>

--- a/sdf/1.11/model.sdf
+++ b/sdf/1.11/model.sdf
@@ -86,7 +86,7 @@
   </element>
 
   <element name="enable_wind" type="bool" default="false" required="0">
-    <description>If set to true, all links in the model will be affected by the wind. Can be overriden by the link wind property.</description>
+    <description>If set to true, all links in the model will be affected by the wind. Can be overridden by the link wind property.</description>
   </element>
 
 </element> <!-- End Model -->

--- a/sdf/1.11/transceiver.sdf
+++ b/sdf/1.11/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/sdf/1.12/camera.sdf
+++ b/sdf/1.12/camera.sdf
@@ -98,7 +98,7 @@
                                             on the visible parts of the objects
 
         - full_2d | full_box_2d: a full 2d box mode which provides axis aligned 2d boxes that fills the
-                                 object dimentions, even if it has an occluded part
+                                 object dimensions, even if it has an occluded part
 
         - 3d: a 3d mode which provides oriented 3d boxes
     </description>

--- a/sdf/1.12/frame.sdf
+++ b/sdf/1.12/frame.sdf
@@ -4,7 +4,7 @@
 
   <attribute name="name" type="string" default="" required="1">
     <description>
-      Name of the frame. It must be unique whithin its scope (model/world),
+      Name of the frame. It must be unique within its scope (model/world),
       i.e., it must not match the name of another frame, link, joint, or model
       within the same scope.
     </description>

--- a/sdf/1.12/model.sdf
+++ b/sdf/1.12/model.sdf
@@ -89,7 +89,7 @@
   <include filename="model_state.sdf" required="0"/>
 
   <element name="enable_wind" type="bool" default="false" required="0">
-    <description>If set to true, all links in the model will be affected by the wind. Can be overriden by the link wind property.</description>
+    <description>If set to true, all links in the model will be affected by the wind. Can be overridden by the link wind property.</description>
   </element>
 
 </element> <!-- End Model -->

--- a/sdf/1.12/transceiver.sdf
+++ b/sdf/1.12/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/sdf/1.4/transceiver.sdf
+++ b/sdf/1.4/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/sdf/1.5/transceiver.sdf
+++ b/sdf/1.5/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/sdf/1.6/model.sdf
+++ b/sdf/1.6/model.sdf
@@ -58,7 +58,7 @@
   </element>
 
   <element name="enable_wind" type="bool" default="false" required="0">
-    <description>If set to true, all links in the model will be affected by the wind. Can be overriden by the link wind property.</description>
+    <description>If set to true, all links in the model will be affected by the wind. Can be overridden by the link wind property.</description>
   </element>
 
 </element> <!-- End Model -->

--- a/sdf/1.6/transceiver.sdf
+++ b/sdf/1.6/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/sdf/1.7/frame.sdf
+++ b/sdf/1.7/frame.sdf
@@ -4,7 +4,7 @@
 
   <attribute name="name" type="string" default="" required="1">
     <description>
-      Name of the frame. It must be unique whithin its scope (model/world),
+      Name of the frame. It must be unique within its scope (model/world),
       i.e., it must not match the name of another frame, link, joint, or model
       within the same scope.
     </description>

--- a/sdf/1.7/model.sdf
+++ b/sdf/1.7/model.sdf
@@ -73,7 +73,7 @@
   </element>
 
   <element name="enable_wind" type="bool" default="false" required="0">
-    <description>If set to true, all links in the model will be affected by the wind. Can be overriden by the link wind property.</description>
+    <description>If set to true, all links in the model will be affected by the wind. Can be overridden by the link wind property.</description>
   </element>
 
 </element> <!-- End Model -->

--- a/sdf/1.7/transceiver.sdf
+++ b/sdf/1.7/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/sdf/1.8/frame.sdf
+++ b/sdf/1.8/frame.sdf
@@ -4,7 +4,7 @@
 
   <attribute name="name" type="string" default="" required="1">
     <description>
-      Name of the frame. It must be unique whithin its scope (model/world),
+      Name of the frame. It must be unique within its scope (model/world),
       i.e., it must not match the name of another frame, link, joint, or model
       within the same scope.
     </description>

--- a/sdf/1.8/model.sdf
+++ b/sdf/1.8/model.sdf
@@ -82,7 +82,7 @@
   </element>
 
   <element name="enable_wind" type="bool" default="false" required="0">
-    <description>If set to true, all links in the model will be affected by the wind. Can be overriden by the link wind property.</description>
+    <description>If set to true, all links in the model will be affected by the wind. Can be overridden by the link wind property.</description>
   </element>
 
 </element> <!-- End Model -->

--- a/sdf/1.8/transceiver.sdf
+++ b/sdf/1.8/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/sdf/1.9/camera.sdf
+++ b/sdf/1.9/camera.sdf
@@ -98,7 +98,7 @@
                                             on the visible parts of the objects
 
         - full_2d | full_box_2d: a full 2d box mode which provides axis aligned 2d boxes that fills the
-                                 object dimentions, even if it has an occluded part
+                                 object dimensions, even if it has an occluded part
 
         - 3d: a 3d mode which provides oriented 3d boxes
     </description>

--- a/sdf/1.9/frame.sdf
+++ b/sdf/1.9/frame.sdf
@@ -4,7 +4,7 @@
 
   <attribute name="name" type="string" default="" required="1">
     <description>
-      Name of the frame. It must be unique whithin its scope (model/world),
+      Name of the frame. It must be unique within its scope (model/world),
       i.e., it must not match the name of another frame, link, joint, or model
       within the same scope.
     </description>

--- a/sdf/1.9/model.sdf
+++ b/sdf/1.9/model.sdf
@@ -86,7 +86,7 @@
   </element>
 
   <element name="enable_wind" type="bool" default="false" required="0">
-    <description>If set to true, all links in the model will be affected by the wind. Can be overriden by the link wind property.</description>
+    <description>If set to true, all links in the model will be affected by the wind. Can be overridden by the link wind property.</description>
   </element>
 
 </element> <!-- End Model -->

--- a/sdf/1.9/transceiver.sdf
+++ b/sdf/1.9/transceiver.sdf
@@ -28,7 +28,7 @@
   </element> <!-- End Power -->
 
   <element name="sensitivity" type="double" default="-90" required="0">
-    <description>Mininum received signal power in dBm</description>
+    <description>Minimum received signal power in dBm</description>
   </element> <!-- End Sensitivity -->
 
 </element> <!-- End Transceiver -->

--- a/src/Actor.cc
+++ b/src/Actor.cc
@@ -100,7 +100,7 @@ class sdf::Actor::Implementation
   /// \brief Time to wait before starting the script.
   public: double scriptDelayStart = 0.0;
 
-  /// \brief True if the animation strat with the simulation.
+  /// \brief True if the animation starts with the simulation.
   public: bool scriptAutoStart = true;
 
   /// \brief Trajectories for the actor.

--- a/src/AirPressure_TEST.cc
+++ b/src/AirPressure_TEST.cc
@@ -90,7 +90,7 @@ TEST(DOMAirPressure, Load)
   EXPECT_NE(nullptr, air.Element());
   EXPECT_EQ(sdf.get(), air.Element().get());
 
-  // The AirPressure::Load function is test more thouroughly in the
+  // The AirPressure::Load function is test more thoroughly in the
   // link_dom.cc integration test.
 }
 

--- a/src/Airspeed_TEST.cc
+++ b/src/Airspeed_TEST.cc
@@ -89,7 +89,7 @@ TEST(DOMAirSpeed, Load)
   EXPECT_NE(nullptr, alt.Element());
   EXPECT_EQ(sdf.get(), alt.Element().get());
 
-  // The AirSpeed::Load function is test more thouroughly in the
+  // The AirSpeed::Load function is test more thoroughly in the
   // link_dom.cc integration test.
 }
 

--- a/src/Altimeter_TEST.cc
+++ b/src/Altimeter_TEST.cc
@@ -98,7 +98,7 @@ TEST(DOMAltimeter, Load)
   EXPECT_NE(nullptr, alt.Element());
   EXPECT_EQ(sdf.get(), alt.Element().get());
 
-  // The Altimeter::Load function is test more thouroughly in the
+  // The Altimeter::Load function is test more thoroughly in the
   // link_dom.cc integration test.
 }
 

--- a/src/Box_TEST.cc
+++ b/src/Box_TEST.cc
@@ -155,7 +155,7 @@ TEST(DOMBox, CalculateInertial)
 {
   sdf::Box box;
 
-  // density of aluminium
+  // density of Aluminum
   double density = 2710;
 
   // Invalid dimensions leading to std::nullopt return in

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -66,7 +66,7 @@ class sdf::Camera::Implementation
   /// \brief Camera trigger topic.
   public: std::string triggerTopic = "";
 
-  /// \brief Horizontal fied of view.
+  /// \brief Horizontal field of view.
   public: gz::math::Angle hfov{1.047};
 
   /// \brief Image width.
@@ -177,16 +177,16 @@ class sdf::Camera::Implementation
   /// \brief lens environment texture size.
   public: int lensEnvTextureSize{256};
 
-  /// \brief lens instrinsics fx.
+  /// \brief lens intrinsics fx.
   public: double lensIntrinsicsFx{277.0};
 
-  /// \brief lens instrinsics fy.
+  /// \brief lens intrinsics fy.
   public: double lensIntrinsicsFy{277.0};
 
-  /// \brief lens instrinsics cx.
+  /// \brief lens intrinsics cx.
   public: double lensIntrinsicsCx{160.0};
 
-  /// \brief lens instrinsics cy.
+  /// \brief lens intrinsics cy.
   public: double lensIntrinsicsCy{120.0};
 
   /// \brief lens projection fx
@@ -207,7 +207,7 @@ class sdf::Camera::Implementation
   /// \brief lens projection ty
   public: double lensProjectionTy{0.0};
 
-  /// \brief lens instrinsics s.
+  /// \brief lens intrinsics s.
   public: double lensIntrinsicsS{0.0};
 
   /// \brief True if this camera has custom intrinsics values

--- a/src/Capsule_TEST.cc
+++ b/src/Capsule_TEST.cc
@@ -191,7 +191,7 @@ TEST(DOMCapsule, CalculateInertial)
 {
   sdf::Capsule capsule;
 
-  // density of aluminium
+  // density of Aluminum
   const double density = 2710;
   const double l = 2.0;
   const double r = 0.1;

--- a/src/Collision_TEST.cc
+++ b/src/Collision_TEST.cc
@@ -324,7 +324,7 @@ TEST(DOMCollision, CalculateInertialWithAutoInertiaParamsElement)
   sdf::ElementPtr autoInertiaParamsElem = collision->AutoInertiaParams();
 
   // <auto_inertial_params> element is used as parent element for custom
-  // intertia calculator params. Custom elements have to be defined with a
+  // inertia calculator params. Custom elements have to be defined with a
   // namespace prefix(gz in this case). More about this can be found in the
   // following proposal:
   // http://sdformat.org/tutorials?tut=custom_elements_attributes_proposal&cat=pose_semantics_docs&

--- a/src/Cone_TEST.cc
+++ b/src/Cone_TEST.cc
@@ -191,7 +191,7 @@ TEST(DOMCone, CalculateInertial)
 {
   sdf::Cone cone;
 
-  // density of aluminium
+  // density of Aluminum
   const double density = 2170;
 
   // Invalid dimensions leading to std::nullopt return in

--- a/src/CustomInertiaCalcProperties.cc
+++ b/src/CustomInertiaCalcProperties.cc
@@ -35,7 +35,7 @@ class CustomInertiaCalcProperties::Implementation
 
   /// \brief SDF element pointer to <auto_inertia_params> tag.
   /// This can be used to access custom params for the
-  /// Inertia Caluclator
+  /// Inertia Calculator
   public: sdf::ElementPtr inertiaCalculatorParams{nullptr};
 };
 

--- a/src/Cylinder.cc
+++ b/src/Cylinder.cc
@@ -15,7 +15,7 @@
  *
 */
 #include <sstream>
-#include <optional>
+#include <utility>
 
 #include <gz/math/Inertial.hh>
 #include "sdf/Cylinder.hh"

--- a/src/Cylinder_TEST.cc
+++ b/src/Cylinder_TEST.cc
@@ -187,7 +187,7 @@ TEST(DOMCylinder, CalculateInertial)
 {
   sdf::Cylinder cylinder;
 
-  // density of aluminium
+  // density of Aluminum
   const double density = 2170;
 
   // Invalid dimensions leading to std::nullopt return in

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -76,7 +76,7 @@ TEST(Element, Required)
 /////////////////////////////////////////////////
 TEST(Element, SetExplicitlySetInFile)
 {
-  // The heirarchy in xml:
+  // The hierarchy in xml:
   // <parent>
   //   <elem>
   //     <child>
@@ -106,7 +106,7 @@ TEST(Element, SetExplicitlySetInFile)
 
   EXPECT_TRUE(elem->GetExplicitlySetInFile());
 
-  // the childs and siblings of the element should all be
+  // the children and siblings of the element should all be
   // set to the same value when using this function
   sdf::ElementPtr child = std::make_shared<sdf::Element>();
   child->SetParent(elem);

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -151,7 +151,7 @@ TEST(DOMEllipsoid, CalculateInertial)
 {
   sdf::Ellipsoid ellipsoid;
 
-  // density of aluminium
+  // density of Aluminum
   const double density = 2170;
 
   // Invalid dimensions leading to std::nullopt return in

--- a/src/Exception.cc
+++ b/src/Exception.cc
@@ -28,7 +28,7 @@ class sdf::Exception::Implementation
   /// \brief The error function
   public: std::string file;
 
-  /// \brief Line the error occured on
+  /// \brief Line the error occurred on
   public: std::int64_t line;
 
   /// \brief The error string

--- a/src/ForceTorque.cc
+++ b/src/ForceTorque.cc
@@ -134,9 +134,9 @@ Errors ForceTorque::Load(ElementPtr _sdf)
   }
 
   auto loadAxisNoise = [&errors](sdf::ElementPtr _parent,
-                          const std::string _groupLabel,
-                          const std::string _axisLabel,
-                          sdf::Noise& _noise)
+                          const std::string &_groupLabel,
+                          const std::string &_axisLabel,
+                          sdf::Noise &_noise)
   {
     if (_parent->HasElement(_groupLabel) &&
         _parent->GetElement(_groupLabel, errors)->HasElement(_axisLabel))

--- a/src/ForceTorque_TEST.cc
+++ b/src/ForceTorque_TEST.cc
@@ -107,7 +107,7 @@ TEST(DOMForceTorque, Load)
   EXPECT_NE(nullptr, ft.Element());
   EXPECT_EQ(sdf.get(), ft.Element().get());
 
-  // The ForceTorque::Load function is tested more thouroughly in the
+  // The ForceTorque::Load function is tested more thoroughly in the
   // link_dom.cc integration test.
 }
 

--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -356,7 +356,7 @@ struct FrameWrapper : public WrapperBase
   {
   }
 
-  /// \brief Constructor from name, pose, and attachement data (without
+  /// \brief Constructor from name, pose, and attachment data (without
   /// sdf::Frame or sdf::InterfaceFrame)
   FrameWrapper(const std::string &_name, const gz::math::Pose3d &_rawPose,
                const std::string &_relativeTo, const std::string &_attachedTo)

--- a/src/Gui.cc
+++ b/src/Gui.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
 */
+#include <vector>
 #include "sdf/Gui.hh"
 #include "sdf/parser.hh"
 #include "Utils.hh"

--- a/src/Heightmap.cc
+++ b/src/Heightmap.cc
@@ -16,6 +16,7 @@
 */
 
 #include <filesystem>
+#include <unordered_set>
 #include <vector>
 
 #include "Utils.hh"

--- a/src/Imu.cc
+++ b/src/Imu.cc
@@ -14,8 +14,6 @@
  * limitations under the License.
  *
  */
-#include <array>
-#include <string>
 #include "sdf/Imu.hh"
 #include "sdf/parser.hh"
 #include "Utils.hh"

--- a/src/Imu_TEST.cc
+++ b/src/Imu_TEST.cc
@@ -124,7 +124,7 @@ TEST(DOMImu, Load)
   EXPECT_NE(nullptr, imu.Element());
   EXPECT_EQ(sdf.get(), imu.Element().get());
 
-  // The Imu::Load function is test more thouroughly in the
+  // The Imu::Load function is test more thoroughly in the
   // link_dom.cc integration test.
 }
 

--- a/src/InstallationDirectories.cc
+++ b/src/InstallationDirectories.cc
@@ -43,7 +43,7 @@ const std::string separator(const std::string &_p)
 
 // Function imported from
 // https://github.com/gazebosim/gz-common/blob/ignition-common4_4.6.2/src/Filesystem.cc#L227
-std::string checkWindowsPath(const std::string _path)
+std::string checkWindowsPath(const std::string &_path)
 {
   if (_path.empty())
     return _path;

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -16,7 +16,9 @@
 */
 #include <algorithm>
 #include <array>
+#include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <gz/math/Pose3.hh>

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -119,7 +119,7 @@ TEST(DOMLidar, Load)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
   EXPECT_NE(nullptr, lidar.Element());
 
-  // The Lidar::Load function is tested more thouroughly in the
+  // The Lidar::Load function is tested more thoroughly in the
   // link_dom.cc integration test.
 }
 

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -93,7 +93,7 @@ class sdf::Link::Implementation
   /// \brief True if this link is kinematic only
   public: bool kinematic = false;
 
-  /// \brief True if automatic caluclation for the link inertial is enabled
+  /// \brief True if automatic calculation for the link inertial is enabled
   public: bool autoInertia = false;
 
   /// \brief This variable is used to track whether the inertia values for

--- a/src/Magnetometer_TEST.cc
+++ b/src/Magnetometer_TEST.cc
@@ -108,7 +108,7 @@ TEST(DOMMagnetometer, Load)
   EXPECT_NE(nullptr, mag.Element());
   EXPECT_EQ(sdf.get(), mag.Element().get());
 
-  // The Magnetometer::Load function is test more thouroughly in the
+  // The Magnetometer::Load function is test more thoroughly in the
   // link_dom.cc integration test.
 }
 

--- a/src/NavSat.cc
+++ b/src/NavSat.cc
@@ -31,7 +31,7 @@ class sdf::NavSat::Implementation
   /// \brief Noise values for the horizontal velocity sensor
   public: Noise horizontalVelocityNoise;
 
-  /// \brief Noise values for the verical velocity sensor
+  /// \brief Noise values for the vertical velocity sensor
   public: Noise verticalVelocityNoise;
 
   /// \brief The SDF element pointer used during load.

--- a/src/Param.cc
+++ b/src/Param.cc
@@ -1137,7 +1137,7 @@ bool PoseStringFromValue(const PrintConfig &_config,
   else if (rotationFormat == "euler_rpy" && inDegrees && snapDegreesToInterval)
   {
     // Helper function that returns a snapped value if it is within the
-    // tolerance of multiples of interval, otherwise the orginal value is
+    // tolerance of multiples of interval, otherwise the original value is
     // returned.
     auto snapToInterval =
         [](double _val, unsigned int _interval, double _tolerance)

--- a/src/ParamPassing.hh
+++ b/src/ParamPassing.hh
@@ -86,7 +86,7 @@ namespace sdf
     /// child element described in xml
     /// \param[in] _xml The xml element to find
     /// \param[in] _config Custom parser configuration.
-    /// \param[out] _errors Vector of errros.
+    /// \param[out] _errors Vector of errors.
     /// \param[in] _isModifyAction Is true if the action is modify, the
     /// attribute 'name' may not be in the sdf element (i.e., may be a
     /// modified/added attribute such as //camera)

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -662,7 +662,7 @@ TEST(Param, ReparsingAfterSetDouble)
   EXPECT_DOUBLE_EQ(value, 5.0);
   EXPECT_TRUE(doubleParam.Reparse());
 
-  // Value will be as expected, as the value was set using the explcit Set
+  // Value will be as expected, as the value was set using the explicit Set
   // function, and no parent element attributes are meant to change the value
   // for type double.
   EXPECT_TRUE(doubleParam.Get<double>(value));
@@ -918,7 +918,7 @@ TEST(Param, ChangeParentElementFail)
   poseElem->AddAttribute("degrees", "bool", "false", false);
   poseElem->AddAttribute("rotation_format", "string", "euler_rpy", false);
 
-  // Param from original default attibute
+  // Param from original default attribute
   sdf::ParamPtr valParam = poseElem->GetValue();
   ASSERT_NE(nullptr, valParam);
   ASSERT_TRUE(valParam->SetFromString("1, 2, 3, 0.4, 0.5, 0.6"));
@@ -957,7 +957,7 @@ TEST(Param, PoseWithDefaultValue)
   poseElem->AddValue("pose", "1 0 0 0 0 0", false);
   poseElem->AddAttribute("rotation_format", "string", "euler_rpy", false);
 
-  // Clone poseElem for testing Parm::SetFromString
+  // Clone poseElem for testing Param::SetFromString
   auto poseElemClone = poseElem->Clone();
 
   const std::string testString = R"(

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -40,8 +40,8 @@ class sdf::ParserConfig::Implementation
     EnforcementPolicy::WARN;
 
   /// \brief Policy indicating how deprecated elements are treated.
-  /// Defaults to the value of `warningsPolicy`. It can be overridden by the user
-  /// to behave behave differently than the `warningsPolicy`.
+  /// Defaults to the value of `warningsPolicy`. It can be overridden
+  /// by the user to behave behave differently than the `warningsPolicy`.
   public: std::optional<EnforcementPolicy> deprecatedElementsPolicy;
 
   /// \brief Policy that is set for handling failures of the

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -40,7 +40,7 @@ class sdf::ParserConfig::Implementation
     EnforcementPolicy::WARN;
 
   /// \brief Policy indicating how deprecated elements are treated.
-  /// Defaults to the value of `warningsPolicy`. It can be overriden by the user
+  /// Defaults to the value of `warningsPolicy`. It can be overridden by the user
   /// to behave behave differently than the `warningsPolicy`.
   public: std::optional<EnforcementPolicy> deprecatedElementsPolicy;
 

--- a/src/Plane.cc
+++ b/src/Plane.cc
@@ -26,7 +26,7 @@ using namespace sdf;
 class sdf::Plane::Implementation
 {
   /// \brief A plane with a unit Z normal vector, size of 1x1 meters, and
-  /// a zero offest.
+  /// a zero offset.
   public: gz::math::Planed plane{gz::math::Vector3d::UnitZ,
             gz::math::Vector2d::One, 0};
 

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -407,7 +407,7 @@ TEST(DOMPlugin, InsertStringContent)
     << "</plugin>\n";
   EXPECT_EQ(completePlugin.str(), plugin.ToElement()->ToString(""));
 
-  // Try out curly braces intitialization
+  // Try out curly braces initialization
   sdf::Plugin plugin2{plugin.Filename(), plugin.Name(), completeContent.str()};
   EXPECT_EQ(plugin.ToElement()->ToString(""),
             plugin2.ToElement()->ToString(""));
@@ -423,19 +423,19 @@ TEST(DOMPlugin, InsertStringContent)
   EXPECT_EQ(plugin.ToElement()->ToString(""),
             plugin2.ToElement()->ToString(""));
 
-  // Contructing a new plugin with no content
+  // Constructing a new plugin with no content
   sdf::Plugin plugin3{"a filename", "a name"};
   EXPECT_EQ("a filename", plugin3.Filename());
   EXPECT_EQ("a name", plugin3.Name());
   EXPECT_TRUE(plugin3.Contents().empty());
 
-  // Contructing a new plugin with bad XML content
+  // Constructing a new plugin with bad XML content
   sdf::Plugin plugin4{"filename", "name", "<garbage>"};
   EXPECT_EQ("filename", plugin4.Filename());
   EXPECT_EQ("name", plugin4.Name());
   EXPECT_TRUE(plugin4.Contents().empty());
 
-  // Contructing a new plugin with bad XML content
+  // Constructing a new plugin with bad XML content
   sdf::Plugin plugin5{"filename", "name", "    "};
   EXPECT_EQ("filename", plugin5.Filename());
   EXPECT_EQ("name", plugin5.Name());

--- a/src/Polyline.cc
+++ b/src/Polyline.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <vector>
+#include <string>
 
 #include "sdf/parser.hh"
 #include "sdf/Polyline.hh"

--- a/src/PrintConfig.cc
+++ b/src/PrintConfig.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <limits>
+#include <sstream>
 
 #include "sdf/PrintConfig.hh"
 #include "sdf/Console.hh"

--- a/src/SDF.cc
+++ b/src/SDF.cc
@@ -19,8 +19,6 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
-#include <list>
-#include <map>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/Scene.cc
+++ b/src/Scene.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
 */
+#include <optional>
 #include "sdf/parser.hh"
 #include "sdf/Scene.hh"
 #include "Utils.hh"

--- a/src/Sky.cc
+++ b/src/Sky.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <filesystem>
+#include <unordered_set>
 
 #include "sdf/parser.hh"
 #include "sdf/Sky.hh"

--- a/src/Sphere_TEST.cc
+++ b/src/Sphere_TEST.cc
@@ -144,7 +144,7 @@ TEST(DOMSphere, CalculateInertial)
 {
   sdf::Sphere sphere;
 
-  // density of aluminium
+  // density of Aluminum
   const double density = 2170;
 
   sphere.SetRadius(-2);

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -125,7 +125,7 @@ static bool StartsWithDelimiter(const std::string &_s)
   return _s.compare(0, kScopeDelimiter.size(), kScopeDelimiter) == 0;
 }
 
-// Join a scope name prefix with a local name using the scope delimeter
+// Join a scope name prefix with a local name using the scope delimiter
 std::string JoinName(
     const std::string &_scopeName, const std::string &_localName)
 {

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -182,7 +182,7 @@ void throwOrPrintErrors(const sdf::Errors& _errors)
 /// tree.
 /// \param[in] _sdf sdf::ElementPtr of the entity with the name attribute
 /// \param[out] _errors Will contain errors encountered in the function.
-/// \return Absolute name of the entity of no errors occurred. nullopt otherwise.
+/// \return Absolute name of the entity if no errors occurred or nullopt.
 static std::optional<std::string> computeAbsoluteName(
     const sdf::ElementPtr &_sdf, sdf::Errors &_errors)
 {

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -182,7 +182,7 @@ void throwOrPrintErrors(const sdf::Errors& _errors)
 /// tree.
 /// \param[in] _sdf sdf::ElementPtr of the entity with the name attribute
 /// \param[out] _errors Will contain errors encountered in the function.
-/// \return Absolute name of the entity of no errors occured. nullopt otherwise.
+/// \return Absolute name of the entity of no errors occurred. nullopt otherwise.
 static std::optional<std::string> computeAbsoluteName(
     const sdf::ElementPtr &_sdf, sdf::Errors &_errors)
 {

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -207,7 +207,7 @@ namespace sdf
   /// \param[out] _errors The vector of errors. An empty vector indicates no
   /// errors were experienced.
   /// \param[in] _elem The SDFormat element to be loaded.
-  /// \param[in] _args Extra arguments forwarded to the Load memeber function.
+  /// \param[in] _args Extra arguments forwarded to the Load member function.
   /// \return An instance of Class loaded from the input SDFormat element.
   template <typename Class, typename... Args>
   Class loadSingle(sdf::Errors &_errors, sdf::ElementPtr _elem, Args &&..._args)

--- a/src/World_TEST.cc
+++ b/src/World_TEST.cc
@@ -45,7 +45,7 @@ TEST(DOMWorld, Construction)
   EXPECT_STREQ("default", world.AudioDevice().c_str());
   EXPECT_EQ(gz::math::Vector3d::Zero, world.WindLinearVelocity());
 
-  // The scene and atmosphere are requred, per the SDF spec. Make sure
+  // The scene and atmosphere are required, per the SDF spec. Make sure
   // that they have been created.
   EXPECT_TRUE(world.Scene());
   EXPECT_TRUE(world.Atmosphere());

--- a/src/XmlUtils.hh
+++ b/src/XmlUtils.hh
@@ -31,7 +31,7 @@ namespace sdf
 
   /// \brief Perform a deep copy of an XML Node
   ///
-  /// This copies an XMLNode _src and all of its decendants
+  /// This copies an XMLNode _src and all of its descendants
   /// into a specified XMLDocument.
   ///
   /// \param[in] _doc Document in which to place the copied node
@@ -43,7 +43,7 @@ namespace sdf
 
   /// \brief Perform a deep copy of an XML Node
   ///
-  /// This copies an XMLNode _src and all of its decendants
+  /// This copies an XMLNode _src and all of its descendants
   /// into a specified XMLDocument.
   ///
   /// \param[out] _errors Vector of errors

--- a/src/cmd/gz.hh
+++ b/src/cmd/gz.hh
@@ -42,7 +42,7 @@ namespace sdf
   /// \param[in] _path Path to SDF file.
   /// \param[in] _inDegrees Print angles in degrees.
   /// \param[in] _snapToDegrees Snap pose rotation angles in degrees.
-  /// \param[in] _snapTolerance Specfies tolerance for snapping.
+  /// \param[in] _snapTolerance Specifies tolerance for snapping.
   /// \param[in] _preserveIncludes Preserve included tags when printing.
   /// \param[in] _outPrecision Output stream precision for floating point.
   /// \param[in] _expandAutoInertials Print auto-computed inertial values.

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -2866,7 +2866,7 @@ void checkScopedJointAxisExpressedInValues(
         const std::string xyzExpressedInLocal =
             sdf::SplitName(xyzExpressedIn).second;
 
-        // If a frame name is specfied, check that the frame exists.
+        // If a frame name is specified, check that the frame exists.
         if (!xyzExpressedIn.empty() &&
             !_scope->NameExistsInFrameAttachedToGraph(xyzExpressedIn))
         {

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -3261,7 +3261,7 @@ void CreateVisual(tinyxml2::XMLElement *_elem, urdf::LinkConstSharedPtr _link,
         (_link->name + kLumpPrefix + _oldLinkName).c_str());
   }
 
-  // add the visualisation transfrom
+  // add the visualisation transform
   double pose[6];
   pose[0] = _visual->origin.position.x;
   pose[1] = _visual->origin.position.y;
@@ -3598,7 +3598,7 @@ void ReduceSDFExtensionContactSensorFrameReplace(
           collisionNameKey->LinkEndChild(collisionNameTxt);
           contact->LinkEndChild(collisionNameKey);
         }
-        // @todo: FIXME: chagning contact sensor's contact collision
+        // @todo: FIXME: changing contact sensor's contact collision
         //   should trigger a update in sensor offset as well.
         //   But first we need to implement offsets in contact sensors
       }

--- a/test/integration/error_output.cc
+++ b/test/integration/error_output.cc
@@ -514,7 +514,7 @@ TEST(ErrorOutput, ModelErrorOutput)
   {
     sdf::Model model;
     parserConfig.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
-    // Set SDF version to someting lower than 1.7 for extra errors
+    // Set SDF version to something lower than 1.7 for extra errors
     sdfParsed->Root()->GetElement("model")->SetOriginalVersion("1.6");
     errors = model.Load(sdfParsed->Root()->GetElement("model"), parserConfig);
 

--- a/test/integration/fixed_joint_reduction.cc
+++ b/test/integration/fixed_joint_reduction.cc
@@ -335,7 +335,7 @@ void FixedJointReductionCollisionVisualExtension(const std::string &_urdfFile,
   //   <visual name='base_link_fixed_joint_lump__child_link_2_visual_2'>
   //     <uri>script_uri_51</uri>
   //     <name>script_name_51</name>
-  // unassigne max_contacts defaut is 10
+  // unassign max_contacts default is 10
   EXPECT_EQ(urdf_child_link_2_col->Get<int>("max_contacts"), 10);
   EXPECT_EQ(urdf_child_link_2_col->Get<int>("max_contacts"),
             sdf_child_link_2_col->Get<int>("max_contacts"));

--- a/test/integration/include.cc
+++ b/test/integration/include.cc
@@ -25,7 +25,7 @@
 #include "test_config.hh"
 
 ////////////////////////////////////////////////////
-/// Ensure that include sdf descriptions can be overriden
+/// Ensure that include sdf descriptions can be overridden
 TEST(Include, IncludeDescription)
 {
   const std::string SDF_DESCRIPTION_PATH =

--- a/test/integration/include_custom_model.sdf
+++ b/test/integration/include_custom_model.sdf
@@ -103,7 +103,7 @@
 
           </link>
 
-          <!-- attribute test get's stripped during replace -->
+          <!-- attribute test gets stripped during replace -->
           <collision element_id="right_wheel::collision" test="hello" name="right_wheel_collision" action="replace">
             <geometry>
               <cylinder>

--- a/test/integration/include_description.sdf
+++ b/test/integration/include_description.sdf
@@ -1,5 +1,5 @@
 <element name="sdf" required="1">
-  <description>This sdf file contains one pose include element whose description will be overriden.</description>
+  <description>This sdf file contains one pose include element whose description will be overridden.</description>
 
   <attribute name="version" type="string" default="1.5" required="1">
     <description>Version number of the SDF format.</description>

--- a/test/integration/interface_api.cc
+++ b/test/integration/interface_api.cc
@@ -107,14 +107,14 @@ class CustomTomlParser
 
       if (_include.IsStatic().has_value())
       {
-        // if //include/static is set, override the value in the inluded model
+        // if //include/static is set, override the value in the included model
         sdf::Param param("static", "bool", "false", false);
         param.Set(*_include.IsStatic());
         doc["static"] = {param};
       }
       if (this->overridePoseInParser && _include.IncludeRawPose().has_value())
       {
-        // if //include/static is set, override the value in the inluded model
+        // if //include/static is set, override the value in the included model
         sdf::Param poseParam("pose", "pose", "", false);
         poseParam.Set(*_include.IncludeRawPose());
         doc["pose"] = {poseParam};

--- a/test/integration/locale_fix.cc
+++ b/test/integration/locale_fix.cc
@@ -32,7 +32,7 @@ TEST(CheckFixForLocal, MakeTestToFail)
   const std::string sdfTestFile =
       sdf::testing::TestFile("integration", "numeric.sdf");
 
-  // Check if any of the latin locales is avilable
+  // Check if any of the latin locales is available
   FILE *fp = popen("locale -a | grep '^es\\|^pt_\\|^it_' | head -n 1", "r");
 
   if (!fp)

--- a/test/integration/material_pbr.cc
+++ b/test/integration/material_pbr.cc
@@ -47,7 +47,7 @@ TEST(Material, PbrDOM)
   ASSERT_NE(nullptr, link);
   EXPECT_EQ("link", link->Name());
 
-  // checkt visual materials
+  // check visual materials
   EXPECT_EQ(3u, link->VisualCount());
 
   // visual metal workflow

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -474,7 +474,7 @@ TEST(NestedModel, NestedInclude)
 }
 
 //////////////////////////////////////////////////
-// Test parsing models with child models containg frames nested via <include>
+// Test parsing models with child models contain frames nested via <include>
 TEST(NestedModel, NestedModelWithFrames)
 {
   const std::string name = "test_model_with_frames";
@@ -795,7 +795,7 @@ TEST(NestedModel, PartiallyFlattened)
 
 //////////////////////////////////////////////////
 // Test parsing models that have two levels of nesting with child models
-// containg frames nested via <include>.
+// contain frames nested via <include>.
 // Compare parsed SDF with expected string
 TEST(NestedModel, TwoLevelNestedModelWithFramesDirectComparison)
 {

--- a/test/integration/pose_1_9_sdf.cc
+++ b/test/integration/pose_1_9_sdf.cc
@@ -522,7 +522,7 @@ TEST(Pose1_9, ChangingParentPoseElementAfterSet)
   quatPoseElem->AddAttribute(
       "rotation_format", "string", "quat_xyzw", false);
 
-  // Param from original default attibute
+  // Param from original default attribute
   sdf::ParamPtr valParam = poseElem->GetValue();
   ASSERT_NE(nullptr, valParam);
 
@@ -590,7 +590,7 @@ TEST(Pose1_9, ChangingParentPoseElementAfterParamSetFromString)
   quatPoseElem->AddAttribute(
       "rotation_format", "string", "quat_xyzw", false);
 
-  // Param from original default attibute
+  // Param from original default attribute
   sdf::ParamPtr valParam = poseElem->GetValue();
   ASSERT_NE(nullptr, valParam);
   ASSERT_TRUE(valParam->SetFromString("1, 2, 3, 0.4, 0.5, 0.6"));

--- a/test/performance/parser_urdf_atlas.urdf
+++ b/test/performance/parser_urdf_atlas.urdf
@@ -1522,7 +1522,7 @@
       <origin rpy="0 0 0" xyz="0.012428 0.0004084 -0.0041835"/>
       <mass value="0.057654"/>
       <!--<inertia iyy="4.2412E-05" ixy="4.9927E-08" iyz="-9.8165E-09" ixx="3.7174E-05" ixz="1.1015E-05" izz="4.167E-05" />-->
-      <!-- distribute iyy and izz equally between head and hokuyo_link given it's constrainted anyways -->
+      <!-- distribute iyy and izz equally between head and hokuyo_link given it's constrained anyways -->
       <!-- tweak ixx of hokuyo so it's larger, 1/10th of head ixx. -->
       <inertia ixx="0.0004005974" ixy="4.9927E-08" ixz="1.1015E-05" iyy="0.002080106" iyz="-9.8165E-09" izz="0.001782985"/>
     </inertial>

--- a/test/sdf/unrecognized_elements_with_namespace.sdf
+++ b/test/sdf/unrecognized_elements_with_namespace.sdf
@@ -14,6 +14,6 @@
     </third_party_software:not_a_model_element>
   </model>
   <third_party_software:not_an_sdf_element>
-    Ignore this one tooo
+    Ignore this one too
   </third_party_software:not_an_sdf_element>
 </sdf>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
General code cleanup
 * Typos fixed (codespell + ide plugin w/ other backend)
 * stl includes slightly improved (removed unused, added which is in use)

Also I found several places where public API are getting `std::string` not by reference, but by copy:

![Screenshot 2025-03-13 035241](https://github.com/user-attachments/assets/2ecc80bd-3c4c-4541-924f-05ce993513d5)
![Screenshot 2025-03-13 041151](https://github.com/user-attachments/assets/d12b6f04-a33e-4c77-a4ba-ddecab6d73b9)

I guess it could be hard to change it right now (w/o breaking ABI) and I have more doubts about returning by-copy strings across whole api... Just sharing, out of scope of this PR

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
