### PR TITLE
Enable and fix schema test

### DIFF
--- a/sdf/1.12/CMakeLists.txt
+++ b/sdf/1.12/CMakeLists.txt
@@ -94,6 +94,11 @@ add_custom_command(
 
 list(APPEND SDF_SCHEMA "${CMAKE_CURRENT_BINARY_DIR}/types.xsd")
 
+configure_file(
+  ${CMAKE_SOURCE_DIR}/sdf/catalog.xml.in
+  ${CMAKE_CURRENT_BINARY_DIR}/catalog.xml
+  @ONLY)
+
 add_custom_target(schema1_12 ALL DEPENDS ${SDF_SCHEMA})
 
 set_source_files_properties(${SDF_SCHEMA} PROPERTIES GENERATED TRUE)

--- a/sdf/catalog.xml.in
+++ b/sdf/catalog.xml.in
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD XML Catalogs V1.0//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/catalog.xml">
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <rewriteURI uriStartString="http://sdformat.org/schemas/" rewritePrefix="file://@CMAKE_CURRENT_BINARY_DIR@/"/>
+</catalog>

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -87,6 +87,7 @@ if (TARGET ${TEST_TYPE}_schema_test)
   target_compile_definitions(${TEST_TYPE}_schema_test
     PRIVATE
     -DSDF_ROOT_SCHEMA="${PROJECT_BINARY_DIR}/sdf/${SDF_PROTOCOL_VERSION}/root.xsd"
+    -DSDF_XML_CATALOG="${PROJECT_BINARY_DIR}/sdf/${SDF_PROTOCOL_VERSION}/catalog.xml"
   )
 
   if (EXISTS ${XMLLINT_EXE})

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -71,31 +71,7 @@ endif()
 
 find_program(XMLLINT_EXE xmllint)
 if (EXISTS ${XMLLINT_EXE})
-  # get xmllint version
-  execute_process(
-    COMMAND ${XMLLINT_EXE} --version
-    ERROR_VARIABLE XMLLINT_VERSION_OUTPUT
-  )
-  # typical output: "/usr/bin/xmllint: using libxml version 20913\ncompiled with: ..."
-  # version is formatted as a single integer, with 20913 representing 2.9.13
-  string(REGEX MATCH "using libxml version [0-9]+" XMLLINT_VERSION_STRING "${XMLLINT_VERSION_OUTPUT}")
-  string(REPLACE "using libxml version " "" XMLLINT_VERSION "${XMLLINT_VERSION_STRING}")
-  if("${XMLLINT_VERSION}" STREQUAL "")
-    message(WARNING "Unable to identify xmllint version. schema_test won't be run")
-  elseif("${XMLLINT_VERSION}" LESS 10000)
-    message(WARNING "Old version of xmllint (${XMLLINT_VERSION_STRING}) detected. schema_test won't be run")
-  elseif("${XMLLINT_VERSION}" LESS 21500)
-    # schema test is broken with very new versions of xmllint
-    # https://github.com/gazebosim/sdformat/issues/1656
-    # enable schema test if xmllint is older than 2.15.0
-    set (tests ${tests} schema_test.cc)
-  else()
-    # TODO: convert to WARNING when https://github.com/gazebosim/sdformat/issues/1656
-    # is resolved on supported platforms. It currently fails on Ubuntu 26.04
-    message(STATUS  "WARNING: xmllint version (${XMLLINT_VERSION}) is too new; "
-                    "schema_test won't be run. "
-                    "See https://github.com/gazebosim/sdformat/issues/1656")
-  endif()
+  set (tests ${tests} schema_test.cc)
 else()
   message(WARNING "xmllint not found. schema_test won't be run")
 endif()

--- a/test/integration/schema_test.cc
+++ b/test/integration/schema_test.cc
@@ -31,7 +31,7 @@ class SDFSchemaGenerator : public testing::Test
   public:
     void runXMLlint(const std::string & model)
     {
-      const auto sdfRootSchema = sdf::filesystem::append(SDF_ROOT_SCHEMA);
+      const std::string sdfRootSchema = SDF_ROOT_SCHEMA;
       std::string xmllintCmd = "xmllint --noout --schema " +
                                 sdfRootSchema + " " + model;
       std::cout << "CMD[" << xmllintCmd << "]\n";

--- a/test/integration/schema_test.cc
+++ b/test/integration/schema_test.cc
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include <gz/utils/Environment.hh>
+
 #include "sdf/parser.hh"
 
 #include "test_config.hh"
@@ -31,8 +33,10 @@ class SDFSchemaGenerator : public testing::Test
   public:
     void runXMLlint(const std::string & model)
     {
+      const std::string sdfCatalog = SDF_XML_CATALOG;
+      gz::utils::setenv("XML_CATALOG_FILES", sdfCatalog.c_str());
       const std::string sdfRootSchema = SDF_ROOT_SCHEMA;
-      std::string xmllintCmd = "xmllint --noout --schema " +
+      std::string xmllintCmd = "xmllint --catalogs --noout --schema " +
                                 sdfRootSchema + " " + model;
       std::cout << "CMD[" << xmllintCmd << "]\n";
       if (system(xmllintCmd.c_str()) != 0)

--- a/tools/xmlschema.py
+++ b/tools/xmlschema.py
@@ -160,30 +160,39 @@ def print_element(element: ElementTree.Element) -> List[str]:
     if elem_type and is_std_type(elem_type):
         elem_type = xsd_type_string(elem_type)
 
+    elements = element.findall("element")
+    attributes = element.findall("attribute")
+
     if not elem_reqd:
         raise RuntimeError("Cannot process element missing 'required' attribute")
 
     min_occurs, max_occurs = SDF_REQUIRED_TO_MIN_MAX_OCCURS[elem_reqd]
     lines.append(f"<xsd:choice  minOccurs='{min_occurs}' maxOccurs='{max_occurs}'>")
 
-    if elem_type is None:
+    if elem_type:
+        lines.append(f"<xsd:element name='{elem_name}' type='{elem_type}'>")
+    else:
         lines.append(f"<xsd:element name='{elem_name}'>")
-        lines.extend(indent_lines(print_documentation(element), 2))
+
+    lines.extend(indent_lines(print_documentation(element), 2))
+
+    if elem_type is None:
         lines.append("  <xsd:complexType>")
-        lines.append("    <xsd:choice maxOccurs='unbounded'>")
 
-        for child_element in element.findall("element"):
-            lines.extend(indent_lines(print_element(child_element), 6))
+        if len(elements):
+            lines.append("    <xsd:choice maxOccurs='unbounded'>")
 
-        lines.append("    </xsd:choice>")
+        for child_element in elements:
+            element_lines = print_element(child_element)
+            lines.extend(indent_lines(element_lines, 6))
 
-        for attribute in element.findall("attribute"):
+        if len(elements):
+            lines.append("    </xsd:choice>")
+
+        for attribute in attributes:
             lines.extend(indent_lines(print_attribute(attribute), 4))
 
         lines.append("  </xsd:complexType>")
-    else:
-        lines.append(f"<xsd:element name='{elem_name}' type='{elem_type}'>")
-        lines.extend(indent_lines(print_documentation(element), 2))
 
     lines.append("</xsd:element>")
     lines.append("</xsd:choice>")
@@ -231,6 +240,9 @@ def print_xsd(element: ElementTree.Element, sdf_root_dir: str) -> List[str]:
     elem_name = get_attribute(element, "name")
     elem_type = get_attribute(element, "type")
 
+    if elem_type and is_std_type(elem_type):
+        elem_type = xsd_type_string(elem_type)
+
     elements = element.findall("element")
     attributes = element.findall("attribute")
     includes = element.findall("include")
@@ -244,8 +256,12 @@ def print_xsd(element: ElementTree.Element, sdf_root_dir: str) -> List[str]:
     for include in includes:
         lines.extend(print_include(include))
 
-    if len(elements) or len(attributes) or len(includes):
+    if elem_type:
+        lines.append(f"<xsd:element name='{elem_name}' type='{elem_type}'>")
+    else:
         lines.append(f"<xsd:element name='{elem_name}'>")
+
+    if len(elements) or len(attributes) or len(includes):
         lines.append("  <xsd:complexType>")
 
         if elem_name != "plugin" and (len(elements) or len(includes)):
@@ -266,18 +282,12 @@ def print_xsd(element: ElementTree.Element, sdf_root_dir: str) -> List[str]:
         if elem_name != "plugin" and (len(elements) or len(includes)):
             lines.append("    </xsd:choice>")
 
-        for attribute_element in attributes:
-            lines.extend(indent_lines(print_attribute(attribute_element), 4))
+        for attribute in attributes:
+            lines.extend(indent_lines(print_attribute(attribute), 4))
 
         lines.append("  </xsd:complexType>")
-        lines.append("</xsd:element>")
-    else:
-        if elem_type and is_std_type(elem_type):
-            elem_type = f' type={xsd_type_string(elem_type)}'
-        else:
-            elem_type = ""
+    lines.append("</xsd:element>")
 
-        lines.append(f"<xsd:element name='{elem_name}'{elem_type} />")
     return lines
 
 

--- a/tools/xmlschema.py
+++ b/tools/xmlschema.py
@@ -162,6 +162,7 @@ def print_element(element: ElementTree.Element) -> List[str]:
 
     elements = element.findall("element")
     attributes = element.findall("attribute")
+    includes = element.findall("include")
 
     if not elem_reqd:
         raise RuntimeError("Cannot process element missing 'required' attribute")
@@ -169,28 +170,42 @@ def print_element(element: ElementTree.Element) -> List[str]:
     min_occurs, max_occurs = SDF_REQUIRED_TO_MIN_MAX_OCCURS[elem_reqd]
     lines.append(f"<xsd:choice  minOccurs='{min_occurs}' maxOccurs='{max_occurs}'>")
 
-    if elem_type:
+    complex_type = len(elements) > 0 or len(attributes) > 0 or len(includes) > 0
+
+    if not complex_type and elem_type:
         lines.append(f"<xsd:element name='{elem_name}' type='{elem_type}'>")
     else:
         lines.append(f"<xsd:element name='{elem_name}'>")
 
     lines.extend(indent_lines(print_documentation(element), 2))
 
-    if elem_type is None:
+    if complex_type:
         lines.append("  <xsd:complexType>")
 
-        if len(elements):
-            lines.append("    <xsd:choice maxOccurs='unbounded'>")
+        if elem_type:
+            lines.append("    <xsd:simpleContent>")
+            lines.append(f"      <xsd:extension base='{elem_type}'>")
+            for attribute in attributes:
+                lines.extend(indent_lines(print_attribute(attribute), 8))
+            lines.append("      </xsd:extension>")
+            lines.append("    </xsd:simpleContent>")
+        else:
+            if len(elements):
+                lines.append("    <xsd:choice maxOccurs='unbounded'>")
 
-        for child_element in elements:
-            element_lines = print_element(child_element)
-            lines.extend(indent_lines(element_lines, 6))
+            for child_element in elements:
+                if "copy_data" in child_element.attrib:
+                    element_lines = print_plugin_element(child_element)
+                    lines.extend(indent_lines(element_lines, 4))
+                else:
+                    element_lines = print_element(child_element)
+                    lines.extend(indent_lines(element_lines, 6))
 
-        if len(elements):
-            lines.append("    </xsd:choice>")
+            if len(elements):
+                lines.append("    </xsd:choice>")
 
-        for attribute in attributes:
-            lines.extend(indent_lines(print_attribute(attribute), 4))
+            for attribute in attributes:
+                lines.extend(indent_lines(print_attribute(attribute), 4))
 
         lines.append("  </xsd:complexType>")
 
@@ -256,34 +271,44 @@ def print_xsd(element: ElementTree.Element, sdf_root_dir: str) -> List[str]:
     for include in includes:
         lines.extend(print_include(include))
 
-    if elem_type:
+    complex_type = len(elements) > 0 or len(attributes) > 0 or len(includes) > 0
+
+    if not complex_type and elem_type:
         lines.append(f"<xsd:element name='{elem_name}' type='{elem_type}'>")
     else:
         lines.append(f"<xsd:element name='{elem_name}'>")
 
-    if len(elements) or len(attributes) or len(includes):
+    if complex_type:
         lines.append("  <xsd:complexType>")
 
-        if elem_name != "plugin" and (len(elements) or len(includes)):
-            lines.append("    <xsd:choice maxOccurs='unbounded'>")
+        if elem_type:
+            lines.append("    <xsd:simpleContent>")
+            lines.append(f"      <xsd:extension base='{elem_type}'>")
+            for attribute in attributes:
+                lines.extend(indent_lines(print_attribute(attribute), 8))
+            lines.append("      </xsd:extension>")
+            lines.append("    </xsd:simpleContent>")
+        else:
+            if elem_name != "plugin" and (len(elements) or len(includes)):
+                lines.append("    <xsd:choice maxOccurs='unbounded'>")
 
-        for child_element in elements:
-            if "copy_data" in child_element.attrib:
-                element_lines = print_plugin_element(child_element)
-                lines.extend(indent_lines(element_lines, 4))
-            else:
-                element_lines = print_element(child_element)
+            for child_element in elements:
+                if "copy_data" in child_element.attrib:
+                    element_lines = print_plugin_element(child_element)
+                    lines.extend(indent_lines(element_lines, 4))
+                else:
+                    element_lines = print_element(child_element)
+                    lines.extend(indent_lines(element_lines, 6))
+
+            for include_element in includes:
+                element_lines = print_include_ref(include_element, sdf_root_dir)
                 lines.extend(indent_lines(element_lines, 6))
 
-        for include_element in includes:
-            element_lines = print_include_ref(include_element, sdf_root_dir)
-            lines.extend(indent_lines(element_lines, 6))
+            if elem_name != "plugin" and (len(elements) or len(includes)):
+                lines.append("    </xsd:choice>")
 
-        if elem_name != "plugin" and (len(elements) or len(includes)):
-            lines.append("    </xsd:choice>")
-
-        for attribute in attributes:
-            lines.extend(indent_lines(print_attribute(attribute), 4))
+            for attribute in attributes:
+                lines.extend(indent_lines(print_attribute(attribute), 4))
 
         lines.append("  </xsd:complexType>")
     lines.append("</xsd:element>")

--- a/tools/xmlschema.py
+++ b/tools/xmlschema.py
@@ -128,7 +128,15 @@ def print_include_ref(element: ElementTree.Element, sdf_root_dir: str) -> List[s
         include_tree = ElementTree.parse(sdf_path)
         root = include_tree.getroot()
         include_element_name = root.attrib["name"]
-        lines.append(f"<xsd:element ref='{include_element_name}'/>")
+
+        elem_reqd = get_attribute(element, "required")
+        if elem_reqd:
+            min_occurs, max_occurs = SDF_REQUIRED_TO_MIN_MAX_OCCURS[elem_reqd]
+            lines.append(f"<xsd:choice  minOccurs='{min_occurs}' maxOccurs='{max_occurs}'>")
+            lines.append(f"  <xsd:element ref='{include_element_name}'/>")
+            lines.append("</xsd:choice>")
+        else:
+            lines.append(f"<xsd:element ref='{include_element_name}'/>")
     return lines
 
 
@@ -147,7 +155,7 @@ def print_plugin_element(element: ElementTree.Element) -> List[str]:
     return lines
 
 
-def print_element(element: ElementTree.Element) -> List[str]:
+def print_element(element: ElementTree.Element, sdf_root_dir: str) -> List[str]:
     """
     Print a child element of the sdf definition
     """
@@ -190,7 +198,7 @@ def print_element(element: ElementTree.Element) -> List[str]:
             lines.append("      </xsd:extension>")
             lines.append("    </xsd:simpleContent>")
         else:
-            if len(elements):
+            if len(elements) or len(includes):
                 lines.append("    <xsd:choice maxOccurs='unbounded'>")
 
             for child_element in elements:
@@ -198,10 +206,14 @@ def print_element(element: ElementTree.Element) -> List[str]:
                     element_lines = print_plugin_element(child_element)
                     lines.extend(indent_lines(element_lines, 4))
                 else:
-                    element_lines = print_element(child_element)
+                    element_lines = print_element(child_element, sdf_root_dir)
                     lines.extend(indent_lines(element_lines, 6))
 
-            if len(elements):
+            for include_element in includes:
+                element_lines = print_include_ref(include_element, sdf_root_dir)
+                lines.extend(indent_lines(element_lines, 6))
+
+            if len(elements) or len(includes):
                 lines.append("    </xsd:choice>")
 
             for attribute in attributes:
@@ -267,9 +279,14 @@ def print_xsd(element: ElementTree.Element, sdf_root_dir: str) -> List[str]:
         "<xsd:include schemaLocation='http://sdformat.org/schemas/types.xsd'/>"
     )
 
-    # Reference any includes in the SDF file
-    for include in includes:
-        lines.extend(print_include(include))
+    # Reference all includes in the SDF file (including nested ones)
+    all_includes = element.findall(".//include")
+    included_files = set()
+    for include in all_includes:
+        filename = get_attribute(include, "filename")
+        if filename and filename not in included_files:
+            included_files.add(filename)
+            lines.extend(print_include(include))
 
     complex_type = len(elements) > 0 or len(attributes) > 0 or len(includes) > 0
 
@@ -297,7 +314,7 @@ def print_xsd(element: ElementTree.Element, sdf_root_dir: str) -> List[str]:
                     element_lines = print_plugin_element(child_element)
                     lines.extend(indent_lines(element_lines, 4))
                 else:
-                    element_lines = print_element(child_element)
+                    element_lines = print_element(child_element, sdf_root_dir)
                     lines.extend(indent_lines(element_lines, 6))
 
             for include_element in includes:


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1656, builds on top of #1704 

## Summary

As noted in #1656, the schema integration test is broken with `xmllint` version 2.15.0 and later, when its internal HTTP client was removed (see also https://github.com/RoboStack/ros-jazzy/issues/200) with failures like:

~~~
Failed to load the document 'http://sdformat.org/schemas/types.xsd' for inclusion
~~~

Gemini suggested using an [XML catalog](https://en.wikipedia.org/wiki/XML_catalog) to map the external document references to locally cached copies, which is done in https://github.com/gazebosim/sdformat/pull/1705/commits/628139a619902ba87a1aa86087e679de7911e874. There are also some failures of the schema test that are fixed by modifying the xmlschema.py script in the following commits (which I recommend reviewing as separate commits):

* https://github.com/gazebosim/sdformat/pull/1705/commits/c981b6407b6c224ac5140f1451b32b5a53196888 refactors the `print_element` and `print_xsd` methods to make their implementations more similar and reduce the diff of subsequent commits. It has mild behavior changes detailed in the commit message. The [diff without whitespace](https://github.com/gazebosim/sdformat/commit/c981b6407b6c224ac5140f1451b32b5a53196888?w=1) may be useful
* https://github.com/gazebosim/sdformat/pull/1705/commits/83230c5c6f56b87984b4d067ecfe35fe406b5d48 adds support for an element with both attributes (complex type) and a text value ([simple content](https://www.w3schools.com/xml/el_simplecontent.asp)), such as `<pose degrees='true'>0 0 0 0 0 0</pose>`. The [diff without whitespace](https://github.com/gazebosim/sdformat/commit/83230c5c6f56b87984b4d067ecfe35fe406b5d48?w=1) may be useful
* https://github.com/gazebosim/sdformat/pull/1705/commits/e4e065259f1d5784206ddb555bc9521dbbb3b452 ensures that nested includes are handled recursively

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

there will be conflicts backporting to harmonic, as it doesn't have 1.12

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.6 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
