### PR TITLE
Remove gz_test_deps from python tests

### DIFF
--- a/python/test/gz_test_deps/README
+++ b/python/test/gz_test_deps/README
@@ -1,8 +1,0 @@
-This python package encapsulates versioned python packages of gz library 
-bindings such that the version number only has to be changed in this package. 
-Here's an example of how to use this in a python test:
-
-```python
-from gz_test_deps import math  # instead of from gz import math
-from gz_test_deps.math import Vector3d  # instead of from gz.math import Vector3d
-```

--- a/python/test/gz_test_deps/math.py
+++ b/python/test/gz_test_deps/math.py
@@ -1,1 +1,0 @@
-from gz.math import *

--- a/python/test/gz_test_deps/sdformat.py
+++ b/python/test/gz_test_deps/sdformat.py
@@ -1,1 +1,0 @@
-from sdformat import *

--- a/python/test/pyAirPressure_TEST.py
+++ b/python/test/pyAirPressure_TEST.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.sdformat import AirPressure, Noise
-import gz_test_deps.sdformat as sdf
+from sdformat import AirPressure, Noise
+import sdformat as sdf
 import unittest
 
 class AtmosphereTEST(unittest.TestCase):

--- a/python/test/pyAirSpeed_TEST.py
+++ b/python/test/pyAirSpeed_TEST.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.sdformat import AirSpeed, Noise
-import gz_test_deps.sdformat as sdf
+from sdformat import AirSpeed, Noise
+import sdformat as sdf
 import unittest
 
 class AirSpeedTEST(unittest.TestCase):

--- a/python/test/pyAltimeter_TEST.py
+++ b/python/test/pyAltimeter_TEST.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.sdformat import Altimeter, Noise
-import gz_test_deps.sdformat as sdf
+from sdformat import Altimeter, Noise
+import sdformat as sdf
 import unittest
 
 

--- a/python/test/pyAtmosphere_TEST.py
+++ b/python/test/pyAtmosphere_TEST.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.math import Temperature
-from gz_test_deps.sdformat import Atmosphere
-import gz_test_deps.sdformat as sdf
+from gz.math import Temperature
+from sdformat import Atmosphere
+import sdformat as sdf
 import unittest
 
 class AtmosphereTEST(unittest.TestCase):

--- a/python/test/pyBox_TEST.py
+++ b/python/test/pyBox_TEST.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
-from gz_test_deps.sdformat import Box
+from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
+from sdformat import Box
 import unittest
 
 class BoxTEST(unittest.TestCase):

--- a/python/test/pyCamera_TEST.py
+++ b/python/test/pyCamera_TEST.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Angle, Pose3d, Vector2d
+from gz.math import Angle, Pose3d, Vector2d
 import math
-from gz_test_deps.sdformat import Camera
-import gz_test_deps.sdformat as sdf
+from sdformat import Camera
+import sdformat as sdf
 import unittest
 
 class CameraTEST(unittest.TestCase):

--- a/python/test/pyCapsule_TEST.py
+++ b/python/test/pyCapsule_TEST.py
@@ -16,8 +16,8 @@ import copy
 
 import math
 
-from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
-from gz_test_deps.sdformat import Capsule
+from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
+from sdformat import Capsule
 
 import unittest
 

--- a/python/test/pyCollision_TEST.py
+++ b/python/test/pyCollision_TEST.py
@@ -15,8 +15,8 @@
 import copy
 from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
 from sdformat import (Box, Collision, Cone, Contact, Cylinder, Error,
-                                   Geometry, ParserConfig, Plane, Root, Surface, Sphere,
-                                   SDFErrorsException)
+                      Geometry, ParserConfig, Plane, Root, Surface, Sphere,
+                      SDFErrorsException)
 import sdformat as sdf
 import unittest
 import math

