### PR TITLE
Install completion script to unversioned folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,6 @@ if (BUILD_SDF)
   find_program(GZ_PROGRAM gz)
   # Note that CLI files are installed regardless of whether the dependency is
   # available during build time
-  set(GZ_TOOLS_VER 2)
 
   #################################################
   # Find python

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -94,4 +94,4 @@ install(
   FILES
     ${CMAKE_CURRENT_BINARY_DIR}/sdf${PROJECT_VERSION_MAJOR}.bash_completion.sh
   DESTINATION
-    ${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${GZ_TOOLS_VER}.completion.d)
+    ${CMAKE_INSTALL_DATAROOTDIR}/gz/gz.completion.d)


### PR DESCRIPTION
# 🎉 New feature

Follow up to https://github.com/gazebo-tooling/release-tools/issues/1244.
Similar to https://github.com/gazebosim/gz-transport/pull/809

## Summary

This removes major version numbers from install paths for the bash-completion scripts since side-by-side installation is no longer supported. Removing the versions helps reduce the number of changes required when updating packaging files (e.g. homebrew formulae).

We forgot to remove `GZ_TOOLS_VER` here and in a [few other packages](https://github.com/search?q=org%3Agazebosim%20GZ_TOOLS_VER&type=code)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
