### PR TITLE
Fix some cmake logic related to python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,12 +123,7 @@ if (BUILD_SDF)
 
   ################################################
   # Find psutil python package for memory tests
-  if (BUILD_TESTING)
-    find_python_module(psutil)
-    if (NOT PY_PSUTIL)
-      gz_build_warning("Python psutil package not found. Memory leak tests will be skipped")
-    endif()
-  endif()
+  find_python_module(psutil)
 
   ########################################
   # Find gz math

--- a/sdf/CMakeLists.txt
+++ b/sdf/CMakeLists.txt
@@ -14,10 +14,6 @@ add_subdirectory(1.12)
 add_custom_target(schema)
 add_dependencies(schema schema1_11)
 
-if (NOT Python3_Interpreter_FOUND)
-  gz_build_error("Python is required to generate the C++ file with the SDF content")
-endif()
-
 # Generate the EmbeddedSdf.cc file, which contains all the supported SDF
 # descriptions in a map of strings. The parser.cc file uses EmbeddedSdf.hh.
 set(EMBEDDED_SDF_CC_PATH "${PROJECT_BINARY_DIR}/src/EmbeddedSdf.cc")

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -63,8 +63,10 @@ set(tests
   world_dom.cc
 )
 
-if (Python3_Interpreter_FOUND AND PY_PSUTIL)
+if (PY_PSUTIL)
   set(tests ${tests} element_memory_leak.cc)
+else()
+  message(WARNING "Python psutil package not found. Memory leak tests will be skipped")
 endif()
 
 find_program(XMLLINT_EXE xmllint)


### PR DESCRIPTION
# 🦟 Bug fix



## Summary

* https://github.com/gazebosim/sdformat/commit/ade8f2f702a2e07c1c7dfa306362cedbb697f2b9: python3 is already required, so remove an unneeded check and unreachable build error.
* https://github.com/gazebosim/sdformat/commit/f4df9bfd4f14dd45f622a9d56690a2774912bbce: fix logic for finding the psutil python package, since `BUILD_TESTING` is not defined when that variable is checked. So unconditionally find the python package, and move the build warning to the place where the memory leak test is disabled if the package is not available.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