--- a/python/test/pyCollision_TEST.py
+++ b/python/test/pyCollision_TEST.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
-from gz_test_deps.sdformat import (Box, Collision, Cone, Contact, Cylinder, Error,
+from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
+from sdformat import (Box, Collision, Cone, Contact, Cylinder, Error,
                                    Geometry, ParserConfig, Plane, Root, Surface, Sphere,
                                    SDFErrorsException)
-import gz_test_deps.sdformat as sdf
+import sdformat as sdf
 import unittest
 import math
 

--- a/python/test/pyCone_TEST.py
+++ b/python/test/pyCone_TEST.py
@@ -18,7 +18,7 @@ import copy
 
 import math
 
-from gz_test_deps.sdformat import Cone
+from sdformat import Cone
 
 import unittest
 

--- a/python/test/pyCylinder_TEST.py
+++ b/python/test/pyCylinder_TEST.py
@@ -16,8 +16,8 @@ import copy
 
 import math
 
-from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
-from gz_test_deps.sdformat import Cylinder
+from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
+from sdformat import Cylinder
 
 import unittest
 

--- a/python/test/pyElement_TEST.py
+++ b/python/test/pyElement_TEST.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.sdformat import Element, SDFErrorsException
-from gz_test_deps.math import Vector3d
+from sdformat import Element, SDFErrorsException
+from gz.math import Vector3d
 import unittest
 
 

--- a/python/test/pyEllipsoid_TEST.py
+++ b/python/test/pyEllipsoid_TEST.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
+from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
 import math
-from gz_test_deps.sdformat import Ellipsoid
+from sdformat import Ellipsoid
 import unittest
 
 

--- a/python/test/pyError_TEST.py
+++ b/python/test/pyError_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Error
-import gz_test_deps.sdformat as sdf
+from sdformat import Error
+import sdformat as sdf
 import unittest
 
 class ErrorColor(unittest.TestCase):

--- a/python/test/pyForceTorque_TEST.py
+++ b/python/test/pyForceTorque_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import ForceTorque, Noise
-import gz_test_deps.sdformat as sdf
+from sdformat import ForceTorque, Noise
+import sdformat as sdf
 import unittest
 
 class ForceTorqueTEST(unittest.TestCase):

--- a/python/test/pyFrame_TEST.py
+++ b/python/test/pyFrame_TEST.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.math import Pose3d
-from gz_test_deps.sdformat import Frame, Error, SDFErrorsException, ErrorCode
+from gz.math import Pose3d
+from sdformat import Frame, Error, SDFErrorsException, ErrorCode
 import unittest
 import math
 

--- a/python/test/pyGeometry_TEST.py
+++ b/python/test/pyGeometry_TEST.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import (Element, Error, Geometry, Box, Capsule, Cone, Cylinder, Ellipsoid,
+from sdformat import (Element, Error, Geometry, Box, Capsule, Cone, Cylinder, Ellipsoid,
                                    Heightmap, Mesh, ParserConfig, Plane, Sphere)
-from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d, Vector2d
-import gz_test_deps.sdformat as sdf
+from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d, Vector2d
+import sdformat as sdf
 import math
 import unittest
 

--- a/python/test/pyGeometry_TEST.py
+++ b/python/test/pyGeometry_TEST.py
@@ -14,7 +14,7 @@
 
 import copy
 from sdformat import (Element, Error, Geometry, Box, Capsule, Cone, Cylinder, Ellipsoid,
-                                   Heightmap, Mesh, ParserConfig, Plane, Sphere)
+                      Heightmap, Mesh, ParserConfig, Plane, Sphere)
 from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d, Vector2d
 import sdformat as sdf
 import math

--- a/python/test/pyGui_TEST.py
+++ b/python/test/pyGui_TEST.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Gui, Plugin
+from sdformat import Gui, Plugin
 import unittest
 
 

--- a/python/test/pyHeightmap_TEST.py
+++ b/python/test/pyHeightmap_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Vector3d
-from gz_test_deps.sdformat import Heightmap, HeightmapBlend, HeightmapTexture
+from gz.math import Vector3d
+from sdformat import Heightmap, HeightmapBlend, HeightmapTexture
 import unittest
 
 

--- a/python/test/pyIMU_TEST.py
+++ b/python/test/pyIMU_TEST.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Vector3d
-from gz_test_deps.sdformat import IMU, Noise
-import gz_test_deps.sdformat as sdf
+from gz.math import Vector3d
+from sdformat import IMU, Noise
+import sdformat as sdf
 import unittest
 
 class IMUTest(unittest.TestCase):

--- a/python/test/pyJointAxis_TEST.py
+++ b/python/test/pyJointAxis_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Vector3d
-from gz_test_deps.sdformat import JointAxis, MimicConstraint, Error, SDFErrorsException
+from gz.math import Vector3d
+from sdformat import JointAxis, MimicConstraint, Error, SDFErrorsException
 import math
 import unittest
 

--- a/python/test/pyJoint_TEST.py
+++ b/python/test/pyJoint_TEST.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Pose3d, Vector3d
-from gz_test_deps.sdformat import (Joint, JointAxis, Error, SemanticPose,
+from gz.math import Pose3d, Vector3d
+from sdformat import (Joint, JointAxis, Error, SemanticPose,
                                    Sensor, SDFErrorsException)
-import gz_test_deps.sdformat as sdf
+import sdformat as sdf
 import math
 import unittest
 

--- a/python/test/pyJoint_TEST.py
+++ b/python/test/pyJoint_TEST.py
@@ -15,7 +15,7 @@
 import copy
 from gz.math import Pose3d, Vector3d
 from sdformat import (Joint, JointAxis, Error, SemanticPose,
-                                   Sensor, SDFErrorsException)
+                      Sensor, SDFErrorsException)
 import sdformat as sdf
 import math
 import unittest

--- a/python/test/pyLidar_TEST.py
+++ b/python/test/pyLidar_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Angle, Helpers
-from gz_test_deps.sdformat import Lidar, Error, Noise
+from gz.math import Angle, Helpers
+from sdformat import Lidar, Error, Noise
 import math
 import unittest
 

--- a/python/test/pyLight_TEST.py
+++ b/python/test/pyLight_TEST.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Angle, Color, Pose3d, Vector3d
-from gz_test_deps.sdformat import Light, SDFErrorsException
-import gz_test_deps.sdformat as sdf
+from gz.math import Angle, Color, Pose3d, Vector3d
+from sdformat import Light, SDFErrorsException
+import sdformat as sdf
 import math
 import unittest
 

--- a/python/test/pyLink_TEST.py
+++ b/python/test/pyLink_TEST.py
@@ -15,7 +15,7 @@
 import copy
 from gz.math import Pose3d, Inertiald, MassMatrix3d, Vector3d
 from sdformat import (Collision, Light, Link, ParserConfig, Projector, Sensor,
-                                   Visual, Root, SDFErrorsException)
+                      Visual, Root, SDFErrorsException)
 import unittest
 import math
 

