### PR TITLE
Use action-ros-ci to build from source

### DIFF
--- a/.github/ci/collection.yaml
+++ b/.github/ci/collection.yaml
@@ -1,0 +1,62 @@
+---
+repositories:
+  gz-cmake:
+    type: git
+    url: https://github.com/gazebosim/gz-cmake
+    version: main
+  gz-common:
+    type: git
+    url: https://github.com/gazebosim/gz-common
+    version: main
+  gz-fuel-tools:
+    type: git
+    url: https://github.com/gazebosim/gz-fuel-tools
+    version: main
+  gz-sim:
+    type: git
+    url: https://github.com/gazebosim/gz-sim
+    version: main
+  gz-gui:
+    type: git
+    url: https://github.com/gazebosim/gz-gui
+    version: main
+  gz-math:
+    type: git
+    url: https://github.com/gazebosim/gz-math
+    version: main
+  gz-msgs:
+    type: git
+    url: https://github.com/gazebosim/gz-msgs
+    version: main
+  gz-physics:
+    type: git
+    url: https://github.com/gazebosim/gz-physics
+    version: main
+  gz-plugin:
+    type: git
+    url: https://github.com/gazebosim/gz-plugin
+    version: main
+  gz-rendering:
+    type: git
+    url: https://github.com/gazebosim/gz-rendering
+    version: main
+  gz-sensors:
+    type: git
+    url: https://github.com/gazebosim/gz-sensors
+    version: main
+  gz-tools:
+    type: git
+    url: https://github.com/gazebosim/gz-tools
+    version: main
+  gz-transport:
+    type: git
+    url: https://github.com/gazebosim/gz-transport
+    version: main
+  gz-utils:
+    type: git
+    url: https://github.com/gazebosim/gz-utils
+    version: main
+  sdformat:
+    type: git
+    url: https://github.com/gazebosim/sdformat
+    version: main

--- a/.github/ci/packages_up_to_sdformat.yaml
+++ b/.github/ci/packages_up_to_sdformat.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: main
+    version: scpeters/colcon-test-result
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils

--- a/.github/ci/packages_up_to_sdformat.yaml
+++ b/.github/ci/packages_up_to_sdformat.yaml
@@ -1,0 +1,22 @@
+---
+repositories:
+  gz-cmake:
+    type: git
+    url: https://github.com/gazebosim/gz-cmake
+    version: main
+  gz-math:
+    type: git
+    url: https://github.com/gazebosim/gz-math
+    version: main
+  gz-tools:
+    type: git
+    url: https://github.com/gazebosim/gz-tools
+    version: main
+  gz-utils:
+    type: git
+    url: https://github.com/gazebosim/gz-utils
+    version: main
+  sdformat:
+    type: git
+    url: https://github.com/gazebosim/sdformat
+    version: main

--- a/.github/workflows/ci_dependencies_from_source.yaml
+++ b/.github/workflows/ci_dependencies_from_source.yaml
@@ -38,9 +38,9 @@ jobs:
       - name: Compile and test
         uses: ros-tooling/action-ros-ci@v0.4
         with:
-          package-name: sdformat
+          package-name: gz-physics
           target-ros2-distro: lyrical
