### PR TITLE
Fix Crash On Negative Value 

### DIFF
--- a/src/Box.cc
+++ b/src/Box.cc
@@ -72,13 +72,15 @@ Errors Box::Load(ElementPtr _sdf)
     std::pair<gz::math::Vector3d, bool> pair =
       _sdf->Get<gz::math::Vector3d>(errors, "size", this->dataPtr->box.Size());
 
-    if (!pair.second)
+    if (!pair.second || pair.first.X() <= 0 || pair.first.Y() <= 0 ||
+        pair.first.Z() <= 0)
     {
       errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Invalid <size> data for a <box> geometry. "
           "Using a size of 1, 1, 1 "});
+    } else {
+      this->dataPtr->box.SetSize(pair.first);
     }
-    this->dataPtr->box.SetSize(pair.first);
   }
   else
   {

--- a/src/Box.cc
+++ b/src/Box.cc
@@ -20,6 +20,7 @@
 #include <gz/math/Material.hh>
 #include <gz/math/MassMatrix3.hh>
 #include <gz/math/Inertial.hh>
+#include "sdf/Console.hh"
 #include "sdf/Box.hh"
 #include "sdf/parser.hh"
 #include "Utils.hh"
@@ -72,13 +73,20 @@ Errors Box::Load(ElementPtr _sdf)
     std::pair<gz::math::Vector3d, bool> pair =
       _sdf->Get<gz::math::Vector3d>(errors, "size", this->dataPtr->box.Size());
 
-    if (!pair.second || pair.first.X() <= 0 || pair.first.Y() <= 0 ||
-        pair.first.Z() <= 0)
+    if (!pair.second)
     {
       errors.push_back({ErrorCode::ELEMENT_INVALID,
-          "Invalid <size> data for a <box> geometry. "
-          "Using a size of 1, 1, 1 "});
-    } else {
+          "Invalid <size> data for a <box> geometry."});
+    }
+    else
+    {
+      if (pair.first.X() <= 0 || pair.first.Y() <= 0 ||
+          pair.first.Z() <= 0)
+      {
+        sdfwarn << "Value of <size> is negative. "
+            << "Using default value of 1, 1, 1.\n";
+        pair.first = gz::math::Vector3d::One;
+      }
       this->dataPtr->box.SetSize(pair.first);
     }
   }

--- a/src/Box_TEST.cc
+++ b/src/Box_TEST.cc
@@ -138,6 +138,16 @@ TEST(DOMBox, Load)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_MISSING, errors[0].Code());
   EXPECT_NE(std::string::npos, errors[0].Message().find("missing a <size>"));
   EXPECT_NE(nullptr, box.Element());
+
+  // Negative <size> element
+  sdf->GetElement("size")->Set<gz::math::Vector3d>(
+      gz::math::Vector3d(-1, -1, -1));
+  errors = box.Load(sdf);
+  ASSERT_EQ(1u, errors.size());
+  ASSERT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
+  ASSERT_NE(std::string::npos, errors[0].Message().find("Invalid <size>"));
+  ASSERT_NE(nullptr, box.Element());
+  EXPECT_EQ(gz::math::Vector3d::One, box.Size());
 }
 
 /////////////////////////////////////////////////

--- a/src/Box_TEST.cc
+++ b/src/Box_TEST.cc
@@ -153,7 +153,7 @@ TEST(DOMBox, Load)
   errors = box.Load(sdf);
   ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, box.Element());
-  EXPECT_EQ(gz::math::Vector3d::One, box.Size()); // Defaulted to 1,1,1
+  EXPECT_EQ(gz::math::Vector3d::One, box.Size());  // Defaulted to 1,1,1
 }
 
 /////////////////////////////////////////////////

--- a/src/Box_TEST.cc
+++ b/src/Box_TEST.cc
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- */
+*/
 #include <optional>
 
 #include <gtest/gtest.h>

--- a/src/Capsule.cc
+++ b/src/Capsule.cc
@@ -20,6 +20,7 @@
 #include <gz/math/Material.hh>
 #include <gz/math/Inertial.hh>
 #include "sdf/Capsule.hh"
+#include "sdf/Console.hh"
 #include "sdf/parser.hh"
 #include "Utils.hh"
 
@@ -78,7 +79,16 @@ Errors Capsule::Load(ElementPtr _sdf)
          << this->dataPtr->capsule.Radius() << ".";
       errors.push_back({ErrorCode::ELEMENT_INVALID, ss.str()});
     }
