### PR TITLE
Optimize load time and memory consumption by reusing element descriptions

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -18,6 +18,18 @@ but with improved human-readability..
    package.xml package name. Use `find_package(sdformat)` instead of
    `find_package(sdformatX)` going forward.
 
+- **sdf/Element.hh**:
+  + `sdf::ElementPtr MutableElementDescription(unsigned int)`
+  + `sdf::ElementPtr MutableElementDescription(const std::string &)`
+
+### Deprecations
+- **sdf/Element.hh**:
+  + Mutable access to an element description via `Element::GetElementDescription` has been deprecated. Please use `Element::MutableElementDescription` instead. For immutable access, please use `Element::ElementDescription`.
+  + ***Deprecation:*** `sdf::ElementPtr GetElementDescription(unsigned int)`
+  + ***Replacement:*** `sdf::ElementPtr ElementDescription(unsigned int) const`
+  + ***Deprecation:*** `sdf::ElementPtr GetElementDescription(const std::string &)`
+  + ***Replacement:*** `sdf::ElementPtr ElementDescription(const std::string &) const`
+
 ### Removals
 
 - **sdf/config.hh**:

--- a/Migration.md
+++ b/Migration.md
@@ -18,7 +18,11 @@ but with improved human-readability..
    package.xml package name. Use `find_package(sdformat)` instead of
    `find_package(sdformatX)` going forward.
 
+### Additions
+
 - **sdf/Element.hh**:
+  + `sdf::ElementConstPtr ElementDescription(unsigned int) const`
+  + `sdf::ElementConstPtr ElementDescription(const std::string &) const`
   + `sdf::ElementPtr MutableElementDescription(unsigned int)`
   + `sdf::ElementPtr MutableElementDescription(const std::string &)`
 
@@ -26,9 +30,9 @@ but with improved human-readability..
 - **sdf/Element.hh**:
   + Mutable access to an element description via `Element::GetElementDescription` has been deprecated. Please use `Element::MutableElementDescription` instead. For immutable access, please use `Element::ElementDescription`.
   + ***Deprecation:*** `sdf::ElementPtr GetElementDescription(unsigned int)`
-  + ***Replacement:*** `sdf::ElementPtr ElementDescription(unsigned int) const`
+  + ***Replacement:*** `sdf::ElementConstPtr ElementDescription(unsigned int) const`
   + ***Deprecation:*** `sdf::ElementPtr GetElementDescription(const std::string &)`
-  + ***Replacement:*** `sdf::ElementPtr ElementDescription(const std::string &) const`
+  + ***Replacement:*** `sdf::ElementConstPtr ElementDescription(const std::string &) const`
 
 ### Removals
 

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -382,13 +382,17 @@ namespace sdf
     /// \param[in] _index the index of the element description to get.
     /// \return An Element pointer to the found element.
     /// \deprecated See ElementDescription
-    public: GZ_DEPRECATED(16) ElementPtr GetElementDescription(unsigned int _index) const;
+    public:
+    GZ_DEPRECATED(16)
+    ElementPtr GetElementDescription(unsigned int _index) const;
 
     /// \brief Get an element description using a key
     /// \param[in] _key the key to use to find the element.
     /// \return An Element pointer to the found element.
     /// \deprecated See ElementDescription
-    public: GZ_DEPRECATED(16) ElementPtr GetElementDescription(const std::string &_key) const;
+    public:
+    GZ_DEPRECATED(16)
+    ElementPtr GetElementDescription(const std::string &_key) const;
 
     /// \brief Get an element description using an index
     /// \param[in] _index the index of the element description to get.
@@ -962,7 +966,8 @@ namespace sdf
     /// \brief XML path of this element.
     public: std::string xmlPath;
 
-    /// \brief Used to keep track of which element descriptions we have cloned in order to provide a mutable pointer.
+    /// \brief Used to keep track of which element descriptions we have cloned
+    /// in order to provide a mutable pointer.
     public: std::unordered_set<ElementConstPtr> clonedElementDescriptions;
 
     /// \brief Generate the string (XML) for the attributes.
@@ -983,10 +988,13 @@ namespace sdf
                                  const PrintConfig &_config,
                                  std::ostringstream &_out) const;
 
