### PR TITLE
Prepare for 16.0.0~pre2 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if (BUILD_SDF)
   gz_configure_project(
     NO_PROJECT_PREFIX
     REPLACE_INCLUDE_PATH sdf
-    VERSION_SUFFIX pre1)
+    VERSION_SUFFIX pre2)
 
   #################################################
   # Find tinyxml2.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,15 @@
 
 1. **Baseline:** this includes all changes from 15.3.0 and earlier.
 
+1. Optimize load time and memory consumption by reusing element descriptions
+    * [Pull request #1589](https://github.com/gazebosim/sdformat/pull/1589)
+
+1. Infrastructure
+    * [Pull request #1588](https://github.com/gazebosim/sdformat/pull/1588)
+
+1. [Bazel] Update bazel module to use jetty release branches
+    * [Pull request #1584](https://github.com/gazebosim/sdformat/pull/1584)
+
 1. [Bazel] Fix dep issue when building with clang
     * [Pull request #1581](https://github.com/gazebosim/sdformat/pull/1581)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 16.0.0~pre2 release.

Comparison to 16.0.0-pre1: https://github.com/gazebosim/sdformat/compare/sdformat16_16.0.0-pre1...sdf16

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.