### PR TITLE
Jetty Changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,39 @@
 ## libsdformat 16.X
 
-### libsdformat 16.0.0 (20XX-XX-XX)
+### libsdformat 16.0.0 (2025-09-24)
+
+1. **Baseline:** this includes all changes from 15.3.0 and earlier.
+
+1. [Bazel] Fix dep issue when building with clang
+    * [Pull request #1581](https://github.com/gazebosim/sdformat/pull/1581)
+
+1. [Bazel] Add back sdformat.hh auto-generated lumped header
+    * [Pull request #1570](https://github.com/gazebosim/sdformat/pull/1570)
+
+1. [Bazel] Fix inclusion of sdf/ data deps
+    * [Pull request #1567](https://github.com/gazebosim/sdformat/pull/1567)
+
+1. [Bazel] Fix build errors with clang
+    * [Pull request #1566](https://github.com/gazebosim/sdformat/pull/1566)
+
+1. Install exe and spec files to unversioned folders
+    * [Pull request #1569](https://github.com/gazebosim/sdformat/pull/1569)
+
+1. Remove gz_test_deps from python tests
+    * [Pull request #1564](https://github.com/gazebosim/sdformat/pull/1564)
+
+1. Bump dependency versions of gz-cmake and others in jetty and remove version from package names
+    * [Pull request #1561](https://github.com/gazebosim/sdformat/pull/1561)
+    * [Release-tools issue #1309](https://github.com/gazebo-tooling/release-tools/issues/1309)
+
+1. Fix initialization and thread-safety of SDF::Version() global
+    * [Pull request #1522](https://github.com/gazebosim/sdformat/pull/1522)
+
+1. Remove deprecations from Camera.hh, ParserConfig.hh, and config.hh
+    * [Pull request #1519](https://github.com/gazebosim/sdformat/pull/1519)
+
+1. Bump major version to 16
+    * [Pull request #1487](https://github.com/gazebosim/sdformat/pull/1487)
 
 ## libsdformat 15.X
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-jetty/issues/26.

## Summary

Changelog for sdformat since 15.3.0: https://github.com/gazebosim/sdformat/compare/sdformat15_15.3.0...main

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
