### PR TITLE
Prepare for sdformat 16.1.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0004 NEW)
 endif(COMMAND CMAKE_POLICY)
 
-project (sdformat VERSION 16.0.1)
+project (sdformat VERSION 16.1.0)
 
 # The protocol version has nothing to do with the package version.
 # It represents the current version of SDFormat implemented by the software

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,39 @@
 ## libsdformat 16.X
 
+### libsdformat 16.1.0 (2026-07-10)
+
+1. [bazel/infra] Automate publish to BCR workflow (backport #1686)
+    * [Pull request #1686](https://github.com/gazebosim/sdformat/pull/1686)
+    * [Pull request #1687](https://github.com/gazebosim/sdformat/pull/1687)
+
+1. [bazel/infra] Update bazel CI to use workflow v7.7.0
+    * [Pull request #1683](https://github.com/gazebosim/sdformat/pull/1683)
+
+1. [bazel] Bump default bazel version to 9.1.1 (backport #1681)
+    * [Pull request #1681](https://github.com/gazebosim/sdformat/pull/1681)
+    * [Pull request #1682](https://github.com/gazebosim/sdformat/pull/1682)
+
+1. macos CI: test on push to release branches only
+    * [Pull request #1672](https://github.com/gazebosim/sdformat/pull/1672)
+
+1. macos CI: use brew trust
+    * [Pull request #1666](https://github.com/gazebosim/sdformat/pull/1666)
+
+1. Fix Python test PYTHONPATH: use `ENVIRONMENT_MODIFICATION` instead of ENVIRONMENT
+    * [Pull request #1649](https://github.com/gazebosim/sdformat/pull/1649)
+
+1. Fix `static_cast` that triggers compile errors with -Wpedantic
+    * [Pull request #1632](https://github.com/gazebosim/sdformat/pull/1632)
+
+1. NavSat::ToElement() method
+    * [Pull request #1585](https://github.com/gazebosim/sdformat/pull/1585)
+
+1. Parse category bitmask SDF element in Surface DOM
+    * [Pull request #1630](https://github.com/gazebosim/sdformat/pull/1630)
+
+1. Use std::vector::reserve in Element::Clone
+    * [Pull request #1480](https://github.com/gazebosim/sdformat/pull/1480)
+
 ### libsdformat 16.0.1 (2026-01-20)
 
 1. **Baseline:** this includes all changes from 16.0.0 and earlier.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sdformat</name>
-  <version>16.0.1</version>
+  <version>16.1.0</version>
   <description>SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications</description>
 


### PR DESCRIPTION
Prepare for 16.1.0 Release

# 🎈 Release

Preparation for 16.1.0 release.

Comparison to 16.0.1: https://github.com/gazebosim/sdformat/compare/sdformat16_16.0.1...sdf16

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