-          vcs-repo-file-url: ${{ github.workspace }}/.github/ci/packages_up_to_sdformat.yaml
+          vcs-repo-file-url: ${{ github.workspace }}/.github/ci/collection.yaml
           colcon-defaults: |
             {
               "build": {

--- a/.github/workflows/ci_dependencies_from_source.yaml
+++ b/.github/workflows/ci_dependencies_from_source.yaml
@@ -2,6 +2,9 @@ name: Ubuntu CI from source
 run-name: Testing ${{ inputs.packages-to-test }} | vcs ${{ inputs.vcs-repo-file-base }} ${{ inputs.vcs-repo-file }}
 
 on:
+  push:
+    branches:
+      - 'scpeters/action_ros_ci_rotary'
   workflow_dispatch:
     inputs:
       packages-to-test:
@@ -35,13 +38,9 @@ jobs:
       - name: Compile and test
         uses: ros-tooling/action-ros-ci@v0.4
         with:
-          package-name: ${{ inputs.packages-to-test }}
+          package-name: sdformat
           target-ros2-distro: lyrical
-          vcs-repo-file-url: >
-            ${{ case(
-              inputs.vcs-repo-file-base == 'relative', format('{0}/{1}', github.workspace, inputs.vcs-repo-file),
-              inputs.vcs-repo-file
-            ) }}
+          vcs-repo-file-url: ${{ github.workspace }}/.github/ci/packages_up_to_sdformat.yaml
           colcon-defaults: |
             {
               "build": {

--- a/.github/workflows/ci_dependencies_from_source.yaml
+++ b/.github/workflows/ci_dependencies_from_source.yaml
@@ -1,0 +1,53 @@
+name: Ubuntu CI from source
+run-name: Testing ${{ inputs.packages-to-test }} | vcs ${{ inputs.vcs-repo-file-base }} ${{ inputs.vcs-repo-file }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      packages-to-test:
+        description: Names of packages to test (e.g. 'gz-math sdformat').
+        required: true
+        type: string
+        default: sdformat
+      vcs-repo-file-base:
+        description: Choose whether vcs-repo-file represents a relative path in the github workspace or a URL.
+        required: true
+        default: relative
+        type: choice
+        options:
+          - relative
+          - url
+      vcs-repo-file:
+        description: Relative path or URL to vcs repo file to import into colcon workspace
+        required: true
+        type: string
+        default: ".github/ci/packages_up_to_sdformat.yaml"
+
+jobs:
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Resolute CI (from source)
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-resolute-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Compile and test
+        uses: ros-tooling/action-ros-ci@v0.4
+        with:
+          package-name: ${{ inputs.packages-to-test }}
+          target-ros2-distro: lyrical
+          vcs-repo-file-url: >
+            ${{ case(
+              inputs.vcs-repo-file-base == 'relative', format('{0}/{1}', github.workspace, inputs.vcs-repo-file),
+              inputs.vcs-repo-file
+            ) }}
+          colcon-defaults: |
+            {
+              "build": {
+                "merge-install": true
+              },
+              "test": {
+                "merge-install": true
+              }
+            }


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/action-gz-ci/issues/80 and https://github.com/gazebo-tooling/release-tools/issues/851

## Summary

We currently don't have an easy way to run Ubuntu CI with multiple dependencies built from source either in Jenkins (https://github.com/gazebo-tooling/release-tools/issues/851) or with action-gz-ci in a GitHub workflow (https://github.com/gazebo-tooling/action-gz-ci/issues/80). This PR is a demonstration of the suggestion in https://github.com/gazebo-tooling/action-gz-ci/issues/80#issuecomment-2636599012 to use action-ros-ci to build and test multiple packages from source in a colcon workspace. This supersedes a previous draft PR https://github.com/gazebosim/sdformat/pull/1648 targeting `sdf16`.

The `Ubuntu CI from source` workflow is added in https://github.com/gazebosim/sdformat/commit/6075e0a14f9f8d01f5091911e6b279497b4cf8df with `workflow_dispatch` manual triggering, since I expect this CI job to initially be triggered manually for specific testing scenarios, not for every pull request or push to `main`. It has the following configuration:

* execute in [rostooling/setup-ros-docker:ubuntu-resolute-latest](https://hub.docker.com/layers/rostooling/setup-ros-docker/ubuntu-resolute-latest) container image
* use `action-ros-ci` with colcon workspace packages specified in `vcs-repo-file-url`
* use actions/checkout to checkout sdformat from the current branch rather than the branch specified in `vcs-repo-file-url`
* `workflow_dispatch` manual triggering with three input parameters:
    * `packages-to-test`: dependencies of these packages will be built, but only these packages will be tested (default `sdformat`)
    * `vcs-repo-file`: location of the VCS repo file from which the colcon workspace will be populated
    * `vcs-repo-file-base`: if `relative`, then interpret `vcs-repo-file` as a relative path within this github repo; if `url` interpret `vcs-repo-file` as a URL to the repo file (such as a link to a file in gazebosim/gazebodistro or a gist)

This commit also includes two vcs repo files:
* `.github/ci/packages_up_to_sdformat.yaml` (default values of `vcs-repo-file` and `vcs-repo-file-base` point to this file)
* `.github/ci/collection.yaml, which is equivalent to [gazebodistro's collection-rotary.yaml](https://github.com/gazebo-tooling/gazebodistro/blob/master/collection-rotary.yaml)

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [x] Other (fill in yourself) we can backport this, but it will require changes to the repositories yaml files, so I think it should be done manually rather than with mergify

## Test it

This workflow cannot be run using `workflow_dispatch` until it is merged to the `main` branch. To test before merging to main I replaced the `workflow_dispatch` trigger with `push` to this PR branch in https://github.com/gazebosim/sdformat/commit/158833d641ff37817ffc6bf17376b662737ffba8.

### Test with custom dependency branches

The resulting [CI workflow run](https://github.com/gazebosim/sdformat/actions/runs/28132119940/job/83310592216) from https://github.com/gazebosim/sdformat/commit/158833d641ff37817ffc6bf17376b662737ffba8 successfully built and tested `sdformat`, but `colcon test-result` failed due to an issue with gz-tools that is fixed by https://github.com/gazebosim/gz-tools/pull/172 (confirmed by the [successful CI workflow run](https://github.com/gazebosim/sdformat/actions/runs/28133273335/job/83314326891) for  https://github.com/gazebosim/sdformat/commit/94519c42d9bb4e4c7521eea8158023cd3a69121e that modifies `packages_up_to_sdformat.yaml` to use the gz-tools branch from https://github.com/gazebosim/gz-tools/pull/172)

### Test reverse dependencies against this branch

The package to test was changed to `gz-physics and `vcs-repo-file` was changed to `collection.yaml` in https://github.com/gazebosim/sdformat/commit/1576cf1c3c468c334ddecd8b78aef211d4c9e322, resulting in the following CI workflow run that built and tested gz-physics but was marked as failed since the gz-tools branch was not updated:

* https://github.com/gazebosim/sdformat/actions/runs/28154710344/job/83380366892

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