-    this->dataPtr->capsule.SetRadius(pair.first);
+    else
+    {
+      if (pair.first <= 0)
+      {
+        sdfwarn << "Value of <radius> is negative. "
+            << "Using default value of 0.5.\n";
+        pair.first = 0.5;
+      }
+      this->dataPtr->capsule.SetRadius(pair.first);
+    }
   }
 
   {
@@ -93,7 +103,16 @@ Errors Capsule::Load(ElementPtr _sdf)
          << this->dataPtr->capsule.Length() << ".";
       errors.push_back({ErrorCode::ELEMENT_INVALID, ss.str()});
     }
-    this->dataPtr->capsule.SetLength(pair.first);
+    else
+    {
+      if (pair.first <= 0)
+      {
+        sdfwarn << "Value of <length> is negative. "
+            << "Using default value of 1.\n";
+        pair.first = 1.0;
+      }
+      this->dataPtr->capsule.SetLength(pair.first);
+    }
   }
 
   return errors;

--- a/src/Capsule_TEST.cc
+++ b/src/Capsule_TEST.cc
@@ -156,11 +156,13 @@ TEST(DOMCapsule, Load)
       << errors[1].Message();
   EXPECT_NE(nullptr, capsule.Element());
 
-  // Add a radius element
+  // Add <radius> element description
   sdf::ElementPtr radiusDesc(new sdf::Element());
   radiusDesc->SetName("radius");
   radiusDesc->AddValue("double", "1.0", true, "radius");
   sdf->AddElementDescription(radiusDesc);
+
+  // Add radius element
   sdf::ElementPtr radiusElem = sdf->AddElement("radius");
   radiusElem->Set<double>(2.0);
 
@@ -171,6 +173,29 @@ TEST(DOMCapsule, Load)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
   EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
       << errors[0].Message();
+
+  // Add <length> element description
+  sdf::ElementPtr lengthDesc(new sdf::Element());
+  lengthDesc->SetName("length");
+  lengthDesc->AddValue("double", "1.0", true, "length");
+  sdf->AddElementDescription(lengthDesc);
+
+  // Add length element and test negative radius
+  sdf::ElementPtr lengthElem = sdf->AddElement("length");
+  lengthElem->Set<double>(3.0);
+  radiusElem->Set<double>(-1.0);
+  errors = capsule.Load(sdf);
+  ASSERT_EQ(0u, errors.size());
+  EXPECT_NE(nullptr, capsule.Element());
+  EXPECT_DOUBLE_EQ(0.5, capsule.Radius());
+
+  // Test negative length
+  radiusElem->Set<double>(1.0);
+  lengthElem->Set<double>(-1.0);
+  errors = capsule.Load(sdf);
+  ASSERT_EQ(0u, errors.size());
+  EXPECT_NE(nullptr, capsule.Element());
+  EXPECT_DOUBLE_EQ(1.0, capsule.Length());
 }
 
 /////////////////////////////////////////////////

--- a/src/Cone.cc
+++ b/src/Cone.cc
@@ -23,6 +23,7 @@
 #include <gz/math/Inertial.hh>
 #include <gz/math/Cone.hh>
 #include "sdf/Cone.hh"
+#include "sdf/Console.hh"
 #include "sdf/parser.hh"
 #include "Utils.hh"
 
@@ -73,7 +74,7 @@ Errors Cone::Load(ElementPtr _sdf)
     std::pair<double, bool> pair = _sdf->Get<double>(errors, "radius",
         this->dataPtr->cone.Radius());
 
-    if (!pair.second || pair.first <= 0)
+    if (!pair.second)
     {
       std::stringstream ss;
       ss << "Invalid <radius> data for a <cone> geometry. "
@@ -83,6 +84,12 @@ Errors Cone::Load(ElementPtr _sdf)
     }
     else
     {
+      if (pair.first <= 0)
+      {
+        sdfwarn << "Value of <radius> is negative. "
+            << "Using default value of 0.5.\n";
+        pair.first = 0.5;
+      }
       this->dataPtr->cone.SetRadius(pair.first);
     }
   }
@@ -91,7 +98,7 @@ Errors Cone::Load(ElementPtr _sdf)
     std::pair<double, bool> pair = _sdf->Get<double>(errors, "length",
         this->dataPtr->cone.Length());
 