--- a/python/test/pyLink_TEST.py
+++ b/python/test/pyLink_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Pose3d, Inertiald, MassMatrix3d, Vector3d
-from gz_test_deps.sdformat import (Collision, Light, Link, ParserConfig, Projector, Sensor,
+from gz.math import Pose3d, Inertiald, MassMatrix3d, Vector3d
+from sdformat import (Collision, Light, Link, ParserConfig, Projector, Sensor,
                                    Visual, Root, SDFErrorsException)
 import unittest
 import math

--- a/python/test/pyMagnetometer_TEST.py
+++ b/python/test/pyMagnetometer_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Magnetometer, Noise
-import gz_test_deps.sdformat as sdf
+from sdformat import Magnetometer, Noise
+import sdformat as sdf
 import unittest
 
 

--- a/python/test/pyMaterial_TEST.py
+++ b/python/test/pyMaterial_TEST.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Material, Pbr, PbrWorkflow
-from gz_test_deps.math import Color
-import gz_test_deps.sdformat as sdf
+from sdformat import Material, Pbr, PbrWorkflow
+from gz.math import Color
+import sdformat as sdf
 import unittest
 
 

--- a/python/test/pyMesh_TEST.py
+++ b/python/test/pyMesh_TEST.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Mesh, ConvexDecomposition
-from gz_test_deps.math import Vector3d
-import gz_test_deps.sdformat as sdf
+from sdformat import Mesh, ConvexDecomposition
+from gz.math import Vector3d
+import sdformat as sdf
 import unittest
 
 

--- a/python/test/pyModel_TEST.py
+++ b/python/test/pyModel_TEST.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Pose3d
-from gz_test_deps.sdformat import (Plugin, Model, Joint, Link, Error, Frame,
+from gz.math import Pose3d
+from sdformat import (Plugin, Model, Joint, Link, Error, Frame,
                                    SemanticPose, SDFErrorsException)
-import gz_test_deps.sdformat as sdf
+import sdformat as sdf
 import math
 import unittest
 

--- a/python/test/pyModel_TEST.py
+++ b/python/test/pyModel_TEST.py
@@ -15,7 +15,7 @@
 import copy
 from gz.math import Pose3d
 from sdformat import (Plugin, Model, Joint, Link, Error, Frame,
-                                   SemanticPose, SDFErrorsException)
+                      SemanticPose, SDFErrorsException)
 import sdformat as sdf
 import math
 import unittest

--- a/python/test/pyNavSat_TEST.py
+++ b/python/test/pyNavSat_TEST.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import NavSat, Noise
+from sdformat import NavSat, Noise
 import unittest
 
 class NavSatColor(unittest.TestCase):

--- a/python/test/pyNoise_TEST.py
+++ b/python/test/pyNoise_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Noise
-import gz_test_deps.sdformat as sdf
+from sdformat import Noise
+import sdformat as sdf
 import math
 import unittest
 

--- a/python/test/pyParam_TEST.py
+++ b/python/test/pyParam_TEST.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.sdformat import Element, Param, SDFErrorsException
-from gz_test_deps.math import Vector2i, Vector3d, Pose3d
+from sdformat import Element, Param, SDFErrorsException
+from gz.math import Vector2i, Vector3d, Pose3d
 import unittest
 
 

--- a/python/test/pyParserConfig_TEST.py
+++ b/python/test/pyParserConfig_TEST.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import ParserConfig
+from sdformat import ParserConfig
 from sdformattest import source_file, test_file
 import unittest
 

--- a/python/test/pyParticleEmitter_TEST.py
+++ b/python/test/pyParticleEmitter_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Color, Pose3d, Vector3d, Helpers
-from gz_test_deps.sdformat import ParticleEmitter
+from gz.math import Color, Pose3d, Vector3d, Helpers
+from sdformat import ParticleEmitter
 import unittest
 
 

--- a/python/test/pyPbr_TEST.py
+++ b/python/test/pyPbr_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Pbr, PbrWorkflow
-import gz_test_deps.sdformat as sdf
+from sdformat import Pbr, PbrWorkflow
+import sdformat as sdf
 import unittest
 
 

--- a/python/test/pyPhysics_TEST.py
+++ b/python/test/pyPhysics_TEST.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Physics
+from sdformat import Physics
 import unittest
 
 

--- a/python/test/pyPlane_TEST.py
+++ b/python/test/pyPlane_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Plane
-from gz_test_deps.math import Vector3d, Vector2d
+from sdformat import Plane
+from gz.math import Vector3d, Vector2d
 import unittest
 
 

--- a/python/test/pyPlugin_TEST.py
+++ b/python/test/pyPlugin_TEST.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Plugin
+from sdformat import Plugin
 import unittest
 
 

--- a/python/test/pyPolyline_TEST.py
+++ b/python/test/pyPolyline_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Polyline
-from gz_test_deps.math import Vector2d
+from sdformat import Polyline
+from gz.math import Vector2d
 import unittest
 
 

--- a/python/test/pyPrintConfig_TEST.py
+++ b/python/test/pyPrintConfig_TEST.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gz_test_deps.sdformat import PrintConfig, SDFErrorsException
+from sdformat import PrintConfig, SDFErrorsException
 import unittest
 
 

--- a/python/test/pyProjector_TEST.py
+++ b/python/test/pyProjector_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.sdformat import Plugin, Projector
-from gz_test_deps.math import Angle, Pose3d
+from sdformat import Plugin, Projector
+from gz.math import Angle, Pose3d
 import unittest
 
 

--- a/python/test/pyRoot_TEST.py
+++ b/python/test/pyRoot_TEST.py
@@ -15,8 +15,8 @@
 import copy
 from gz.math import Pose3d
 from sdformat import (ConfigureResolveAutoInertials, Error, Model, ParserConfig, Light, Root, SDF_VERSION,
-                                   SDFErrorsException, SDF_PROTOCOL_VERSION,
-                                   World)
+                      SDFErrorsException, SDF_PROTOCOL_VERSION,
+                      World)
 import sdformat as sdf
 
 import unittest