-    /// \brief Helper function to get the index of an element description identified by a given key
+    /// \brief Helper function to get the index of an element description
+    /// identified by a given key
     /// \param[in] _key Key of the element description
     /// \return An optional index. nullopt of the key was not found
-    public: std::optional<unsigned int> ElementDescriptionIndex(const std::string &_key);
+    public:
+    std::optional<unsigned int> ElementDescriptionIndex(
+        const std::string &_key);
   };
 
   ///////////////////////////////////////////////

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -18,7 +18,6 @@
 #define SDF_ELEMENT_HH_
 
 #include <any>
-#include <gz/math/Export.hh>
 #include <map>
 #include <memory>
 #include <optional>

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -18,10 +18,13 @@
 #define SDF_ELEMENT_HH_
 
 #include <any>
+#include <gz/math/Export.hh>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -378,12 +381,36 @@ namespace sdf
     /// \brief Get an element description using an index
     /// \param[in] _index the index of the element description to get.
     /// \return An Element pointer to the found element.
-    public: ElementPtr GetElementDescription(unsigned int _index) const;
+    /// \deprecated See ElementDescription
+    public: GZ_DEPRECATED(16) ElementPtr GetElementDescription(unsigned int _index) const;
 
     /// \brief Get an element description using a key
     /// \param[in] _key the key to use to find the element.
     /// \return An Element pointer to the found element.
-    public: ElementPtr GetElementDescription(const std::string &_key) const;
+    /// \deprecated See ElementDescription
+    public: GZ_DEPRECATED(16) ElementPtr GetElementDescription(const std::string &_key) const;
+
+    /// \brief Get an element description using an index
+    /// \param[in] _index the index of the element description to get.
+    /// \return An Element pointer to the found element.
+    /// \sa MutableElementDescription
+    public: ElementConstPtr ElementDescription(unsigned int _index) const;
+
+    /// \brief Get an element description using a key
+    /// \param[in] _key the key to use to find the element.
+    /// \return An Element pointer to the found element.
+    /// \sa MutableElementDescription
+    public: ElementConstPtr ElementDescription(const std::string &_key) const;
+
+    /// \brief Get a mutable element description using an index
+    /// \param[in] _index the index of the element description to get.
+    /// \return An Element pointer to the found element.
+    public: ElementPtr MutableElementDescription(unsigned int _index);
+
+    /// \brief Get a mutable element description using a key
+    /// \param[in] _key the key to use to find the element.
+    /// \return An Element pointer to the found element.
+    public: ElementPtr MutableElementDescription(const std::string &_key);
 
     /// \brief Return true if an element description exists.
     /// \param[in] _name the name of the element to find.
@@ -935,6 +962,9 @@ namespace sdf
     /// \brief XML path of this element.
     public: std::string xmlPath;
 
+    /// \brief Used to keep track of which element descriptions we have cloned in order to provide a mutable pointer.
+    public: std::unordered_set<ElementConstPtr> clonedElementDescriptions;
+
     /// \brief Generate the string (XML) for the attributes.
     /// \param[in] _includeDefaultAttributes flag to include default attributes.
     /// \param[in] _config Configuration for printing attributes.
@@ -952,6 +982,11 @@ namespace sdf
                                  bool _includeDefaultAttributes,
                                  const PrintConfig &_config,
                                  std::ostringstream &_out) const;
+
+    /// \brief Helper function to get the index of an element description identified by a given key
+    /// \param[in] _key Key of the element description
+    /// \return An optional index. nullopt of the key was not found
+    public: std::optional<unsigned int> ElementDescriptionIndex(const std::string &_key);
   };
 
   ///////////////////////////////////////////////
@@ -1038,7 +1073,7 @@ namespace sdf
       }
       else if (this->HasElementDescription(_key))
       {
-        result.first = this->GetElementDescription(_key)->Get<T>(_errors);
+        result.first = this->ElementDescription(_key)->Get<T>(_errors);
       }
       else
       {

--- a/python/src/sdf/pyElement.cc
+++ b/python/src/sdf/pyElement.cc
@@ -61,7 +61,6 @@ void defineElement(py::object module)
   using PyClassElement = py::class_<Element, ElementPtr>;
 
   // TODO(azeey): GetElementDescription has been deprecated. Remove in sdformat17
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   auto warnings = py::module::import("warnings");
   auto builtins = py::module::import("builtins");
 
@@ -157,7 +156,9 @@ void defineElement(py::object module)
                   "GetElementDescription is deprecated. Use ElementDescription "
                   "or MutableElementDescription instead",
                    builtins.attr("DeprecationWarning"));
