### PR TITLE
Respect GZ_PYTHON_INSTALL_PATH if passed as an argument

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -29,21 +29,23 @@ else()
   return()
 endif()
 
-if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
-  if(NOT Python3_SITEARCH)
-    # Get variable from Python3 module
-    find_package(Python3 COMPONENTS Interpreter)
-  endif()
+if(NOT DEFINED GZ_PYTHON_INSTALL_PATH)
+  if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
+    if(NOT Python3_SITEARCH)
+      # Get variable from Python3 module
+      find_package(Python3 COMPONENTS Interpreter)
+    endif()
 
-  if(USE_DIST_PACKAGES_FOR_PYTHON)
-    string(REPLACE "site-packages" "dist-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITEARCH})
+    if(USE_DIST_PACKAGES_FOR_PYTHON)
+      string(REPLACE "site-packages" "dist-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITEARCH})
+    else()
+      # custom cmake command is returning dist-packages
+      string(REPLACE "dist-packages" "site-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITEARCH})
+    endif()
   else()
-    # custom cmake command is returning dist-packages
-    string(REPLACE "dist-packages" "site-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITEARCH})
+    # If not a system installation, respect local paths
+    set(GZ_PYTHON_INSTALL_PATH ${CMAKE_INSTALL_LIBDIR}/python)
   endif()
-else()
-  # If not a system installation, respect local paths
-  set(GZ_PYTHON_INSTALL_PATH ${CMAKE_INSTALL_LIBDIR}/python)
 endif()
 
 # Set the build location and install location for a CPython extension


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The PR adds the ability to set the `GZ_PYTHON_INSTALL_PATH` from CMake arguments by no overriding it if it is set. This is useful for paths injected by the different package managers and distributions.

One use case is for the ROS vendor packages where the Python path is controlled by an `ament_python` helper call.

Easier to see https://github.com/gazebosim/sdformat/pull/1586/files?w=1

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

GeNote to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.