--- a/python/test/pyRoot_TEST.py
+++ b/python/test/pyRoot_TEST.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Pose3d
-from gz_test_deps.sdformat import (ConfigureResolveAutoInertials, Error, Model, ParserConfig, Light, Root, SDF_VERSION,
+from gz.math import Pose3d
+from sdformat import (ConfigureResolveAutoInertials, Error, Model, ParserConfig, Light, Root, SDF_VERSION,
                                    SDFErrorsException, SDF_PROTOCOL_VERSION,
                                    World)
-import gz_test_deps.sdformat as sdf
+import sdformat as sdf
 
 import unittest
 

--- a/python/test/pyScene_TEST.py
+++ b/python/test/pyScene_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Color
-from gz_test_deps.sdformat import Scene, Sky
+from gz.math import Color
+from sdformat import Scene, Sky
 import unittest
 
 

--- a/python/test/pySemanticPose_TEST.py
+++ b/python/test/pySemanticPose_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Pose3d
-from gz_test_deps.sdformat import Link, SemanticPose
+from gz.math import Pose3d
+from sdformat import Link, SemanticPose
 import unittest
 
 class semantic_poseTEST(unittest.TestCase):

--- a/python/test/pySensor_TEST.py
+++ b/python/test/pySensor_TEST.py
@@ -15,9 +15,9 @@
 import copy
 from gz.math import Pose3d
 from sdformat import (AirPressure, Altimeter, Camera, IMU,
-                                   ForceTorque, Lidar, Magnetometer, NavSat,
-                                   Noise, Plugin, SemanticPose, Sensor,
-                                   SDFErrorsException)
+                      ForceTorque, Lidar, Magnetometer, NavSat,
+                      Noise, Plugin, SemanticPose, Sensor,
+                      SDFErrorsException)
 import sdformat as sdf
 import unittest
 

