### PR TITLE
Install types.xsd for all spec versions

### DIFF
--- a/sdf/1.10/CMakeLists.txt
+++ b/sdf/1.10/CMakeLists.txt
@@ -75,10 +75,21 @@ foreach(FIL ${sdfs})
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     COMMENT "Running xml schema compiler on ${FIL}"
     VERBATIM)
 endforeach()
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+    "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+  COMMENT "Copying types.xsd to binary dir"
+  VERBATIM)
+
+list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
 add_custom_target(schema1_10 ALL DEPENDS ${SDF_SCHEMA})
 

--- a/sdf/1.11/CMakeLists.txt
+++ b/sdf/1.11/CMakeLists.txt
@@ -77,10 +77,21 @@ foreach(FIL ${sdfs})
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     COMMENT "Running xml schema compiler on ${FIL}"
     VERBATIM)
 endforeach()
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+    "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+  COMMENT "Copying types.xsd to binary dir"
+  VERBATIM)
+
+list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
 add_custom_target(schema1_11 ALL DEPENDS ${SDF_SCHEMA})
 

--- a/sdf/1.12/CMakeLists.txt
+++ b/sdf/1.12/CMakeLists.txt
@@ -78,10 +78,21 @@ foreach(FIL ${sdfs})
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     COMMENT "Running xml schema compiler on ${FIL}"
     VERBATIM)
 endforeach()
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+    "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+  COMMENT "Copying types.xsd to binary dir"
+  VERBATIM)
+
+list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
 add_custom_target(schema1_12 ALL DEPENDS ${SDF_SCHEMA})
 

--- a/sdf/1.5/CMakeLists.txt
+++ b/sdf/1.5/CMakeLists.txt
@@ -69,10 +69,21 @@ foreach(FIL ${sdfs})
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     COMMENT "Running xml schema compiler on ${FIL}"
     VERBATIM)
 endforeach()
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+    "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+  COMMENT "Copying types.xsd to binary dir"
+  VERBATIM)
+
+list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
 add_custom_target(schema1_5 ALL DEPENDS ${SDF_SCHEMA})
 

--- a/sdf/1.6/CMakeLists.txt
+++ b/sdf/1.6/CMakeLists.txt
@@ -73,10 +73,21 @@ foreach(FIL ${sdfs})
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     COMMENT "Running xml schema compiler on ${FIL}"
     VERBATIM)
 endforeach()
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+    "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+  COMMENT "Copying types.xsd to binary dir"
+  VERBATIM)
+
+list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
 add_custom_target(schema1_6 ALL DEPENDS ${SDF_SCHEMA})
 

--- a/sdf/1.7/CMakeLists.txt
+++ b/sdf/1.7/CMakeLists.txt
@@ -74,10 +74,21 @@ foreach(FIL ${sdfs})
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     COMMENT "Running xml schema compiler on ${FIL}"
     VERBATIM)
 endforeach()
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+    "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+  COMMENT "Copying types.xsd to binary dir"
+  VERBATIM)
+
+list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
 add_custom_target(schema1_7 ALL DEPENDS ${SDF_SCHEMA})
 

--- a/sdf/1.8/CMakeLists.txt
+++ b/sdf/1.8/CMakeLists.txt
@@ -76,10 +76,21 @@ foreach(FIL ${sdfs})
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     COMMENT "Running xml schema compiler on ${FIL}"
     VERBATIM)
 endforeach()
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+    "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+  COMMENT "Copying types.xsd to binary dir"
+  VERBATIM)
+
+list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
 add_custom_target(schema1_8 ALL DEPENDS ${SDF_SCHEMA})
 

--- a/sdf/1.9/CMakeLists.txt
+++ b/sdf/1.9/CMakeLists.txt
@@ -76,10 +76,21 @@ foreach(FIL ${sdfs})
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.xsd"
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     ARGS --sdf-dir ${CMAKE_CURRENT_SOURCE_DIR} --input-file ${ABS_FIL} --output-dir ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${CMAKE_SOURCE_DIR}/tools/xmlschema.py
     COMMENT "Running xml schema compiler on ${FIL}"
     VERBATIM)
 endforeach()
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+    "${CMAKE_CURRENT_BINARY_DIR}/types.xsd"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/schema/types.xsd"
+  COMMENT "Copying types.xsd to binary dir"
+  VERBATIM)
+
+list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
 add_custom_target(schema1_9 ALL DEPENDS ${SDF_SCHEMA})
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of #1656 

## Summary

Gemini noticed that the `types.xsd` schema files that are present in each sdf spec folder (such as [sdf/1.12/schema/types.xsd](https://github.com/gazebosim/sdformat/blob/main/sdf/1.12/schema/types.xsd)) are not installed alongside the other `.sdf` and `.xsd` files. This installs all of those files.

Gemini also noticed that the `.xsd` files generated by the xmlschema.py script do not have a dependency declared on that script. This adds that dependency to ensure that all `.xsd` files will be regenerated when the xmlschema.py script is modified.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

There will be conflicts when backporting to collections without SDFormat 1.12

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.6 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