+            GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
             return _self.GetElementDescription(_index);
+            GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
           },
           "Get an element description using an index")
       .def(
@@ -169,7 +170,9 @@ void defineElement(py::object module)
               "or MutableElementDescription instead",
               builtins.attr("DeprecationWarning"));
 
+            GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
             return _self.GetElementDescription(_key);
+            GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
           },
           "Get an element description using a key")
       .def("element_description",
@@ -261,7 +264,6 @@ void defineElement(py::object module)
            "Set a text description for the element.")
       .def("add_element_description", &Element::AddElementDescription,
            "Add a new element description");
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   // Definitions for `Get<T>`, and `Set<T>` which will bind to `get_bool`, 
   // `get_int`, etc.

--- a/python/src/sdf/pyElement.cc
+++ b/python/src/sdf/pyElement.cc
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <string>
+#include <gz/utils/SuppressWarning.hh>
 
 #include "pyParam.hh"
 #include "pybind11_helpers.hh"
@@ -58,6 +59,11 @@ namespace python
 void defineElement(py::object module)
 {
   using PyClassElement = py::class_<Element, ElementPtr>;
+
+  // TODO(azeey): GetElementDescription has been deprecated. Remove in sdformat17
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  auto warnings = py::module::import("warnings");
+  auto builtins = py::module::import("builtins");
 
   auto elemClass = PyClassElement(module, "Element");
   elemClass.def(py::init<>())
@@ -143,13 +149,43 @@ void defineElement(py::object module)
       .def("get_element_description_count",
            &Element::GetElementDescriptionCount,
            "Get the number of element descriptions.")
-      .def("get_element_description",
-           py::overload_cast<unsigned int>(&Element::GetElementDescription,
+      .def(
+          "get_element_description",
+          [warnings, builtins](const Element &_self, unsigned int _index)
+          {
+            warnings.attr("warn")(
+                  "GetElementDescription is deprecated. Use ElementDescription "
+                  "or MutableElementDescription instead",
+                   builtins.attr("DeprecationWarning"));
+            return _self.GetElementDescription(_index);
+          },
+          "Get an element description using an index")
+      .def(
+          "get_element_description",
+          [warnings, builtins](const Element &_self, const std::string &_key)
+          {
+            warnings.attr("warn")(
+              "GetElementDescription is deprecated. Use ElementDescription "
+              "or MutableElementDescription instead",
+              builtins.attr("DeprecationWarning"));
+
+            return _self.GetElementDescription(_key);
+          },
+          "Get an element description using a key")
+      .def("element_description",
+           py::overload_cast<unsigned int>(&Element::ElementDescription,
                                            py::const_),
            "Get an element description using an index")
-      .def("get_element_description",
+      .def("element_description",
+           py::overload_cast<const std::string &>(&Element::ElementDescription,
+                                                  py::const_),
+           "Get an element description using a key")
+      .def("mutable_element_description",
+           py::overload_cast<unsigned int>(&Element::MutableElementDescription),
+           "Get an element description using an index")
+      .def("mutable_element_description",
            py::overload_cast<const std::string &>(
-               &Element::GetElementDescription, py::const_),
+               &Element::MutableElementDescription),
            "Get an element description using a key")
       .def("has_element_description", &Element::HasElementDescription,
            "Return true if an element description exists.")
@@ -225,6 +261,7 @@ void defineElement(py::object module)
            "Set a text description for the element.")
       .def("add_element_description", &Element::AddElementDescription,
            "Add a new element description");
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   // Definitions for `Get<T>`, and `Set<T>` which will bind to `get_bool`, 
   // `get_int`, etc.

--- a/python/test/pyElement_TEST.py
+++ b/python/test/pyElement_TEST.py
@@ -485,7 +485,6 @@ class ElementTEST(unittest.TestCase):
 
         elem_clone = elem.clone()
         self.assertEqual(elem_clone.element_description("radius"), desc)
-        self.assertEqual(elem_clone.element_description("radius"), desc)
         self.assertEqual(elem_clone.element_description(0), desc)
 
         with warnings.catch_warnings():

--- a/python/test/pyElement_TEST.py
+++ b/python/test/pyElement_TEST.py
@@ -15,6 +15,7 @@
 from sdformat import Element, SDFErrorsException
 from gz.math import Vector3d
 import unittest
+import warnings
 
 
 class ElementTEST(unittest.TestCase):
@@ -475,6 +476,40 @@ class ElementTEST(unittest.TestCase):
         self.assertEqual("first_child",
                          child_elem_b.get_attribute("name").get_as_string())
 
+    def test_mutable_element_description(self):
+        elem = Element()
+        desc = Element()
+        desc.set_name("radius")
+        desc.add_value("double", "1", True, "radius")
+        elem.add_element_description(desc)
+
+        elem_clone = elem.clone()
+        self.assertEqual(elem_clone.element_description("radius"), desc)
+        self.assertEqual(elem_clone.element_description("radius"), desc)
+        self.assertEqual(elem_clone.element_description(0), desc)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertEqual(elem_clone.get_element_description("radius"), desc)
+            self.assertEqual(elem_clone.get_element_description(0), desc)
+
+        newDesc = elem_clone.mutable_element_description("radius")
+        self.assertNotEqual(newDesc, desc)
+        ## If we call mutable_element_description multiple times, it shouldn't create clone new Elements
+        self.assertEqual(newDesc, elem_clone.mutable_element_description("radius"))
+        self.assertEqual(newDesc, elem_clone.mutable_element_description(0))
+
+        # After mutable_element_description is called, calling the read-only
+        # element_description will return a different pointer than the original
+        # description
+        self.assertNotEqual(elem_clone.element_description("radius"), desc)
+        self.assertNotEqual(elem_clone.element_description(0), desc)
+
+
+        # Resetting the element clears the element descriptions.
+        elem_clone.reset()
+        self.assertIsNone(elem_clone.element_description("radius"))
+        self.assertIsNone(elem_clone.mutable_element_description("radius"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -17,6 +17,9 @@
 
 #include <algorithm>
 #include <iostream>
+#include <iterator>
+#include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -344,6 +347,7 @@ void Element::Copy(const ElementPtr _elem, sdf::Errors &_errors)
   }
 
   this->dataPtr->elementDescriptions.clear();
+  this->dataPtr->clonedElementDescriptions.clear();
   for (ElementPtr_V::const_iterator iter =
        _elem->dataPtr->elementDescriptions.begin();
        iter != _elem->dataPtr->elementDescriptions.end(); ++iter)
@@ -686,6 +690,20 @@ void ElementPrivate::PrintAttributes(sdf::Errors &_errors,
   }
 }
 
+std::optional<unsigned int> ElementPrivate::ElementDescriptionIndex(const std::string &_key) {
+
+  ElementPtr_V::iterator iter;
+  for (iter = this->elementDescriptions.begin();
+       iter != this->elementDescriptions.end(); ++iter)
+  {
+    if ((*iter)->GetName() == _key)
+    {
+      return std::distance(this->elementDescriptions.begin(), iter);
+    }
+  }
+  return std::nullopt;
+}
+
 /////////////////////////////////////////////////
 void Element::PrintValues(std::string _prefix,
                           const PrintConfig &_config) const
@@ -890,8 +908,20 @@ size_t Element::GetElementDescriptionCount() const
   return this->dataPtr->elementDescriptions.size();
 }
 
-/////////////////////////////////////////////////
+///////////////////////////////////////////////
 ElementPtr Element::GetElementDescription(unsigned int _index) const
+{
+  return std::const_pointer_cast<Element>(this->ElementDescription(_index));
+}
+
+/////////////////////////////////////////////////
+ElementPtr Element::GetElementDescription(const std::string &_key) const
+{
+  return std::const_pointer_cast<Element>(this->ElementDescription(_key));
+}
+
+/////////////////////////////////////////////////
+ElementConstPtr Element::ElementDescription(unsigned int _index) const
 {
   ElementPtr result;
   if (_index < this->dataPtr->elementDescriptions.size())
@@ -902,7 +932,7 @@ ElementPtr Element::GetElementDescription(unsigned int _index) const
 }
 
 /////////////////////////////////////////////////
-ElementPtr Element::GetElementDescription(const std::string &_key) const
+ElementConstPtr Element::ElementDescription(const std::string &_key) const
 {
   ElementPtr_V::const_iterator iter;
   for (iter = this->dataPtr->elementDescriptions.begin();
@@ -915,6 +945,48 @@ ElementPtr Element::GetElementDescription(const std::string &_key) const
   }
 
   return ElementPtr();
+}
+
+/////////////////////////////////////////////////
+ElementPtr Element::MutableElementDescription(unsigned int _index)
+{
+  auto desc = static_cast<const Element *>(this)->ElementDescription(_index);
+  if (!desc)
+  {
+    return ElementPtr();
+  }
+
+  // To improve performance of the sdformat library, element descriptions are
+  // shared amont elements of the same type. If the user requests a mutable
+  // element description, we make a clone here so that other elements are not
+  // affected by the potential modifications the user makes. We keep track of
+  // the clones we've made so that it a clone is made at most once for each
+  // element description.
+  if (this->dataPtr->clonedElementDescriptions.count(desc) == 0)
+  {
+    auto clonedDesc = desc->Clone();
+    this->dataPtr->clonedElementDescriptions.insert(clonedDesc);
+    this->dataPtr->elementDescriptions[_index] = clonedDesc;
+    return clonedDesc;
+  }
+  else
+  {
+    return std::const_pointer_cast<Element>(desc);
+  }
+}
+
+/////////////////////////////////////////////////
+ElementPtr Element::MutableElementDescription(const std::string &_key)
+{
+  auto index = this->dataPtr->ElementDescriptionIndex(_key);
+  if (index)
+  {
+    return this->MutableElementDescription(*index);
+  }
+  else
+  {
+    return sdf::ElementPtr();
+  }
 }
 
 /////////////////////////////////////////////////
@@ -1175,7 +1247,7 @@ void Element::InsertElement(ElementPtr _elem,  bool _setParentToSelf)
 /////////////////////////////////////////////////
 bool Element::HasElementDescription(const std::string &_name) const
 {
-  return this->GetElementDescription(_name) != ElementPtr();
+  return this->ElementDescription(_name) != ElementConstPtr();
 }
 
 /////////////////////////////////////////////////
@@ -1200,7 +1272,7 @@ ElementPtr Element::AddElement(const std::string &_name, sdf::Errors &_errors)
     for (unsigned int i = 0; i < parent->GetElementDescriptionCount(); ++i)
     {
       this->dataPtr->elementDescriptions.push_back(
-        parent->GetElementDescription(i));
+        parent->dataPtr->elementDescriptions[i]);
     }
   }
 