-    if (!pair.second || pair.first <= 0)
+    if (!pair.second)
     {
       std::stringstream ss;
       ss << "Invalid <length> data for a <cone> geometry. "
@@ -101,6 +108,12 @@ Errors Cone::Load(ElementPtr _sdf)
     }
     else
     {
+      if (pair.first <= 0)
+      {
+        sdfwarn << "Value of <length> is negative. "
+            << "Using default of 1.\n";
+        pair.first = 1.0;
+      }
       this->dataPtr->cone.SetLength(pair.first);
     }
   }

--- a/src/Cone.cc
+++ b/src/Cone.cc
@@ -73,7 +73,7 @@ Errors Cone::Load(ElementPtr _sdf)
     std::pair<double, bool> pair = _sdf->Get<double>(errors, "radius",
         this->dataPtr->cone.Radius());
 
-    if (!pair.second)
+    if (!pair.second || pair.first <= 0)
     {
       std::stringstream ss;
       ss << "Invalid <radius> data for a <cone> geometry. "
@@ -81,14 +81,17 @@ Errors Cone::Load(ElementPtr _sdf)
          << this->dataPtr->cone.Radius() << ".";
       errors.push_back({ErrorCode::ELEMENT_INVALID, ss.str()});
     }
-    this->dataPtr->cone.SetRadius(pair.first);
+    else
+    {
+      this->dataPtr->cone.SetRadius(pair.first);
+    }
   }
 
   {
     std::pair<double, bool> pair = _sdf->Get<double>(errors, "length",
         this->dataPtr->cone.Length());
 
-    if (!pair.second)
+    if (!pair.second || pair.first <= 0)
     {
       std::stringstream ss;
       ss << "Invalid <length> data for a <cone> geometry. "
@@ -96,7 +99,10 @@ Errors Cone::Load(ElementPtr _sdf)
          << this->dataPtr->cone.Length() << ".";
       errors.push_back({ErrorCode::ELEMENT_INVALID, ss.str()});
     }
-    this->dataPtr->cone.SetLength(pair.first);
+    else
+    {
+      this->dataPtr->cone.SetLength(pair.first);
+    }
   }
 
   return errors;

--- a/src/Cone_TEST.cc
+++ b/src/Cone_TEST.cc
@@ -156,11 +156,13 @@ TEST(DOMCone, Load)
       << errors[1].Message();
   EXPECT_NE(nullptr, cone.Element());
 
-  // Add a radius element
+  // Add <radius> element description
   sdf::ElementPtr radiusDesc(new sdf::Element());
   radiusDesc->SetName("radius");
   radiusDesc->AddValue("double", "1.0", true, "radius");
   sdf->AddElementDescription(radiusDesc);
+
+  // Add a radius element
   sdf::ElementPtr radiusElem = sdf->AddElement("radius");
   radiusElem->Set<double>(2.0);
 
@@ -172,25 +174,28 @@ TEST(DOMCone, Load)
   EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
       << errors[0].Message();
 
-  // Negative <radius> element
+  // Now add <length> element description
+  sdf::ElementPtr lengthDesc(new sdf::Element());
+  lengthDesc->SetName("length");
+  lengthDesc->AddValue("double", "1.0", true, "length");
+  sdf->AddElementDescription(lengthDesc);
+
+  // Add length element and test negative radius
+  sdf::ElementPtr lengthElem = sdf->AddElement("length");
+  lengthElem->Set<double>(3.0);
   radiusElem->Set<double>(-1.0);
   errors = cone.Load(sdf);
-  ASSERT_EQ(2u, errors.size());
-  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
-  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <radius>"))
-      << errors[0].Message();
+  ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, cone.Element());
+  EXPECT_DOUBLE_EQ(0.5, cone.Radius()); // default fallback
 
-  // Negative <length> element
+  // Test negative length
   radiusElem->Set<double>(1.0);
-  sdf::ElementPtr lengthElem = sdf->AddElement("length");
   lengthElem->Set<double>(-1.0);
   errors = cone.Load(sdf);
-  ASSERT_EQ(2u, errors.size());
-  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
-  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
-      << errors[0].Message();
+  ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, cone.Element());
+  EXPECT_DOUBLE_EQ(1.0, cone.Length()); // default fallback
 }
 
 /////////////////////////////////////////////////

