### PR TITLE
[Bazel] Add back sdformat.hh auto-generated lumped header

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
-load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
+load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header", "gz_include_header")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 
@@ -40,6 +40,19 @@ gz_configure_header(
         "SDF_PROTOCOL_VERSION=1.12",
     ],
     package_xml = "package.xml",
+)
+
+public_headers_no_gen = glob(
+    ["include/sdf/*.hh"],
+    exclude = ["include/sdf/sdf.hh"],
+)
+
+gz_include_header(
+    name = "Include",
+    out = "include/sdf/sdformat.hh",
+    hdrs = public_headers_no_gen + [
+        "include/sdf/config.hh",
+    ],
 )
 
 py_binary(
@@ -94,15 +107,12 @@ cc_library(
             "src/*_TEST.cc",
         ],
     ) + ["EmbeddedSdf.cc"],
-    hdrs = glob(
-        include = [
-            "include/sdf/*.hh",
-        ],
-        exclude = [
-            # Bazel does not generate top-level includes, so exclude the redirect
-            "include/sdf/sdf.hh",
-        ],
-    ) + ["include/sdf/config.hh"],
+    hdrs = public_headers_no_gen + [
+        "include/sdf/config.hh",
+        "include/sdf/sdf.hh",
+        "include/sdf/sdf_config.h",
+        "include/sdf/sdformat.hh",
+    ],
     data = glob(["sdf/**"]),
     defines = [
         "CMAKE_INSTALL_RELATIVE_DATAROOTDIR=\\\"\\\"",
@@ -111,6 +121,7 @@ cc_library(
     ],
     includes = [
         "include",
+        "include/sdf",
         "src",
     ],
     visibility = ["//visibility:public"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "rules_license", version = "0.0.8")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
 
 # Gazebo Dependencies
-bazel_dep(name = "rules_gazebo", version = "0.0.2")
+bazel_dep(name = "rules_gazebo", version = "0.0.6")
 bazel_dep(name = "gz-utils")
 bazel_dep(name = "gz-math")
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

At the time when migrating from WORKSPACE to Bzlmod setup for sdformat, we had dropped the `sdformat.hh` generated lumped header. But when adding bazel build for gz-sim (in https://github.com/gazebosim/gz-sim/pull/2933), I found that we may accidentally break downstream builds since some public headers in gz-sim transitively include `sdformat.hh`.

To prevent breaking downstream builds on an existing gz-sim release, this PR adds back the `sdformat.hh` file in bazel build. This requires bumping `rules_gazebo` in MODULE.bazel since we need the `gz_include_header` rule that I added there in https://github.com/gazebosim/rules_gazebo/pull/19.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