--- a/python/test/pySensor_TEST.py
+++ b/python/test/pySensor_TEST.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Pose3d
-from gz_test_deps.sdformat import (AirPressure, Altimeter, Camera, IMU,
+from gz.math import Pose3d
+from sdformat import (AirPressure, Altimeter, Camera, IMU,
                                    ForceTorque, Lidar, Magnetometer, NavSat,
                                    Noise, Plugin, SemanticPose, Sensor,
                                    SDFErrorsException)
-import gz_test_deps.sdformat as sdf
+import sdformat as sdf
 import unittest
 
 

--- a/python/test/pySky_TEST.py
+++ b/python/test/pySky_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Angle, Color
-from gz_test_deps.sdformat import Sky
+from gz.math import Angle, Color
+from sdformat import Sky
 import unittest
 
 

--- a/python/test/pySphere_TEST.py
+++ b/python/test/pySphere_TEST.py
@@ -14,8 +14,8 @@
 
 import copy
 import math
-from gz_test_deps.sdformat import Sphere
-from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
+from sdformat import Sphere
+from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
 import unittest
 
 class SphereTEST(unittest.TestCase):

--- a/python/test/pySurface_TEST.py
+++ b/python/test/pySurface_TEST.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Vector3d
-from gz_test_deps.sdformat import Surface, Contact, Friction, ODE, \
+from gz.math import Vector3d
+from sdformat import Surface, Contact, Friction, ODE, \
                                   BulletFriction, Torsional
 import unittest
 

--- a/python/test/pyVisual_TEST.py
+++ b/python/test/pyVisual_TEST.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Pose3d, Color
-from gz_test_deps.sdformat import (Geometry, Material, Visual, Plugin,
+from gz.math import Pose3d, Color
+from sdformat import (Geometry, Material, Visual, Plugin,
                                    SDFErrorsException)
-import gz_test_deps.sdformat as sdf
+import sdformat as sdf
 import unittest
 import math
 

--- a/python/test/pyVisual_TEST.py
+++ b/python/test/pyVisual_TEST.py
@@ -15,7 +15,7 @@
 import copy
 from gz.math import Pose3d, Color
 from sdformat import (Geometry, Material, Visual, Plugin,
-                                   SDFErrorsException)
+                      SDFErrorsException)
 import sdformat as sdf
 import unittest
 import math

--- a/python/test/pyWorld_TEST.py
+++ b/python/test/pyWorld_TEST.py
@@ -16,7 +16,7 @@ import copy
 from gz.math import Color, Vector3d, SphericalCoordinates
 from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
 from sdformat import (Atmosphere, Gui, Physics, Plugin, Error,
-                                   Frame, Joint, Light, Model, ParserConfig, Root, Scene, World)
+                      Frame, Joint, Light, Model, ParserConfig, Root, Scene, World)
 import sdformat as sdf
 import unittest
 import math

--- a/python/test/pyWorld_TEST.py
+++ b/python/test/pyWorld_TEST.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import copy
-from gz_test_deps.math import Color, Vector3d, SphericalCoordinates
-from gz_test_deps.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
-from gz_test_deps.sdformat import (Atmosphere, Gui, Physics, Plugin, Error,
+from gz.math import Color, Vector3d, SphericalCoordinates
+from gz.math import Inertiald, MassMatrix3d, Pose3d, Vector3d
+from sdformat import (Atmosphere, Gui, Physics, Plugin, Error,
                                    Frame, Joint, Light, Model, ParserConfig, Root, Scene, World)
-import gz_test_deps.sdformat as sdf
+import sdformat as sdf
 import unittest
 import math
 


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1309.

## Summary

Since major versions were removed from package names, we can remove the `gz_test_deps` folder, which was a helper to avoid version numbers in python imports, but this is not needed anymore.

## Test it

Check that CI passes.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
