### PR TITLE
Fixed windows warning

### DIFF
--- a/src/Element.cc
+++ b/src/Element.cc
@@ -699,7 +699,7 @@ std::optional<unsigned int> ElementPrivate::ElementDescriptionIndex(
   {
     if ((*iter)->GetName() == _key)
     {
-      return std::static_cast<unsigned int>(
+      return static_cast<unsigned int>(
         std::distance(this->elementDescriptions.begin(), iter));
     }
   }

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -699,7 +699,8 @@ std::optional<unsigned int> ElementPrivate::ElementDescriptionIndex(
   {
     if ((*iter)->GetName() == _key)
     {
-      return std::distance(this->elementDescriptions.begin(), iter);
+      return std::static_cast<unsigned int>(
+        std::distance(this->elementDescriptions.begin(), iter));
     }
   }
   return std::nullopt;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/sdformat/issues/1593

## Summary

`std::distince` might return a negative value depending on the indexes introduced, but in this case we are always using the begining of the iterator as the first argument. I assume that this will always positive and then the method can always return a `unsigned int`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
