### PR TITLE
Allow camera HFOV lower than 0.5°

### DIFF
--- a/sdf/1.10/camera.sdf
+++ b/sdf/1.10/camera.sdf
@@ -17,7 +17,7 @@
     <description>Name of the topic that will trigger the camera if enabled</description>
   </element> <!-- End Trigger_Topic -->
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.001" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 

--- a/sdf/1.11/camera.sdf
+++ b/sdf/1.11/camera.sdf
@@ -17,7 +17,7 @@
     <description>Name of the topic that will trigger the camera if enabled</description>
   </element> <!-- End Trigger_Topic -->
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.001" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 

--- a/sdf/1.12/camera.sdf
+++ b/sdf/1.12/camera.sdf
@@ -17,7 +17,7 @@
     <description>Name of the topic that will trigger the camera if enabled</description>
   </element> <!-- End Trigger_Topic -->
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.001" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 

--- a/sdf/1.5/camera.sdf
+++ b/sdf/1.5/camera.sdf
@@ -5,7 +5,7 @@
     <description>An optional name for the camera.</description>
   </attribute>
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.001" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 

--- a/sdf/1.6/camera.sdf
+++ b/sdf/1.6/camera.sdf
@@ -5,7 +5,7 @@
     <description>An optional name for the camera.</description>
   </attribute>
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.001" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 

--- a/sdf/1.7/camera.sdf
+++ b/sdf/1.7/camera.sdf
@@ -9,7 +9,7 @@
     <description>Name of the camera info</description>
   </element> <!-- End camera Info topic -->
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.001" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 

--- a/sdf/1.8/camera.sdf
+++ b/sdf/1.8/camera.sdf
@@ -9,7 +9,7 @@
     <description>Name of the camera info</description>
   </element> <!-- End camera Info topic -->
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.01" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 

--- a/sdf/1.8/camera.sdf
+++ b/sdf/1.8/camera.sdf
@@ -9,7 +9,7 @@
     <description>Name of the camera info</description>
   </element> <!-- End camera Info topic -->
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.01" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.001" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 

--- a/sdf/1.9/camera.sdf
+++ b/sdf/1.9/camera.sdf
@@ -17,7 +17,7 @@
     <description>Name of the topic that will trigger the camera if enabled</description>
   </element> <!-- End Trigger_Topic -->
 
-  <element name="horizontal_fov" type="double" default="1.047" min="0.1" max="6.283186" required="1">
+  <element name="horizontal_fov" type="double" default="1.047" min="0.001" max="6.283186" required="1">
     <description>Horizontal field of view</description>
   </element> <!-- End Horizontal_FOV -->
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1562

## Summary
The current lower HFOV angle (0.1 rad / 5.72958°) for a camera is too high compared to the limit in `gz_sensors` (0.01 rad).
The proposed modification allow angle as narrow ad 0.5° and above.

Corresponding PR in `gz-sensors` depot : https://github.com/gazebosim/gz-sensors/pull/520

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.