### PR TITLE
Backport load optimization without deprecation

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -20,8 +20,10 @@
 #include <any>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -384,6 +386,28 @@ namespace sdf
     /// \param[in] _key the key to use to find the element.
     /// \return An Element pointer to the found element.
     public: ElementPtr GetElementDescription(const std::string &_key) const;
+
+    /// \brief Get an element description using an index
+    /// \param[in] _index the index of the element description to get.
+    /// \return An Element pointer to the found element.
+    /// \sa MutableElementDescription
+    public: ElementConstPtr ElementDescription(unsigned int _index) const;
+
+    /// \brief Get an element description using a key
+    /// \param[in] _key the key to use to find the element.
+    /// \return An Element pointer to the found element.
+    /// \sa MutableElementDescription
+    public: ElementConstPtr ElementDescription(const std::string &_key) const;
+
+    /// \brief Get a mutable element description using an index
+    /// \param[in] _index the index of the element description to get.
+    /// \return An Element pointer to the found element.
+    public: ElementPtr MutableElementDescription(unsigned int _index);
+
+    /// \brief Get a mutable element description using a key
+    /// \param[in] _key the key to use to find the element.
+    /// \return An Element pointer to the found element.
+    public: ElementPtr MutableElementDescription(const std::string &_key);
 
     /// \brief Return true if an element description exists.
     /// \param[in] _name the name of the element to find.
@@ -935,6 +959,10 @@ namespace sdf
     /// \brief XML path of this element.
     public: std::string xmlPath;
 
+    /// \brief Used to keep track of which element descriptions we have cloned
+    /// in order to provide a mutable pointer.
+    public: std::unordered_set<ElementConstPtr> clonedElementDescriptions;
+
     /// \brief Generate the string (XML) for the attributes.
     /// \param[in] _includeDefaultAttributes flag to include default attributes.
     /// \param[in] _config Configuration for printing attributes.
@@ -952,6 +980,14 @@ namespace sdf
                                  bool _includeDefaultAttributes,
                                  const PrintConfig &_config,
                                  std::ostringstream &_out) const;
+
+    /// \brief Helper function to get the index of an element description
+    /// identified by a given key
+    /// \param[in] _key Key of the element description
+    /// \return An optional index. nullopt of the key was not found
+    public:
+    std::optional<unsigned int> ElementDescriptionIndex(
+        const std::string &_key);
   };
 
   ///////////////////////////////////////////////
@@ -1038,7 +1074,7 @@ namespace sdf
       }
       else if (this->HasElementDescription(_key))
       {
-        result.first = this->GetElementDescription(_key)->Get<T>(_errors);
+        result.first = this->ElementDescription(_key)->Get<T>(_errors);
       }
       else
       {

--- a/python/src/sdf/pyElement.cc
+++ b/python/src/sdf/pyElement.cc
@@ -151,6 +151,21 @@ void defineElement(py::object module)
            py::overload_cast<const std::string &>(
                &Element::GetElementDescription, py::const_),
            "Get an element description using a key")