--- a/src/Cone_TEST.cc
+++ b/src/Cone_TEST.cc
@@ -187,7 +187,7 @@ TEST(DOMCone, Load)
   errors = cone.Load(sdf);
   ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, cone.Element());
-  EXPECT_DOUBLE_EQ(0.5, cone.Radius()); // default fallback
+  EXPECT_DOUBLE_EQ(0.5, cone.Radius());  // default fallback
 
   // Test negative length
   radiusElem->Set<double>(1.0);
@@ -195,7 +195,7 @@ TEST(DOMCone, Load)
   errors = cone.Load(sdf);
   ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, cone.Element());
-  EXPECT_DOUBLE_EQ(1.0, cone.Length()); // default fallback
+  EXPECT_DOUBLE_EQ(1.0, cone.Length());  // default fallback
 }
 
 /////////////////////////////////////////////////

--- a/src/Cone_TEST.cc
+++ b/src/Cone_TEST.cc
@@ -171,6 +171,26 @@ TEST(DOMCone, Load)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
   EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
       << errors[0].Message();
+
+  // Negative <radius> element
+  radiusElem->Set<double>(-1.0);
+  errors = cone.Load(sdf);
+  ASSERT_EQ(2u, errors.size());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
+  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <radius>"))
+      << errors[0].Message();
+  EXPECT_NE(nullptr, cone.Element());
+
+  // Negative <length> element
+  radiusElem->Set<double>(1.0);
+  sdf::ElementPtr lengthElem = sdf->AddElement("length");
+  lengthElem->Set<double>(-1.0);
+  errors = cone.Load(sdf);
+  ASSERT_EQ(2u, errors.size());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
+  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
+      << errors[0].Message();
+  EXPECT_NE(nullptr, cone.Element());
 }
 
 /////////////////////////////////////////////////

--- a/src/Cylinder.cc
+++ b/src/Cylinder.cc
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include <gz/math/Inertial.hh>
+#include "sdf/Console.hh"
 #include "sdf/Cylinder.hh"
 #include "sdf/parser.hh"
 #include "Utils.hh"
@@ -69,7 +70,7 @@ Errors Cylinder::Load(ElementPtr _sdf)
     std::pair<double, bool> pair = _sdf->Get<double>(errors, "radius",
         this->dataPtr->cylinder.Radius());
 
-    if (!pair.second || pair.first <= 0)
+    if (!pair.second)
     {
       std::stringstream ss;
       ss << "Invalid <radius> data for a <cylinder> geometry. "
@@ -79,6 +80,12 @@ Errors Cylinder::Load(ElementPtr _sdf)
     }
     else
     {
+      if (pair.first <= 0)
+      {
+        sdfwarn << "Value of <radius> is negative. "
+            << "Using default value of 0.5.\n";
+        pair.first = 0.5;
+      }
       this->dataPtr->cylinder.SetRadius(pair.first);
     }
   }
@@ -87,7 +94,7 @@ Errors Cylinder::Load(ElementPtr _sdf)
     std::pair<double, bool> pair = _sdf->Get<double>(errors, "length",
         this->dataPtr->cylinder.Length());
 
-    if (!pair.second || pair.first <= 0)
+    if (!pair.second)
     {
       std::stringstream ss;
       ss << "Invalid <length> data for a <cylinder> geometry. "
@@ -97,6 +104,12 @@ Errors Cylinder::Load(ElementPtr _sdf)
     }
     else
     {
+      if (pair.first <= 0)
+      {
+        sdfwarn << "Value of <length> is negative. "
+            << "Using default value of 1.\n";
+        pair.first = 1.0;
+      }
       this->dataPtr->cylinder.SetLength(pair.first);
     }
   }

--- a/src/Cylinder.cc
+++ b/src/Cylinder.cc
@@ -69,7 +69,7 @@ Errors Cylinder::Load(ElementPtr _sdf)
     std::pair<double, bool> pair = _sdf->Get<double>(errors, "radius",
         this->dataPtr->cylinder.Radius());
 
-    if (!pair.second)
+    if (!pair.second || pair.first <= 0)
     {
       std::stringstream ss;
       ss << "Invalid <radius> data for a <cylinder> geometry. "
@@ -77,14 +77,17 @@ Errors Cylinder::Load(ElementPtr _sdf)
          << this->dataPtr->cylinder.Radius() << ".";
       errors.push_back({ErrorCode::ELEMENT_INVALID, ss.str()});
     }
