### PR TITLE
Disable schema test if xmllint is too new

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -71,9 +71,33 @@ endif()
 
 find_program(XMLLINT_EXE xmllint)
 if (EXISTS ${XMLLINT_EXE})
-  set (tests ${tests} schema_test.cc)
+  # get xmllint version
+  execute_process(
+    COMMAND ${XMLLINT_EXE} --version
+    ERROR_VARIABLE XMLLINT_VERSION_OUTPUT
+  )
+  # typical output: "/usr/bin/xmllint: using libxml version 20913\ncompiled with: ..."
+  # version is formatted as a single integer, with 20913 representing 2.9.13
+  string(REGEX MATCH "using libxml version [0-9]+" XMLLINT_VERSION_STRING "${XMLLINT_VERSION_OUTPUT}")
+  string(REPLACE "using libxml version " "" XMLLINT_VERSION "${XMLLINT_VERSION_STRING}")
+  if("${XMLLINT_VERSION}" STREQUAL "")
+    message(WARNING "Unable to identify xmllint version. schema_test won't be run")
+  elseif("${XMLLINT_VERSION}" LESS 10000)
+    message(WARNING "Old version of xmllint (${XMLLINT_VERSION_STRING}) detected. schema_test won't be run")
+  elseif("${XMLLINT_VERSION}" LESS 21500)
+    # schema test is broken with very new versions of xmllint
+    # https://github.com/gazebosim/sdformat/issues/1656
+    # enable schema test if xmllint is older than 2.15.0
+    set (tests ${tests} schema_test.cc)
+  else()
+    # TODO: convert to WARNING when https://github.com/gazebosim/sdformat/issues/1656
+    # is resolved on supported platforms. It currently fails on Ubuntu 26.04
+    message(STATUS  "WARNING: xmllint version (${XMLLINT_VERSION}) is too new; "
+                    "schema_test won't be run. "
+                    "See https://github.com/gazebosim/sdformat/issues/1656")
+  endif()
 else()
-  gz_build_warning("xmllint not found. schema_test won't be run")
+  message(WARNING "xmllint not found. schema_test won't be run")
 endif()
 
 gz_build_tests(TYPE ${TEST_TYPE}


### PR DESCRIPTION
# 🦟 Bug fix

Mitigation for #1656, manual backport of #1658 and part of https://github.com/gazebo-tooling/release-tools/issues/1503

## Summary

As noted in #1656, `INTEGRATION_schema_test` fails with versions of `xmllint` newer than 2.15. This disables the test if the `xmllint` version is too new. It also fixes the warning when `xmllint` is not found.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
