### PR TITLE
Use gz-rotary-sdformat in macos workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,9 +50,9 @@ jobs:
         fi
         # gz-math7 has problems with swig, remove it for now
         brew remove swig || true
-        brew install --only-dependencies ${PACKAGE};
-        # install :build dependencies of a formula
-        brew install $(brew deps --1 --include-build ${PACKAGE})
+        brew install --only-dependencies --HEAD ${PACKAGE};
+        # install non-rotary :build dependencies of a formula
+        brew install $(brew deps --1 --include-build ${PACKAGE} | grep -v gz-rotary-)
 
     - run: mkdir build
     - name: cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ jobs:
   build:
 
     env:
-      PACKAGE: sdformat16
+      PACKAGE: gz-rotary-sdformat
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
# 🦟 Bug fix

Fixes incorrect dependency versions in macos workflow

## Summary

The macos workflow has started failing recently for pull requests targeting the `main` branch (see https://github.com/gazebosim/sdformat/pull/1691 and https://github.com/gazebosim/sdformat/pull/1693).

The macos workflow currently uses a hardcoded `PACKAGE` variable to encode the homebrew formula name whose dependencies should be installed. The `main` branch is still using the Jetty formula `sdformat16`, so this should be updated to `gz-rotary-sdformat`, which also avoids needing to specify the number.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