-    this->dataPtr->cylinder.SetRadius(pair.first);
+    else
+    {
+      this->dataPtr->cylinder.SetRadius(pair.first);
+    }
   }
 
   {
     std::pair<double, bool> pair = _sdf->Get<double>(errors, "length",
         this->dataPtr->cylinder.Length());
 
-    if (!pair.second)
+    if (!pair.second || pair.first <= 0)
     {
       std::stringstream ss;
       ss << "Invalid <length> data for a <cylinder> geometry. "
@@ -92,7 +95,10 @@ Errors Cylinder::Load(ElementPtr _sdf)
          << this->dataPtr->cylinder.Length() << ".";
       errors.push_back({ErrorCode::ELEMENT_INVALID, ss.str()});
     }
-    this->dataPtr->cylinder.SetLength(pair.first);
+    else
+    {
+      this->dataPtr->cylinder.SetLength(pair.first);
+    }
   }
 
   return errors;

--- a/src/Cylinder_TEST.cc
+++ b/src/Cylinder_TEST.cc
@@ -167,6 +167,26 @@ TEST(DOMCylinder, Load)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
   EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
       << errors[0].Message();
+
+  // Negative <radius> element
+  radiusElem->Set<double>(-1.0);
+  errors = cylinder.Load(sdf);
+  ASSERT_EQ(2u, errors.size());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
+  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <radius>"))
+      << errors[0].Message();
+  EXPECT_NE(nullptr, cylinder.Element());
+
+  // Negative <length> element
+  radiusElem->Set<double>(1.0);
+  sdf::ElementPtr lengthElem = sdf->AddElement("length");
+  lengthElem->Set<double>(-1.0);
+  errors = cylinder.Load(sdf);
+  ASSERT_EQ(2u, errors.size());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
+  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
+      << errors[0].Message();
+  EXPECT_NE(nullptr, cylinder.Element());
 }
 
 /////////////////////////////////////////////////

--- a/src/Cylinder_TEST.cc
+++ b/src/Cylinder_TEST.cc
@@ -152,11 +152,13 @@ TEST(DOMCylinder, Load)
       << errors[1].Message();
   EXPECT_NE(nullptr, cylinder.Element());
 
-  // Add a radius element
+  // Add <radius> element description
   sdf::ElementPtr radiusDesc(new sdf::Element());
   radiusDesc->SetName("radius");
   radiusDesc->AddValue("double", "1.0", true, "radius");
   sdf->AddElementDescription(radiusDesc);
+
+  // Add radius element
   sdf::ElementPtr radiusElem = sdf->AddElement("radius");
   radiusElem->Set<double>(2.0);
 
@@ -168,25 +170,28 @@ TEST(DOMCylinder, Load)
   EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
       << errors[0].Message();
 
-  // Negative <radius> element
+  // Now add <length> element description
+  sdf::ElementPtr lengthDesc(new sdf::Element());
+  lengthDesc->SetName("length");
+  lengthDesc->AddValue("double", "1.0", true, "length");
+  sdf->AddElementDescription(lengthDesc);
+
+  // Add length element and test negative radius
+  sdf::ElementPtr lengthElem = sdf->AddElement("length");
+  lengthElem->Set<double>(3.0);
   radiusElem->Set<double>(-1.0);
   errors = cylinder.Load(sdf);
-  ASSERT_EQ(2u, errors.size());
-  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
-  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <radius>"))
-      << errors[0].Message();
+  ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, cylinder.Element());
+  EXPECT_DOUBLE_EQ(0.5, cylinder.Radius()); // fallback
 
-  // Negative <length> element
+  // Test negative length
   radiusElem->Set<double>(1.0);
-  sdf::ElementPtr lengthElem = sdf->AddElement("length");
   lengthElem->Set<double>(-1.0);
   errors = cylinder.Load(sdf);
-  ASSERT_EQ(2u, errors.size());
-  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
-  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <length>"))
-      << errors[0].Message();
+  ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, cylinder.Element());
+  EXPECT_DOUBLE_EQ(1.0, cylinder.Length()); // fallback
 }
 
 /////////////////////////////////////////////////

--- a/src/Cylinder_TEST.cc
+++ b/src/Cylinder_TEST.cc
@@ -183,7 +183,7 @@ TEST(DOMCylinder, Load)
   errors = cylinder.Load(sdf);
   ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, cylinder.Element());