@@ -1309,6 +1381,7 @@ void Element::Reset()
   }
   this->dataPtr->elements.clear();
   this->dataPtr->elementDescriptions.clear();
+  this->dataPtr->clonedElementDescriptions.clear();
 
   this->dataPtr->value.reset();
 
@@ -1476,10 +1549,10 @@ std::any Element::GetAny(sdf::Errors &_errors, const std::string &_key) const
       }
       else
       {
-        tmp = this->GetElementDescription(_key);
-        if (tmp != ElementPtr())
+        auto desc = this->ElementDescription(_key);
+        if (desc != ElementConstPtr())
         {
-          result = tmp->GetAny(_errors);
+          result = desc->GetAny(_errors);
         }
         else
         {

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -690,6 +690,7 @@ void ElementPrivate::PrintAttributes(sdf::Errors &_errors,
   }
 }
 
+/////////////////////////////////////////////////
 std::optional<unsigned int> ElementPrivate::ElementDescriptionIndex(
     const std::string &_key)
 {
@@ -908,7 +909,7 @@ size_t Element::GetElementDescriptionCount() const
   return this->dataPtr->elementDescriptions.size();
 }
 
-///////////////////////////////////////////////
+/////////////////////////////////////////////////
 ElementPtr Element::GetElementDescription(unsigned int _index) const
 {
   return std::const_pointer_cast<Element>(this->ElementDescription(_index));
@@ -956,11 +957,11 @@ ElementPtr Element::MutableElementDescription(unsigned int _index)
     return ElementPtr();
   }
 
-  // To improve performance of the sdformat library, element descriptions are
-  // shared amont elements of the same type. If the user requests a mutable
+  // To improve the performance of libsdformat, element descriptions are
+  // shared among elements of the same type. If the user requests a mutable
   // element description, we make a clone here so that other elements are not
   // affected by the potential modifications the user makes. We keep track of
-  // the clones we've made so that it a clone is made at most once for each
+  // the clones we've made so that a clone is made at most once for each
   // element description.
   if (this->dataPtr->clonedElementDescriptions.count(desc) == 0)
   {

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -690,10 +690,10 @@ void ElementPrivate::PrintAttributes(sdf::Errors &_errors,
   }
 }
 
-std::optional<unsigned int> ElementPrivate::ElementDescriptionIndex(const std::string &_key) {
-
-  ElementPtr_V::iterator iter;
-  for (iter = this->elementDescriptions.begin();
+std::optional<unsigned int> ElementPrivate::ElementDescriptionIndex(
+    const std::string &_key)
+{
+  for (auto iter = this->elementDescriptions.begin();
        iter != this->elementDescriptions.end(); ++iter)
   {
     if ((*iter)->GetName() == _key)

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -267,7 +267,7 @@ ElementPtr Element::Clone(sdf::Errors &_errors) const
   for (eiter = this->dataPtr->elementDescriptions.begin();
       eiter != this->dataPtr->elementDescriptions.end(); ++eiter)
   {
-    clone->dataPtr->elementDescriptions.push_back((*eiter)->Clone(_errors));
+    clone->dataPtr->elementDescriptions.push_back(*eiter);
   }
 
   for (eiter = this->dataPtr->elements.begin();
@@ -348,7 +348,7 @@ void Element::Copy(const ElementPtr _elem, sdf::Errors &_errors)
        _elem->dataPtr->elementDescriptions.begin();
        iter != _elem->dataPtr->elementDescriptions.end(); ++iter)
   {
-    this->dataPtr->elementDescriptions.push_back((*iter)->Clone(_errors));
+    this->dataPtr->elementDescriptions.push_back(*iter);
   }
 
   this->dataPtr->elements.clear();
@@ -1200,7 +1200,7 @@ ElementPtr Element::AddElement(const std::string &_name, sdf::Errors &_errors)
     for (unsigned int i = 0; i < parent->GetElementDescriptionCount(); ++i)
     {
       this->dataPtr->elementDescriptions.push_back(
-        parent->GetElementDescription(i)->Clone(_errors));
+        parent->GetElementDescription(i));
     }
   }
 

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -350,17 +350,17 @@ TEST(Element, AddElementReferenceSDF)
 
   ASSERT_EQ(child->GetElementDescriptionCount(), 1UL);
 
-  sdf::ElementPtr check = child->GetElementDescription(4);
+  sdf::ElementConstPtr check = child->ElementDescription(4);
   ASSERT_EQ(check, sdf::ElementPtr());
 
-  check = child->GetElementDescription(0);
+  check = child->ElementDescription(0);
   ASSERT_NE(check, sdf::ElementPtr());
   ASSERT_EQ(check->GetName(), "parent");
 
-  check = child->GetElementDescription("bad");
+  check = child->ElementDescription("bad");
   ASSERT_EQ(check, sdf::ElementPtr());
 
-  check = child->GetElementDescription("parent");
+  check = child->ElementDescription("parent");
   ASSERT_NE(check, sdf::ElementPtr());
   ASSERT_EQ(check->GetName(), "parent");
 

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include <gz/utils/SuppressWarning.hh>
+
 #include "sdf/Element.hh"
 #include "sdf/Filesystem.hh"
 #include "sdf/Param.hh"
@@ -1089,4 +1091,41 @@ TEST(Element, FindElement)
     ASSERT_TRUE(childElemB->HasAttribute("name"));
     EXPECT_EQ("first_child", childElemB->GetAttribute("name")->GetAsString());
   }
+}
+
+TEST(Element, MutableElementDescription)
+{
+  sdf::ElementPtr elem = std::make_shared<sdf::Element>();
+  sdf::ElementPtr desc = std::make_shared<sdf::Element>();
+  desc->SetName("radius");
+  desc->AddValue("double", "1", true, "radius");
+  elem->AddElementDescription(desc);
+
+  auto elemClone = elem->Clone();
+
+  EXPECT_EQ(elemClone->ElementDescription("radius"), desc);
+  EXPECT_EQ(elemClone->ElementDescription(0), desc);
+
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  EXPECT_EQ(elemClone->GetElementDescription("radius"), desc);
+  EXPECT_EQ(elemClone->GetElementDescription(0), desc);
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
+  auto newDesc = elemClone->MutableElementDescription("radius");
+  EXPECT_NE(newDesc, desc);
+  // If we call MutableElementDescription multiple times, it shouldn't create
+  // clone new Elements
+  EXPECT_EQ(newDesc, elemClone->MutableElementDescription("radius"));
+  EXPECT_EQ(newDesc, elemClone->MutableElementDescription(0));
+
+  // After MutableElementDescription is called, calling the read-only
+  // ElementDescription will return a different pointer than the original
+  // description
+  EXPECT_NE(elemClone->ElementDescription("radius"), desc);
+  EXPECT_NE(elemClone->ElementDescription(0), desc);
+
+  // Resetting the element clears the element descriptions.
+  elemClone->Reset();
+  EXPECT_EQ(nullptr, elemClone->ElementDescription("radius"));
+  EXPECT_EQ(nullptr, elemClone->MutableElementDescription("radius"));
 }

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -461,7 +461,7 @@ void handleIndividualChildActions(const ParserConfig &_config,
       continue;
     }
 
-    ElementPtr elemChild = elemDesc->GetElementDescription(elemName);
+    ElementPtr elemChild = elemDesc->MutableElementDescription(elemName);
 
     if (!xmlToSdf(_config, _source, xmlChild, elemChild, _errors))
     {

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1615,7 +1615,7 @@ static void validateIncludeElement(tinyxml2::XMLElement *_xml,
   for (unsigned int descCounter = 0;
       descCounter != _sdf->GetElementDescriptionCount(); ++descCounter)
   {
-    ElementPtr elemDesc = _sdf->GetElementDescription(descCounter);
+    ElementConstPtr elemDesc = _sdf->ElementDescription(descCounter);
     if (elemDesc->GetName() == _xml->Value())
     {
       ElementPtr element = elemDesc->Clone();
@@ -1957,7 +1957,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           }
 
           auto includeSDFFirstElem = includeSDF->Root()->GetFirstElement();
-          auto includeDesc = _sdf->GetElementDescription("include");
+          auto includeDesc = _sdf->ElementDescription("include");
           if (includeDesc)
           {
             // Store the contents of the <include> tag as the includeElement of
@@ -1981,7 +1981,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
       for (descCounter = 0;
            descCounter != _sdf->GetElementDescriptionCount(); ++descCounter)
       {
-        ElementPtr elemDesc = _sdf->GetElementDescription(descCounter);
+        ElementConstPtr elemDesc = _sdf->ElementDescription(descCounter);
         if (elemDesc->GetName() == elemXml->Value())
         {
           std::string elemXmlPath = _sdf->XmlPath() + "/" + elemXml->Value();
@@ -2047,7 +2047,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     for (unsigned int descCounter = 0;
          descCounter != _sdf->GetElementDescriptionCount(); ++descCounter)
     {
-      ElementPtr elemDesc = _sdf->GetElementDescription(descCounter);
+      ElementConstPtr elemDesc = _sdf->ElementDescription(descCounter);
 
       if (elemDesc->GetRequired() == "1" || elemDesc->GetRequired() == "+")
       {


### PR DESCRIPTION
# 🦟 Bug fix

Toward https://github.com/gazebosim/jetty_demo/issues/3

## Summary
As far as I can tell, element descriptions are not mutated, so there is no reason to clone them. But I'm not 100% sure if this has unintended consequences.

I created a small test where a large sdf is loaded to show the before and after memory consumption results:
**Before**
```bash
$ time build/sdf_memory 3k_shapes.sdf
Successfully loaded file
8647.16MB
build/sdf_memory 3k_shapes.sdf  6.77s user 3.13s system 99% cpu 9.904 total
```

**After**
```bash
$ time build/sdf_memory 3k_shapes.sdf
Successfully loaded file
289.069MB
build/sdf_memory 3k_shapes.sdf  0.40s user 0.19s system 97% cpu 0.611 total
```

This is a significant speedup and reduction in memory usage, so it would be worth figuring out if we can truly do this without any negative consequences.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
