### PR TITLE
Remove two static destructors

### DIFF
--- a/src/SDF.cc
+++ b/src/SDF.cc
@@ -578,8 +578,8 @@ const std::string &SDF::EmbeddedSpec(
   }
 
   // An empty SDF string is returned if a query into the embeddedSdf map fails.
-  static const std::string emptySdfString;
-  return emptySdfString;
+  static const gz::utils::NeverDestroyed<std::string> emptySdfString;
+  return emptySdfString.Access();
 }
 }
 }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1738,17 +1738,15 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
         // element into _sdf.
         if (sdf::isSdfFile(filename) || _config.CustomModelParsers().empty())
         {
-          // NOTE: sdf::init is an expensive call. For performance reason,
-          // a new sdf pointer is created here by cloning a fresh sdf template
-          // pointer instead of calling init every iteration.
-          // SDFPtr includeSDF(new SDF);
-          // init(includeSDF, _config);
-          static SDFPtr includeSDFTemplate;
-          if (!includeSDFTemplate)
-          {
-            includeSDFTemplate.reset(new SDF);
-            init(includeSDFTemplate, _config);
-          }
+          // NOTE: sdf::init is an expensive call. For performance reason, a new
+          // sdf pointer is created here by cloning a fresh sdf template pointer
+          // instead of calling init every iteration. This template is
+          // purposefully never deleted ala gz::utils::NeverDestroyed.
+          static SDF* includeSDFTemplate = [&_config]() {
+            SDFPtr temp(new SDF, [](SDF*) { /* The deleter is a no-op. */ });
+            init(temp, _config);
+            return temp.get();
+          }();
           SDFPtr includeSDF(new SDF);
           includeSDF->SetRoot(includeSDFTemplate->Root()->Clone());
 


### PR DESCRIPTION
The destructor of a function-local static variable is run at program exit, which can lead to the "static destruction order fiasco". Avoid this by removing the destructor.

https://en.cppreference.com/cpp/language/siof
https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

~Fixes #N/A~.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Backport Policy

This does not change API.

To the best of my understanding, it doesn't change ABI either.

- [ ] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.