-  EXPECT_DOUBLE_EQ(0.5, cylinder.Radius()); // fallback
+  EXPECT_DOUBLE_EQ(0.5, cylinder.Radius());  // Default to 0.5
 
   // Test negative length
   radiusElem->Set<double>(1.0);
@@ -191,7 +191,7 @@ TEST(DOMCylinder, Load)
   errors = cylinder.Load(sdf);
   ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, cylinder.Element());
-  EXPECT_DOUBLE_EQ(1.0, cylinder.Length()); // fallback
+  EXPECT_DOUBLE_EQ(1.0, cylinder.Length());  // Default to 1.0
 }
 
 /////////////////////////////////////////////////

--- a/src/Ellipsoid.cc
+++ b/src/Ellipsoid.cc
@@ -72,13 +72,17 @@ Errors Ellipsoid::Load(ElementPtr _sdf)
       _sdf->Get<gz::math::Vector3d>(
         errors, "radii", this->dataPtr->ellipsoid.Radii());
 
-    if (!pair.second)
+    if (!pair.second || pair.first.X() <= 0 ||
+        pair.first.Y() <= 0 || pair.first.Z() <= 0)
     {
       errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Invalid <radii> data for a <ellipsoid> geometry. "
           "Using a radii of 1, 1, 1 "});
     }
-    this->dataPtr->ellipsoid.SetRadii(pair.first);
+    else
+    {
+      this->dataPtr->ellipsoid.SetRadii(pair.first);
+    }
   }
   else
   {

--- a/src/Ellipsoid.cc
+++ b/src/Ellipsoid.cc
@@ -19,6 +19,7 @@
 
 #include <gz/math/Inertial.hh>
 #include <gz/math/Material.hh>
+#include "sdf/Console.hh"
 #include "sdf/Ellipsoid.hh"
 #include "sdf/parser.hh"
 #include "Utils.hh"
@@ -72,8 +73,7 @@ Errors Ellipsoid::Load(ElementPtr _sdf)
       _sdf->Get<gz::math::Vector3d>(
         errors, "radii", this->dataPtr->ellipsoid.Radii());
 
-    if (!pair.second || pair.first.X() <= 0 ||
-        pair.first.Y() <= 0 || pair.first.Z() <= 0)
+    if (!pair.second)
     {
       errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Invalid <radii> data for a <ellipsoid> geometry. "
@@ -81,6 +81,12 @@ Errors Ellipsoid::Load(ElementPtr _sdf)
     }
     else
     {
+      if (pair.first.X() <= 0 || pair.first.Y() <= 0 || pair.first.Z() <= 0)
+      {
+        sdfwarn << "Value of <radii> is negative. "
+            << "Using default value of 1, 1, 1.\n";
+        pair.first = gz::math::Vector3d::One;
+      }
       this->dataPtr->ellipsoid.SetRadii(pair.first);
     }
   }

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -129,20 +129,23 @@ TEST(DOMEllipsoid, Load)
   sdf->SetName("ellipsoid");
   errors = ellipsoid.Load(sdf);
   ASSERT_EQ(1u, errors.size());
-  EXPECT_EQ(sdf::ErrorCode::ELEMENT_MISSING, errors[0].Code());
   EXPECT_NE(std::string::npos, errors[0].Message().find("missing a <radii>"))
       << errors[0].Message();
   EXPECT_NE(nullptr, ellipsoid.Element());
+
+  // Add <radii> element description
+  sdf::ElementPtr radiiDesc(new sdf::Element());
+  radiiDesc->SetName("radii");
+  radiiDesc->AddValue("vector3", "1 1 1", true, "radii of the ellipsoid");
+  sdf->AddElementDescription(radiiDesc);
 
   // Negative <radii> element
   sdf::ElementPtr radiiElem = sdf->AddElement("radii");
   radiiElem->Set<gz::math::Vector3d>(gz::math::Vector3d(-1, -1, -1));
   errors = ellipsoid.Load(sdf);
