### PR TITLE
Prepare for 14.8.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat14 VERSION 14.7.0)
+project (sdformat14 VERSION 14.8.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 ## libsdformat 14.X
 
+### libsdformat 14.8.0 (2025-07-02)
+
+1. Improve error messages when embedSdf.py fails
+    * [Pull request #1550](https://github.com/gazebosim/sdformat/pull/1550)
+
+1. Add AxisAlignedBox getters for all relevant geometries
+    * [Pull request #1547](https://github.com/gazebosim/sdformat/pull/1547)
+
+1. Unify Python3_Development_FOUND checks
+    * [Pull request #1541](https://github.com/gazebosim/sdformat/pull/1541)
+
+1. Add policy for handling CalculateInertial failures
+    * [Pull request #1543](https://github.com/gazebosim/sdformat/pull/1543)
+
 ### libsdformat 14.7.0 (2025-01-30)
 
 1. Resolve auto inertia based on input mass

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat14</name>
-  <version>14.7.0</version>
+  <version>14.8.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION

# 🎈 Release

Preparation for 14.8.0 release.

Comparison to 14.7.0: https://github.com/gazebosim/sdformat/compare/sdformat14_14.7.0...prep_14.8.0

<!-- Add links to PRs that require this release (if needed) -->


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
