### PR TITLE
Fix inclusion of sdf/ data deps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -103,9 +103,7 @@ cc_library(
             "include/sdf/sdf.hh",
         ],
     ) + ["include/sdf/config.hh"],
-    data = [
-        "sdf",
-    ],
+    data = glob(["sdf/**"]),
     defines = [
         "CMAKE_INSTALL_RELATIVE_DATAROOTDIR=\\\"\\\"",
         'SDF_SHARE_PATH=\\".\\"',


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
Explicitly depend on all files in the subdirectory by using a glob instead of the directory itself.

This fixes a bug currently causing creating a

```
load("@rules_pkg//:pkg.bzl", "pkg_tar")
pkg_tar(
  name = "my-rule"
  srcs = ["my-binary-that-depends-on-sdformat"],
  include_runfiles = True,
)
```

to fail with

```
IsADirectoryError: [Errno 21] Is a directory: 'external/sdformat+/sdf'
```

Bazel normally requires all dependencies to be explicitly declared, and e.g. pkg_tar requires it (https://github.com/bazelbuild/rules_pkg/issues/611). I'm honestly surprised that `cc_library` allows depending on a directory like this :)

I'm not quite sure how to add tests for this, as pulling in a dependency on `rules_pkg` seems a bit much? But I have verified the behavior in my local checkout.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