-  ASSERT_EQ(1u, errors.size());
-  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
-  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <radii>"))
-      << errors[0].Message();
+  ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, ellipsoid.Element());
+  EXPECT_EQ(gz::math::Vector3d::One, ellipsoid.Shape().Radii());
 }
 
 /////////////////////////////////////////////////

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -133,6 +133,16 @@ TEST(DOMEllipsoid, Load)
   EXPECT_NE(std::string::npos, errors[0].Message().find("missing a <radii>"))
       << errors[0].Message();
   EXPECT_NE(nullptr, ellipsoid.Element());
+
+  // Negative <radii> element
+  sdf::ElementPtr radiiElem = sdf->AddElement("radii");
+  radiiElem->Set<gz::math::Vector3d>(gz::math::Vector3d(-1, -1, -1));
+  errors = ellipsoid.Load(sdf);
+  ASSERT_EQ(1u, errors.size());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
+  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <radii>"))
+      << errors[0].Message();
+  EXPECT_NE(nullptr, ellipsoid.Element());
 }
 
 /////////////////////////////////////////////////

--- a/src/Plane.cc
+++ b/src/Plane.cc
@@ -16,6 +16,7 @@
 */
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
+#include "sdf/Console.hh"
 #include "sdf/parser.hh"
 #include "sdf/Plane.hh"
 #include "Utils.hh"
@@ -92,8 +93,7 @@ Errors Plane::Load(ElementPtr _sdf)
       _sdf->Get<gz::math::Vector2d>(
       errors, "size", this->dataPtr->plane.Size());
 
-    if (!pair.second || pair.first.X() <= 0 ||
-        pair.first.Y() <= 0)
+    if (!pair.second)
     {
       errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Invalid <size> data for a <plane> geometry. "
@@ -101,6 +101,12 @@ Errors Plane::Load(ElementPtr _sdf)
     }
     else
     {
+      if (pair.first.X() <= 0 || pair.first.Y() <= 0) 
+      {
+        sdfwarn << "Value of <size> is negative. "
+            << "Using default value of 1, 1.\n";
+        pair.first = gz::math::Vector2d::One;
+      }
       this->SetSize(pair.first);
     }
   }

--- a/src/Plane.cc
+++ b/src/Plane.cc
@@ -92,13 +92,17 @@ Errors Plane::Load(ElementPtr _sdf)
       _sdf->Get<gz::math::Vector2d>(
       errors, "size", this->dataPtr->plane.Size());
 
-    if (!pair.second)
+    if (!pair.second || pair.first.X() <= 0 ||
+        pair.first.Y() <= 0)
     {
       errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Invalid <size> data for a <plane> geometry. "
           "Using a size of 1, 1."});
     }
-    this->SetSize(pair.first);
+    else
+    {
+      this->SetSize(pair.first);
+    }
   }
   else
   {

--- a/src/Plane.cc
+++ b/src/Plane.cc
@@ -101,7 +101,7 @@ Errors Plane::Load(ElementPtr _sdf)
     }
     else
     {
-      if (pair.first.X() <= 0 || pair.first.Y() <= 0) 
+      if (pair.first.X() <= 0 || pair.first.Y() <= 0)
       {
         sdfwarn << "Value of <size> is negative. "
             << "Using default value of 1, 1.\n";

--- a/src/Plane_TEST.cc
+++ b/src/Plane_TEST.cc
@@ -156,6 +156,15 @@ TEST(DOMPlane, Load)
   ASSERT_EQ(1u, errors.size());
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_MISSING, errors[0].Code());
   EXPECT_NE(std::string::npos, errors[0].Message().find("missing a <size>"));
+
+  // Negative <size> element
+  sdf::ElementPtr sizeElem = sdf->AddElement("size");
+  sizeElem->Set<gz::math::Vector2d>(gz::math::Vector2d(-1, -1));
+  errors = plane.Load(sdf);
+  ASSERT_EQ(1u, errors.size());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
+  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <size>"));
+  EXPECT_NE(nullptr, plane.Element());
 }
 
 /////////////////////////////////////////////////

--- a/src/Plane_TEST.cc
+++ b/src/Plane_TEST.cc
@@ -142,11 +142,13 @@ TEST(DOMPlane, Load)
   EXPECT_NE(std::string::npos, errors[1].Message().find("missing a <size>"));
   EXPECT_NE(nullptr, plane.Element());
 
-  // Add a normal element
+  // Add <normal> element description
   sdf::ElementPtr normalDesc(new sdf::Element());
   normalDesc->SetName("normal");
   normalDesc->AddValue("vector3", "0 0 1", true, "normal");
   sdf->AddElementDescription(normalDesc);