+      .def("element_description",
+           py::overload_cast<unsigned int>(&Element::ElementDescription,
+                                           py::const_),
+           "Get an element description using an index")
+      .def("element_description",
+           py::overload_cast<const std::string &>(&Element::ElementDescription,
+                                                  py::const_),
+           "Get an element description using a key")
+      .def("mutable_element_description",
+           py::overload_cast<unsigned int>(&Element::MutableElementDescription),
+           "Get an element description using an index")
+      .def("mutable_element_description",
+           py::overload_cast<const std::string &>(
+               &Element::MutableElementDescription),
+           "Get an element description using a key")
       .def("has_element_description", &Element::HasElementDescription,
            "Return true if an element description exists.")
       .def("has_attribute", &Element::HasAttribute,

--- a/python/test/pyElement_TEST.py
+++ b/python/test/pyElement_TEST.py
@@ -475,6 +475,37 @@ class ElementTEST(unittest.TestCase):
         self.assertEqual("first_child",
                          child_elem_b.get_attribute("name").get_as_string())
 
+    def test_mutable_element_description(self):
+        elem = Element()
+        desc = Element()
+        desc.set_name("radius")
+        desc.add_value("double", "1", True, "radius")
+        elem.add_element_description(desc)
+
+        elem_clone = elem.clone()
+        self.assertEqual(elem_clone.element_description("radius"), desc)
+        self.assertEqual(elem_clone.element_description(0), desc)
+
+        self.assertEqual(elem_clone.get_element_description("radius"), desc)
+        self.assertEqual(elem_clone.get_element_description(0), desc)
+
+        newDesc = elem_clone.mutable_element_description("radius")
+        self.assertNotEqual(newDesc, desc)
+        ## If we call mutable_element_description multiple times, it shouldn't create clone new Elements
+        self.assertEqual(newDesc, elem_clone.mutable_element_description("radius"))
+        self.assertEqual(newDesc, elem_clone.mutable_element_description(0))
+
+        # After mutable_element_description is called, calling the read-only
+        # element_description will return a different pointer than the original
+        # description
+        self.assertNotEqual(elem_clone.element_description("radius"), desc)
+        self.assertNotEqual(elem_clone.element_description(0), desc)
+
+
+        # Resetting the element clears the element descriptions.
+        elem_clone.reset()
+        self.assertIsNone(elem_clone.element_description("radius"))
+        self.assertIsNone(elem_clone.mutable_element_description("radius"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -17,6 +17,9 @@
 
 #include <algorithm>
 #include <iostream>
+#include <iterator>
+#include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -270,7 +273,7 @@ ElementPtr Element::Clone(sdf::Errors &_errors) const
   for (eiter = this->dataPtr->elementDescriptions.begin();
       eiter != this->dataPtr->elementDescriptions.end(); ++eiter)
   {
-    clone->dataPtr->elementDescriptions.push_back((*eiter)->Clone(_errors));
+    clone->dataPtr->elementDescriptions.push_back(*eiter);
   }
 
   clone->dataPtr->elements.reserve(this->dataPtr->elements.size());
@@ -348,11 +351,12 @@ void Element::Copy(const ElementPtr _elem, sdf::Errors &_errors)
   }
 
   this->dataPtr->elementDescriptions.clear();
+  this->dataPtr->clonedElementDescriptions.clear();
   for (ElementPtr_V::const_iterator iter =
        _elem->dataPtr->elementDescriptions.begin();
        iter != _elem->dataPtr->elementDescriptions.end(); ++iter)
   {
-    this->dataPtr->elementDescriptions.push_back((*iter)->Clone(_errors));
+    this->dataPtr->elementDescriptions.push_back(*iter);
   }
 
   this->dataPtr->elements.clear();
@@ -691,6 +695,21 @@ void ElementPrivate::PrintAttributes(sdf::Errors &_errors,
 }
 
 /////////////////////////////////////////////////
+std::optional<unsigned int> ElementPrivate::ElementDescriptionIndex(
+    const std::string &_key)
+{
+  for (auto iter = this->elementDescriptions.begin();
+       iter != this->elementDescriptions.end(); ++iter)
+  {
+    if ((*iter)->GetName() == _key)
+    {
+      return std::distance(this->elementDescriptions.begin(), iter);
+    }
+  }
+  return std::nullopt;
+}
+
+/////////////////////////////////////////////////
 void Element::PrintValues(std::string _prefix,
                           const PrintConfig &_config) const
 {
@@ -897,6 +916,18 @@ size_t Element::GetElementDescriptionCount() const
 /////////////////////////////////////////////////
 ElementPtr Element::GetElementDescription(unsigned int _index) const
 {
+  return std::const_pointer_cast<Element>(this->ElementDescription(_index));
+}
+
+/////////////////////////////////////////////////
+ElementPtr Element::GetElementDescription(const std::string &_key) const
+{
+  return std::const_pointer_cast<Element>(this->ElementDescription(_key));
+}
+
+/////////////////////////////////////////////////
+ElementConstPtr Element::ElementDescription(unsigned int _index) const
+{
   ElementPtr result;
   if (_index < this->dataPtr->elementDescriptions.size())
   {
@@ -906,7 +937,7 @@ ElementPtr Element::GetElementDescription(unsigned int _index) const
 }
 
 /////////////////////////////////////////////////
-ElementPtr Element::GetElementDescription(const std::string &_key) const
+ElementConstPtr Element::ElementDescription(const std::string &_key) const
 {
   ElementPtr_V::const_iterator iter;
   for (iter = this->dataPtr->elementDescriptions.begin();
@@ -919,6 +950,48 @@ ElementPtr Element::GetElementDescription(const std::string &_key) const
   }
 
   return ElementPtr();
+}
+
+/////////////////////////////////////////////////
+ElementPtr Element::MutableElementDescription(unsigned int _index)
+{
+  auto desc = static_cast<const Element *>(this)->ElementDescription(_index);
+  if (!desc)
+  {
+    return ElementPtr();
+  }
+
+  // To improve the performance of libsdformat, element descriptions are
+  // shared among elements of the same type. If the user requests a mutable
+  // element description, we make a clone here so that other elements are not
+  // affected by the potential modifications the user makes. We keep track of
+  // the clones we've made so that a clone is made at most once for each
+  // element description.
+  if (this->dataPtr->clonedElementDescriptions.count(desc) == 0)
+  {
+    auto clonedDesc = desc->Clone();
+    this->dataPtr->clonedElementDescriptions.insert(clonedDesc);
+    this->dataPtr->elementDescriptions[_index] = clonedDesc;
+    return clonedDesc;
+  }
+  else
+  {
+    return std::const_pointer_cast<Element>(desc);
+  }
+}
+
+/////////////////////////////////////////////////
+ElementPtr Element::MutableElementDescription(const std::string &_key)
+{
+  auto index = this->dataPtr->ElementDescriptionIndex(_key);
+  if (index)
+  {
+    return this->MutableElementDescription(*index);
+  }
+  else
+  {
+    return sdf::ElementPtr();
+  }
 }
 
 /////////////////////////////////////////////////
@@ -1179,7 +1252,7 @@ void Element::InsertElement(ElementPtr _elem,  bool _setParentToSelf)
 /////////////////////////////////////////////////
 bool Element::HasElementDescription(const std::string &_name) const
 {
-  return this->GetElementDescription(_name) != ElementPtr();
+  return this->ElementDescription(_name) != ElementConstPtr();
 }
 
 /////////////////////////////////////////////////
@@ -1204,7 +1277,7 @@ ElementPtr Element::AddElement(const std::string &_name, sdf::Errors &_errors)
     for (unsigned int i = 0; i < parent->GetElementDescriptionCount(); ++i)
     {
       this->dataPtr->elementDescriptions.push_back(
-        parent->GetElementDescription(i)->Clone(_errors));
+        parent->dataPtr->elementDescriptions[i]);
     }
   }
 
@@ -1313,6 +1386,7 @@ void Element::Reset()
   }
   this->dataPtr->elements.clear();
   this->dataPtr->elementDescriptions.clear();
+  this->dataPtr->clonedElementDescriptions.clear();
 
   this->dataPtr->value.reset();
 
@@ -1480,10 +1554,10 @@ std::any Element::GetAny(sdf::Errors &_errors, const std::string &_key) const
       }
       else
       {
-        tmp = this->GetElementDescription(_key);
-        if (tmp != ElementPtr())
+        auto desc = this->ElementDescription(_key);
+        if (desc != ElementConstPtr())
         {
-          result = tmp->GetAny(_errors);
+          result = desc->GetAny(_errors);
         }
         else
         {

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -703,7 +703,8 @@ std::optional<unsigned int> ElementPrivate::ElementDescriptionIndex(
   {
     if ((*iter)->GetName() == _key)
     {
-      return std::distance(this->elementDescriptions.begin(), iter);
+      return static_cast<unsigned int>(
+        std::distance(this->elementDescriptions.begin(), iter));
     }
   }
   return std::nullopt;

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -350,17 +350,17 @@ TEST(Element, AddElementReferenceSDF)
 
   ASSERT_EQ(child->GetElementDescriptionCount(), 1UL);
 
-  sdf::ElementPtr check = child->GetElementDescription(4);
+  sdf::ElementConstPtr check = child->ElementDescription(4);
   ASSERT_EQ(check, sdf::ElementPtr());
 
-  check = child->GetElementDescription(0);
+  check = child->ElementDescription(0);
   ASSERT_NE(check, sdf::ElementPtr());
   ASSERT_EQ(check->GetName(), "parent");
 
-  check = child->GetElementDescription("bad");
+  check = child->ElementDescription("bad");
   ASSERT_EQ(check, sdf::ElementPtr());
 
-  check = child->GetElementDescription("parent");
+  check = child->ElementDescription("parent");
   ASSERT_NE(check, sdf::ElementPtr());
   ASSERT_EQ(check->GetName(), "parent");
 
@@ -1089,4 +1089,39 @@ TEST(Element, FindElement)
     ASSERT_TRUE(childElemB->HasAttribute("name"));
     EXPECT_EQ("first_child", childElemB->GetAttribute("name")->GetAsString());
   }
+}
+
+TEST(Element, MutableElementDescription)
+{
+  sdf::ElementPtr elem = std::make_shared<sdf::Element>();
+  sdf::ElementPtr desc = std::make_shared<sdf::Element>();
+  desc->SetName("radius");
+  desc->AddValue("double", "1", true, "radius");
+  elem->AddElementDescription(desc);
+
+  auto elemClone = elem->Clone();
+
+  EXPECT_EQ(elemClone->ElementDescription("radius"), desc);
+  EXPECT_EQ(elemClone->ElementDescription(0), desc);
+
+  EXPECT_EQ(elemClone->GetElementDescription("radius"), desc);
+  EXPECT_EQ(elemClone->GetElementDescription(0), desc);
+
+  auto newDesc = elemClone->MutableElementDescription("radius");
+  EXPECT_NE(newDesc, desc);
+  // If we call MutableElementDescription multiple times, it shouldn't create
+  // clone new Elements
+  EXPECT_EQ(newDesc, elemClone->MutableElementDescription("radius"));
+  EXPECT_EQ(newDesc, elemClone->MutableElementDescription(0));
+
+  // After MutableElementDescription is called, calling the read-only
+  // ElementDescription will return a different pointer than the original
+  // description
+  EXPECT_NE(elemClone->ElementDescription("radius"), desc);
+  EXPECT_NE(elemClone->ElementDescription(0), desc);
+
+  // Resetting the element clears the element descriptions.
+  elemClone->Reset();
+  EXPECT_EQ(nullptr, elemClone->ElementDescription("radius"));
+  EXPECT_EQ(nullptr, elemClone->MutableElementDescription("radius"));
 }

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -461,7 +461,7 @@ void handleIndividualChildActions(const ParserConfig &_config,
       continue;
     }
 
-    ElementPtr elemChild = elemDesc->GetElementDescription(elemName);
+    ElementPtr elemChild = elemDesc->MutableElementDescription(elemName);
 
     if (!xmlToSdf(_config, _source, xmlChild, elemChild, _errors))
     {

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1615,7 +1615,7 @@ static void validateIncludeElement(tinyxml2::XMLElement *_xml,
   for (unsigned int descCounter = 0;
       descCounter != _sdf->GetElementDescriptionCount(); ++descCounter)
   {
-    ElementPtr elemDesc = _sdf->GetElementDescription(descCounter);
+    ElementConstPtr elemDesc = _sdf->ElementDescription(descCounter);
     if (elemDesc->GetName() == _xml->Value())
     {
       ElementPtr element = elemDesc->Clone();
@@ -1957,7 +1957,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           }
 
           auto includeSDFFirstElem = includeSDF->Root()->GetFirstElement();
-          auto includeDesc = _sdf->GetElementDescription("include");
+          auto includeDesc = _sdf->ElementDescription("include");
           if (includeDesc)
           {
             // Store the contents of the <include> tag as the includeElement of
@@ -1981,7 +1981,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
       for (descCounter = 0;
            descCounter != _sdf->GetElementDescriptionCount(); ++descCounter)
       {
-        ElementPtr elemDesc = _sdf->GetElementDescription(descCounter);
+        ElementConstPtr elemDesc = _sdf->ElementDescription(descCounter);
         if (elemDesc->GetName() == elemXml->Value())
         {
           std::string elemXmlPath = _sdf->XmlPath() + "/" + elemXml->Value();
@@ -2047,7 +2047,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     for (unsigned int descCounter = 0;
          descCounter != _sdf->GetElementDescriptionCount(); ++descCounter)
     {
-      ElementPtr elemDesc = _sdf->GetElementDescription(descCounter);
+      ElementConstPtr elemDesc = _sdf->ElementDescription(descCounter);
 
       if (elemDesc->GetRequired() == "1" || elemDesc->GetRequired() == "+")
       {


### PR DESCRIPTION
This is a partial backport of #1589 without the deprecations.

## Original PR description:

Optimize load time and memory consumption by reusing element descriptions (#1589)

In most usages of `GetElementDescription`, the returned `sdf::ElementPtr` is not mutated, thus it is possible to implement a copy-on-write mechanism to avoid unnecessary clones of element descriptions. This PR removes clones of element description during the loading of an SDFormat file and introduces APIs to get immutable element descriptions. It also provides mutable element descriptions which clone the element description when called.

* Do not clone element descriptions
* Add MutableElementDescription and deprecate GetElementDescription
* Add tests
* Narrower use of GZ_UTILS_WARN_* macros
* Reword comments, Migration guide
* Remove duplicate line in python test
* Add / adjust //// lines
