### PR TITLE
Test building python bindings in macOS

### DIFF
--- a/.github/ci/after_make_test.sh
+++ b/.github/ci/after_make_test.sh
@@ -15,4 +15,11 @@ cmake ..;
 make;
 ./simple ../simple.sdf;
 
+# Compile python bindings
+cd $BUILD_DIR/../python
+mkdir build;
+cd build;
+cmake ..;
+make;
+
 cd $BUILD_DIR

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -71,3 +71,10 @@ jobs:
         cmake ..;
         make;
         ./simple ../simple.sdf;
+    - name: Compile python bindings
+      working-directory: python
+      run: |
+        mkdir build;
+        cd build;
+        cmake ..;
+        make;


### PR DESCRIPTION
# 🎉 New feature

Adds macOS CI testing for feature added in #1491

## Summary

The ability to build python bindings separately from the core library was added in #1491 and is currently used when building the homebrew formulae, so this adds macOS CI testing. This adds a quick test to the macOS GitHub actions workflow to compile the python bindings after compiling example code.

## Test it

Verify the macOS GitHub actions workflow succeeds

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