+
+  // Add normal element
   sdf::ElementPtr normalElem = sdf->AddElement("normal");
   normalElem->Set<gz::math::Vector3d>({1, 0, 0});
 
@@ -157,14 +159,19 @@ TEST(DOMPlane, Load)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_MISSING, errors[0].Code());
   EXPECT_NE(std::string::npos, errors[0].Message().find("missing a <size>"));
 
+  // Now add <size> element description
+  sdf::ElementPtr sizeDesc(new sdf::Element());
+  sizeDesc->SetName("size");
+  sizeDesc->AddValue("vector2d", "1 1", true, "size");
+  sdf->AddElementDescription(sizeDesc);
+
   // Negative <size> element
   sdf::ElementPtr sizeElem = sdf->AddElement("size");
   sizeElem->Set<gz::math::Vector2d>(gz::math::Vector2d(-1, -1));
   errors = plane.Load(sdf);
-  ASSERT_EQ(1u, errors.size());
-  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INVALID, errors[0].Code());
-  EXPECT_NE(std::string::npos, errors[0].Message().find("Invalid <size>"));
+  ASSERT_EQ(0u, errors.size());
   EXPECT_NE(nullptr, plane.Element());
+  EXPECT_EQ(gz::math::Vector2d::One, plane.Size());
 }
 
 /////////////////////////////////////////////////

--- a/src/Sphere.cc
+++ b/src/Sphere.cc
@@ -17,7 +17,7 @@
 #include <optional>
 #include <gz/math/Inertial.hh>
 #include <gz/math/Material.hh>
-
+#include "sdf/Console.hh"
 #include "sdf/parser.hh"
 #include "sdf/Sphere.hh"
 #include "Utils.hh"
@@ -75,7 +75,16 @@ Errors Sphere::Load(ElementPtr _sdf)
           "Invalid <radius> data for a <sphere> geometry. "
           "Using a radius of 1.0."});
     }
-    this->dataPtr->sphere.SetRadius(pair.first);
+    else
+    {
+      if (pair.first <= 0)
+      {
+        sdfwarn << "Value of <radius> is negative. "
+            << "Using default value of 1.0.\n";
+        pair.first = 1.0;
+      }
+      this->dataPtr->sphere.SetRadius(pair.first);
+    }
   }
   else
   {

--- a/src/Sphere_TEST.cc
+++ b/src/Sphere_TEST.cc
@@ -125,8 +125,30 @@ TEST(DOMSphere, Load)
   errors = sphere.Load(sdf);
   ASSERT_EQ(1u, errors.size());
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_MISSING, errors[0].Code());
-  EXPECT_NE(std::string::npos, errors[0].Message().find("missing a <radius>"));
+  EXPECT_NE(std::string::npos, errors[0].Message().find("missing a <radius>"))
+      << errors[0].Message();
   EXPECT_NE(nullptr, sphere.Element());
+
+  // Add <radius> element description
+  sdf::ElementPtr radiusDesc(new sdf::Element());
+  radiusDesc->SetName("radius");
+  radiusDesc->AddValue("double", "1.0", true, "radius of the sphere");
+  sdf->AddElementDescription(radiusDesc);
+
+  // Valid <radius> element
+  sdf::ElementPtr radiusElem = sdf->AddElement("radius");
+  radiusElem->Set<double>(2.5);
+  errors = sphere.Load(sdf);
+  ASSERT_EQ(0u, errors.size());
+  EXPECT_NE(nullptr, sphere.Element());
+  EXPECT_DOUBLE_EQ(2.5, sphere.Radius());
+
+  // Negative <radius> element
+  radiusElem->Set<double>(-1.0);
+  errors = sphere.Load(sdf);
+  ASSERT_EQ(0u, errors.size());
+  EXPECT_NE(nullptr, sphere.Element());
+  EXPECT_DOUBLE_EQ(1.0, sphere.Radius());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2616

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
This PR introduces a fix for Gazebo crashing whenever an `sdf` element with negative size parameter was loaded. This is done by by simply adding a check in the `load` function of each element to identify whether the parameter that is being loaded is negative or not.

You can test  it by running: 
`gz sim -v 3 c5.xml`

[c5.txt](https://github.com/user-attachments/files/19576675/c5.txt)

From there, you should be seeing some warnings and all of the shapes.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.