### PR TITLE
Fix bazel build errors with clang

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -169,7 +169,6 @@ test_sources = glob(
 cc_test(
     name = "Converter_TEST",
     srcs = [
-        "include/sdf/config.hh",
         "src/Converter.hh",
         "src/Converter_TEST.cc",
         "src/XmlUtils.hh",
@@ -201,7 +200,6 @@ cc_test(
         "//test:sdf",
     ],
     deps = [
-        ":Config",
         ":sdformat",
         "//test:test_utils",
         "@googletest//:gtest",
@@ -253,7 +251,6 @@ cc_test(
         "//test:sdf",
     ],
     deps = [
-        ":Config",
         ":sdformat",
         "//test:test_utils",
         "@googletest//:gtest",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
 load("@rules_license//rules:license.bzl", "license")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 
 package(
     default_applicable_licenses = [":license"],
@@ -101,7 +102,7 @@ cc_library(
             # Bazel does not generate top-level includes, so exclude the redirect
             "include/sdf/sdf.hh",
         ],
-    ),
+    ) + ["include/sdf/config.hh"],
     data = [
         "sdf",
     ],
@@ -116,7 +117,6 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":Config",
         ":Export",
         ":urdf_parser",
         "@gz-math",
@@ -147,12 +147,20 @@ test_sources = glob(
     cc_test(
         name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
         srcs = [src],
+        copts = [
+            # Some tests are for private headers
+            "-Wno-private-header",
+        ],
         deps = [
             ":sdformat",
             "//test:test_utils",
             "@googletest//:gtest",
             "@googletest//:gtest_main",
+            "@gz-math",
+            "@gz-utils//:Environment",
             "@gz-utils//:ExtraTestMacros",
+            "@gz-utils//:SuppressWarning",
+            "@tinyxml2",
         ],
     )
     for src in test_sources
@@ -161,6 +169,7 @@ test_sources = glob(
 cc_test(
     name = "Converter_TEST",
     srcs = [
+        "include/sdf/config.hh",
         "src/Converter.hh",
         "src/Converter_TEST.cc",
         "src/XmlUtils.hh",
@@ -177,6 +186,7 @@ cc_test(
         "//test:test_utils",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+        "@tinyxml2",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
 
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2")
 bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "rules_python", version = "0.40.0")
 bazel_dep(name = "rules_license", version = "0.0.8")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes bazel build issues detected with
```
$ bazel build --action_env=CC=/usr/bin/clang ...
```
and
```
$ USE_BAZEL_VERSION=8.2.1 bazel build --incompatible_autoload_externally= ...
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
