### PR TITLE
Workaround macOS latest failure

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,9 @@ jobs:
         fi
         # gz-math7 has problems with swig, remove it for now
         brew remove swig || true
+        # remove following two lines once #1587 is resolved
+        brew remove cmake || true
+        brew untap local/pinned || true
         brew install --only-dependencies ${PACKAGE};
 
     - run: mkdir build


### PR DESCRIPTION
# 🦟 Bug fix

Workaround for https://github.com/gazebosim/sdformat/issues/1587.

## Summary

Apply workaround suggested in https://github.com/actions/runner-images/issues/12912. This can be reverted after https://github.com/actions/runner-images/issues/12934 is closed.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
